### PR TITLE
refactor(@vtmn/react): use more conventional types

### DIFF
--- a/packages/sources/react/package.json
+++ b/packages/sources/react/package.json
@@ -21,7 +21,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/sources/react/src/components/VtmnButton/VtmnButton.tsx
+++ b/packages/sources/react/src/components/VtmnButton/VtmnButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import '@vtmn/css-button';
 
 export interface VtmnButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends React.ComponentPropsWithoutRef<'button'> {
   /**
    * The variant of the button.
    * @default 'primary'
@@ -26,13 +26,13 @@ export interface VtmnButtonProps
   icon?: string;
 }
 
-export const VtmnButton: React.FC<VtmnButtonProps> = ({
+export const VtmnButton = ({
   variant = 'primary',
   size = 'medium',
   children,
   className,
   ...props
-}) => {
+}: VtmnButtonProps) => {
   return (
     <button
       className={`vtmn-btn vtmn-btn_variant--${variant} vtmn-btn_size--${size} ${


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side).
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

As I've struggled myself with `React` types in `TypeScript` recently and as I've stumbled upon your repo (looking for inspiration for my own `rollup` configuration 😄), I decided to suggest a few changes based on my own experience

I've used this guideline as a reference: https://react-typescript-cheatsheet.netlify.app/

The sections I've used are these ones:
- https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components
- https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase#wrappingmirroring-a-html-element

Following these guidelines may save you a few headaches in the long run 😄  (trust me, I've been there)

Also, I realized the `types` declaration in the `package.json` didn't point to the correct folder where the types are so I've changed this as well

## Does this introduce a breaking change?

- No

## Other information

Nope

❤️ Thank you!

Awww you're welcome ❤️ 
