### PR TITLE
ci: deploy storybook

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Test
         run: yarn test
 
+      - name: Deploy Storybook
+        run: yarn run deploy-storybook --ci --source-branch=main
+        env:
+          GH_TOKEN: '${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}'
+
   sonarcloud:
     name: SonarCloud analysis
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   "storybook-deployer": {
     "gitUsername": "Vitamin BOT",
     "gitEmail": "designsystem@decathlon.net",
-    "commitMessage": "chore: deploy Storybook"
+    "commitMessage": "chore: deploy storybook"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   "storybook-deployer": {
     "gitUsername": "Vitamin BOT",
     "gitEmail": "designsystem@decathlon.net",
-    "commitMessage": "Deploy Storybook"
+    "commitMessage": "chore: deploy Storybook"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "build": "lerna run build",
+    "deploy-storybook": "storybook-to-ghpages --packages packages",
     "postinstall": "npx husky install",
     "pack": "lerna run pack",
     "prettier": "prettier .",
@@ -46,6 +47,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@octokit/core": "^3.2.4",
+    "@storybook/storybook-deployer": "^2.8.7",
     "husky": "^4.3.6",
     "lerna": "^3.22.1",
     "lint-staged": "^10.5.3",
@@ -62,5 +64,10 @@
       "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
-  ]
+  ],
+  "storybook-deployer": {
+    "gitUsername": "Vitamin BOT",
+    "gitEmail": "designsystem@decathlon.net",
+    "commitMessage": "Deploy Storybook"
+  }
 }

--- a/packages/showcases/css/package.json
+++ b/packages/showcases/css/package.json
@@ -2,6 +2,7 @@
   "name": "@decathlon/vitamin-showcase-css",
   "version": "0.0.1",
   "private": true,
+  "description": "Decathlon - Vitamin CSS showcase",
   "license": "Apache-2.0",
   "scripts": {
     "build:docs": "build-storybook --docs",

--- a/packages/showcases/css/package.json
+++ b/packages/showcases/css/package.json
@@ -2,7 +2,7 @@
   "name": "@decathlon/vitamin-showcase-css",
   "version": "0.0.1",
   "private": true,
-  "description": "Decathlon - Vitamin CSS showcase",
+  "description": "Decathlon Design System - Vitamin CSS showcase",
   "license": "Apache-2.0",
   "scripts": {
     "build:docs": "build-storybook --docs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,6 +2951,17 @@
     regenerator-runtime "^0.13.7"
     source-map "^0.7.3"
 
+"@storybook/storybook-deployer@^2.8.7":
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.7.tgz#c1eed33d03bd9267f884c60eea8e03dc3261ec11"
+  integrity sha512-O0hKHV6hg93fPMvKGC5M/sd7KTL473+SzMKm+WZNVEyLEfXXcVU+Ts9/VL1IhmC1P2A8Bg9oBnkcPqAqjAN46w==
+  dependencies:
+    git-url-parse "^11.1.2"
+    glob "^7.1.3"
+    parse-repo "^1.0.4"
+    shelljs "^0.8.1"
+    yargs "^15.0.0"
+
 "@storybook/theming@5.2.8":
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.2.8.tgz#a4c9e0e9a5789c1aa71e4fcb7a8ee86efe3dadcf"
@@ -10458,6 +10469,11 @@ parse-path@^4.0.0:
     qs "^6.9.4"
     query-string "^6.13.8"
 
+parse-repo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
+  integrity sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=
+
 parse-url@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.2.tgz#856a3be1fcdf78dc93fc8b3791f169072d898b59"
@@ -12416,7 +12432,7 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.4:
+shelljs@^0.8.1, shelljs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -14410,7 +14426,7 @@ yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.1.0:
+yargs@^15.0.0, yargs@^15.1.0:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
## Description

Storybook deployment is managed thanks to [storybook-deloyer](https://github.com/storybookjs/storybook-deployer)
which pushes all storybooks of this monorepo to github pages.

It is automatically done on merge on main branch.
It should be automatically deployed after merging this PR to https://decathlon.github.io/vitamin-web.

Aggregation page of the multiple storybooks [can be personnalized](https://github.com/storybookjs/storybook-deployer#customize-monorepo-indexhtml) (not addressed in this PR).
For now it's a basic page listing storybooks using the name/description in each `package.json` :
 
![image](https://user-images.githubusercontent.com/23191482/104381979-a41a2c00-552d-11eb-9917-6bd684000e86.png)


See https://thollander.github.io/vitamin-web for example.
