### PR TITLE
refactor(css design tokens): typography line heights + font size from px to rem unit

### DIFF
--- a/packages/showcases/css/.storybook/preview-head.html
+++ b/packages/showcases/css/.storybook/preview-head.html
@@ -9,6 +9,6 @@
 
 <style>
   .block {
-    padding: 6px 0;
+    padding: 0.375rem 0;
   }
 </style>

--- a/packages/sources/css/src/design-tokens/src/typography.css
+++ b/packages/sources/css/src/design-tokens/src/typography.css
@@ -21,16 +21,16 @@
  * @presenter FontSize
  */
 :root {
-  --vtmn-typo_display-1-font-size: 60px;
-  --vtmn-typo_display-2-font-size: 32px;
-  --vtmn-typo_title-1-font-size: 40px;
-  --vtmn-typo_title-2-font-size: 36px;
-  --vtmn-typo_title-3-font-size: 28px;
-  --vtmn-typo_title-4-font-size: 24px;
-  --vtmn-typo_title-5-font-size: 20px;
-  --vtmn-typo_text-1-font-size: 18px;
-  --vtmn-typo_text-2-font-size: 16px;
-  --vtmn-typo_text-3-font-size: 14px;
+  --vtmn-typo_display-1-font-size: 3.75rem;
+  --vtmn-typo_display-2-font-size: 2.625rem;
+  --vtmn-typo_title-1-font-size: 2.5rem;
+  --vtmn-typo_title-2-font-size: 2.25rem;
+  --vtmn-typo_title-3-font-size: 1.75rem;
+  --vtmn-typo_title-4-font-size: 1.5rem;
+  --vtmn-typo_title-5-font-size: 1.25rem;
+  --vtmn-typo_text-1-font-size: 1.125rem;
+  --vtmn-typo_text-2-font-size: 1rem;
+  --vtmn-typo_text-3-font-size: 0.875rem;
 }
 
 /**
@@ -38,102 +38,102 @@
  * @presenter LineHeight
  */
 :root {
-  --vtmn-typo_display-1-line-height: 48px;
-  --vtmn-typo_display-2-line-height: 30px;
-  --vtmn-typo_title-1-line-height: 42px;
-  --vtmn-typo_title-2-line-height: 40px;
-  --vtmn-typo_title-3-line-height: 27px;
-  --vtmn-typo_title-4-line-height: 28px;
-  --vtmn-typo_title-5-line-height: 24px;
-  --vtmn-typo_text-1-line-height: 26px;
-  --vtmn-typo_text-2-line-height: 24px;
-  --vtmn-typo_text-3-line-height: 22px;
+  --vtmn-typo_display-1-line-height: 1;
+  --vtmn-typo_display-2-line-height: 1.04;
+  --vtmn-typo_title-1-line-height: 1.1;
+  --vtmn-typo_title-2-line-height: 1.11;
+  --vtmn-typo_title-3-line-height: 1.14;
+  --vtmn-typo_title-4-line-height: 1.16;
+  --vtmn-typo_title-5-line-height: 1.2;
+  --vtmn-typo_text-1-line-height: 1.55;
+  --vtmn-typo_text-2-line-height: 1.5;
+  --vtmn-typo_text-3-line-height: 1.42;
 }
 
 @screen tablet {
   :root {
-    --vtmn-typo_display-1-font-size: 76px;
-    --vtmn-typo_display-2-font-size: 48px;
-    --vtmn-typo_title-1-font-size: 44px;
-    --vtmn-typo_title-2-font-size: 38px;
-    --vtmn-typo_title-3-font-size: 30px;
-    --vtmn-typo_title-4-font-size: 24px;
-    --vtmn-typo_title-5-font-size: 20px;
+    --vtmn-typo_display-1-font-size: 4.75rem;
+    --vtmn-typo_display-2-font-size: 3rem;
+    --vtmn-typo_title-1-font-size: 2.75rem;
+    --vtmn-typo_title-2-font-size: 2.375rem;
+    --vtmn-typo_title-3-font-size: 1.875rem;
+    --vtmn-typo_title-4-font-size: 1.5rem;
+    --vtmn-typo_title-5-font-size: 1.25rem;
   }
 
   :root {
-    --vtmn-typo_display-1-line-height: 60px;
-    --vtmn-typo_display-2-line-height: 44px;
-    --vtmn-typo_title-1-line-height: 48px;
-    --vtmn-typo_title-2-line-height: 42px;
-    --vtmn-typo_title-3-line-height: 34px;
-    --vtmn-typo_title-4-line-height: 28px;
-    --vtmn-typo_title-5-line-height: 24px;
+    --vtmn-typo_display-1-line-height: 1;
+    --vtmn-typo_display-2-line-height: 1.08;
+    --vtmn-typo_title-1-line-height: 1.09;
+    --vtmn-typo_title-2-line-height: 1.15;
+    --vtmn-typo_title-3-line-height: 1.2;
+    --vtmn-typo_title-4-line-height: 1.16;
+    --vtmn-typo_title-5-line-height: 1.2;
   }
 }
 
 @screen small-desktop {
   :root {
-    --vtmn-typo_display-1-font-size: 76px;
-    --vtmn-typo_display-2-font-size: 48px;
-    --vtmn-typo_title-1-font-size: 44px;
-    --vtmn-typo_title-2-font-size: 38px;
-    --vtmn-typo_title-3-font-size: 30px;
-    --vtmn-typo_title-4-font-size: 24px;
-    --vtmn-typo_title-5-font-size: 20px;
+    --vtmn-typo_display-1-font-size: 4.75rem;
+    --vtmn-typo_display-2-font-size: 3rem;
+    --vtmn-typo_title-1-font-size: 2.75rem;
+    --vtmn-typo_title-2-font-size: 2.375rem;
+    --vtmn-typo_title-3-font-size: 1.875rem;
+    --vtmn-typo_title-4-font-size: 1.5rem;
+    --vtmn-typo_title-5-font-size: 1.25rem;
   }
 
   :root {
-    --vtmn-typo_display-1-line-height: 60px;
-    --vtmn-typo_display-2-line-height: 44px;
-    --vtmn-typo_title-1-line-height: 48px;
-    --vtmn-typo_title-2-line-height: 42px;
-    --vtmn-typo_title-3-line-height: 34px;
-    --vtmn-typo_title-4-line-height: 28px;
-    --vtmn-typo_title-5-line-height: 24px;
+    --vtmn-typo_display-1-line-height: 1;
+    --vtmn-typo_display-2-line-height: 1.06;
+    --vtmn-typo_title-1-line-height: 1.08;
+    --vtmn-typo_title-2-line-height: 1.1;
+    --vtmn-typo_title-3-line-height: 1.12;
+    --vtmn-typo_title-4-line-height: 1.23;
+    --vtmn-typo_title-5-line-height: 1.2;
   }
 }
 
 @screen medium-desktop {
   :root {
-    --vtmn-typo_display-1-font-size: 96px;
-    --vtmn-typo_display-2-font-size: 60px;
-    --vtmn-typo_title-1-font-size: 48px;
-    --vtmn-typo_title-2-font-size: 40px;
-    --vtmn-typo_title-3-font-size: 32px;
-    --vtmn-typo_title-4-font-size: 26px;
-    --vtmn-typo_title-5-font-size: 20px;
+    --vtmn-typo_display-1-font-size: 6rem;
+    --vtmn-typo_display-2-font-size: 3.75rem;
+    --vtmn-typo_title-1-font-size: 3rem;
+    --vtmn-typo_title-2-font-size: 2.5rem;
+    --vtmn-typo_title-3-font-size: 2rem;
+    --vtmn-typo_title-4-font-size: 1.625rem;
+    --vtmn-typo_title-5-font-size: 1.25rem;
   }
 
   :root {
-    --vtmn-typo_display-1-line-height: 76px;
-    --vtmn-typo_display-2-line-height: 56px;
-    --vtmn-typo_title-1-line-height: 50px;
-    --vtmn-typo_title-2-line-height: 42px;
-    --vtmn-typo_title-3-line-height: 42px;
-    --vtmn-typo_title-4-line-height: 32px;
-    --vtmn-typo_title-5-line-height: 24px;
+    --vtmn-typo_display-1-line-height: 1;
+    --vtmn-typo_display-2-line-height: 1.06;
+    --vtmn-typo_title-1-line-height: 1.08;
+    --vtmn-typo_title-2-line-height: 1.1;
+    --vtmn-typo_title-3-line-height: 1.12;
+    --vtmn-typo_title-4-line-height: 1.23;
+    --vtmn-typo_title-5-line-height: 1.2;
   }
 }
 
 @screen large-desktop {
   :root {
-    --vtmn-typo_display-1-font-size: 96px;
-    --vtmn-typo_display-2-font-size: 60px;
-    --vtmn-typo_title-1-font-size: 48px;
-    --vtmn-typo_title-2-font-size: 40px;
-    --vtmn-typo_title-3-font-size: 32px;
-    --vtmn-typo_title-4-font-size: 26px;
-    --vtmn-typo_title-5-font-size: 20px;
+    --vtmn-typo_display-1-font-size: 6rem;
+    --vtmn-typo_display-2-font-size: 3.75rem;
+    --vtmn-typo_title-1-font-size: 3rem;
+    --vtmn-typo_title-2-font-size: 2.5rem;
+    --vtmn-typo_title-3-font-size: 2rem;
+    --vtmn-typo_title-4-font-size: 1.625rem;
+    --vtmn-typo_title-5-font-size: 1.25rem;
   }
 
   :root {
-    --vtmn-typo_display-1-line-height: 76px;
-    --vtmn-typo_display-2-line-height: 56px;
-    --vtmn-typo_title-1-line-height: 50px;
-    --vtmn-typo_title-2-line-height: 42px;
-    --vtmn-typo_title-3-line-height: 42px;
-    --vtmn-typo_title-4-line-height: 32px;
-    --vtmn-typo_title-5-line-height: 24px;
+    --vtmn-typo_display-1-line-height: 1;
+    --vtmn-typo_display-2-line-height: 1.06;
+    --vtmn-typo_title-1-line-height: 1.08;
+    --vtmn-typo_title-2-line-height: 1.1;
+    --vtmn-typo_title-3-line-height: 1.12;
+    --vtmn-typo_title-4-line-height: 1.23;
+    --vtmn-typo_title-5-line-height: 1.2;
   }
 }


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side).
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

This Pull Request fixes #30 & #29. I have also replaced `px` units on typography's design tokens with a relative unit: `rem` (see #19).

I've used official values now validated by designers available here: https://www.decathlon.design/726f8c765/p/860e14-typography

Thanks in advance for your review! :)

## Does this introduce a breaking change?

- No
