### PR TITLE
refactor(@vtmn/css): add line-heights to buttons

### DIFF
--- a/packages/sources/css/src/components/button/src/index.css
+++ b/packages/sources/css/src/components/button/src/index.css
@@ -27,7 +27,6 @@
   text-align: center;
   color: var(--vtmn-color_white);
   text-decoration: none;
-  letter-spacing: 0.0375rem;
 }
 
 .vtmn-btn:hover {

--- a/packages/sources/css/src/components/button/src/index.css
+++ b/packages/sources/css/src/components/button/src/index.css
@@ -22,7 +22,6 @@
   display: inline-block;
   font-family: var(--vtmn-typo_font-family--condensed);
   font-weight: var(--vtmn-typo_font-weight--bold);
-  overflow: hidden;
   position: relative;
   text-align: center;
   color: var(--vtmn-color_white);

--- a/packages/sources/css/src/components/button/src/index.css
+++ b/packages/sources/css/src/components/button/src/index.css
@@ -6,17 +6,20 @@
 /* Default button */
 .vtmn-btn {
   box-shadow: inset 0 0 0 rem(2px) transparent;
-  min-width: rem(96px);
   font-size: rem(16px);
+  min-height: rem(48px);
+  min-width: rem(120px);
+  max-width: 100%;
   padding: rem(14px) rem(24px);
-  white-space: no-wrap;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   background-color: var(--vtmn-color_brand-digital);
   border-radius: rem(4px);
   border-width: 0;
   box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: inline-block;
   font-family: var(--vtmn-typo_font-family--condensed);
   font-weight: var(--vtmn-typo_font-weight--bold);
   overflow: hidden;
@@ -24,6 +27,7 @@
   text-align: center;
   color: var(--vtmn-color_white);
   text-decoration: none;
+  letter-spacing: 0.0375rem;
 }
 
 .vtmn-btn:hover {
@@ -170,21 +174,76 @@
 
 /* Sizes */
 .vtmn-btn_size--small {
-  font-size: rem(12px);
+  font-size: rem(14px);
   padding: rem(8px) rem(16px);
+  line-height: calc(16 / 14);
+  min-height: rem(32px);
+  min-width: rem(84px);
 }
 
 .vtmn-btn_size--medium,
 .vtmn-btn_size--stretched {
   font-size: rem(16px);
   padding: rem(14px) rem(24px);
+  line-height: 1.25;
+  min-height: rem(48px);
+  min-width: rem(120px);
 }
 
 .vtmn-btn_size--large {
   font-size: rem(20px);
   padding: rem(20px) rem(40px);
+  line-height: 1.2;
+  min-height: rem(64px);
+  min-width: rem(84px);
 }
 
 .vtmn-btn_size--stretched {
   width: 100%;
+}
+
+/* Button icons  */
+.vtmn-btn-icon {
+  height: rem(16px);
+  width: rem(16px);
+  margin-right: rem(12px);
+  vertical-align: middle;
+}
+.vtmn-btn-icon--without-label {
+  height: rem(20px);
+  width: rem(20px);
+  margin-right: 0;
+}
+
+.vtmn-btn_size--small .vtmn-btn-icon {
+  height: rem(14px);
+  width: rem(14px);
+  margin-right: rem(8px);
+}
+.vtmn-btn_size--small .vtmn-btn-icon--without-label {
+  height: rem(16px);
+  width: rem(16px);
+  margin-right: 0;
+}
+
+.vtmn-btn_size--medium .vtmn-btn-icon {
+  height: rem(16px);
+  width: rem(16px);
+  margin-right: rem(12px);
+}
+.vtmn-btn_size--medium .vtmn-btn-icon .vtmn-btn-icon--without-label {
+  height: rem(20px);
+  width: rem(20px);
+  margin-right: 0;
+}
+
+.vtmn-btn_size--large .vtmn-btn-icon {
+  height: rem(20px);
+  width: rem(20px);
+  margin-right: rem(16px);
+}
+.vtmn-btn_size--large .vtmn-btn-icon--without-label {
+  height: rem(24px);
+  width: rem(24px);
+  margin-right: 0;
 }


### PR DESCRIPTION

## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side).
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

Add line-heights to cta in order to give them a fitting default height.

According to [design-system statements](https://www.decathlon.design/726f8c765/p/8008f8-button/t/58ed03) :

**S should be 32px** 
that's 2rem 
that's **_0.875rem_** (font-size) * **_~1.2857_** (line-height) + **_0.4375rem_** (padding-top) + **_0.4375rem_** (padding-bottom)

**M should be 48px** 
that's 3rem 
that's **_1rem_** (font-size) * **_1.25_** (line-height) + **_0.875rem_** (padding-top) + **_0.875rem_** (padding-bottom)

**L should be 64px** 
that's 4rem 
that's **_1.25rem_** (font-size) * **_1.2_** (line-height) + **_1.25rem_** (padding-top) + **_1.25rem_** (padding-bottom)


