### PR TITLE
feat(vtmn-text-input): Add more specification on inputs

### DIFF
--- a/packages/sources/css/src/components/text-input/src/index.css
+++ b/packages/sources/css/src/components/text-input/src/index.css
@@ -3,14 +3,15 @@
 @import '@vtmn/css-design-tokens/src/spacings';
 @import '@vtmn/css-design-tokens/src/typography';
 
-input.vtmn-text-input,
-input.vtmn-text-input::before,
-input.vtmn-text-input::after {
+.vtmn-text-input,
+.vtmn-text-input::before,
+.vtmn-text-input::after {
   box-sizing: border-box;
 }
 
-input.vtmn-text-input {
+.vtmn-text-input {
   box-shadow: inset 0 0 0 rem(1px) var(--vtmn-color_grey-light-1);
+  border:none;
   background-color: var(--vtmn-color_white);
   border-radius: rem(4px);
   display: block;
@@ -28,47 +29,47 @@ textarea.vtmn-text-input {
   min-height: rem(40px);
 }
 
-input.vtmn-text-input:not([disabled]):hover {
+.vtmn-text-input:not([disabled]):hover {
   box-shadow: inset 0 0 0 rem(1px) var(--vtmn-color_brand-digital);
 }
 
-input.vtmn-text-input:not([disabled]):focus,
-input.vtmn-text-input:not([disabled]):active {
+.vtmn-text-input:not([disabled]):focus,
+.vtmn-text-input:not([disabled]):active {
   outline: none;
   box-shadow: inset 0 0 0 rem(2px) var(--vtmn-color_brand-digital-light-1);
 }
 
-input.vtmn-text-input::placeholder {
+.vtmn-text-input::placeholder {
   color: var(--vtmn-color_grey);
 }
 
-input.vtmn-text-input[disabled] {
+.vtmn-text-input[disabled] {
   cursor: not-allowed;
   background-color: var(--vtmn-color_grey-light-3);
   border-color: var(--vtmn-color_grey-light-1);
   color: var(--vtmn-color_grey-light-1);
 }
 
-input.vtmn-text-input[disabled]::placeholder {
+.vtmn-text-input[disabled]::placeholder {
   color: var(--vtmn-color_grey-light-1);
 }
 
-input.vtmn-text-input_label {
+.vtmn-text-input_label {
   color: var(--vtmn-color_black);
   font-size: rem(16px);
   line-height: 1;
 }
 
-input.vtmn-text-input_helper-text {
+.vtmn-text-input_helper-text {
   color: var(--vtmn-color_grey);
   font-size: rem(14px);
   line-height: 1;
 }
 
-input.vtmn-text-input--valid {
+.vtmn-text-input--valid {
   box-shadow: inset 0 0 0 rem(2px) var(--vtmn-color_success);
 }
 
-input.vtmn-text-input--error {
+.vtmn-text-input--error {
   box-shadow: inset 0 0 0 rem(2px) var(--vtmn-color_danger);
 }

--- a/packages/sources/css/src/components/text-input/src/index.css
+++ b/packages/sources/css/src/components/text-input/src/index.css
@@ -3,13 +3,13 @@
 @import '@vtmn/css-design-tokens/src/spacings';
 @import '@vtmn/css-design-tokens/src/typography';
 
-.vtmn-text-input,
-.vtmn-text-input::before,
-.vtmn-text-input::after {
+input.vtmn-text-input,
+input.vtmn-text-input::before,
+input.vtmn-text-input::after {
   box-sizing: border-box;
 }
 
-.vtmn-text-input {
+input.vtmn-text-input {
   box-shadow: inset 0 0 0 rem(1px) var(--vtmn-color_grey-light-1);
   background-color: var(--vtmn-color_white);
   border-radius: rem(4px);
@@ -28,47 +28,47 @@ textarea.vtmn-text-input {
   min-height: rem(40px);
 }
 
-.vtmn-text-input:not([disabled]):hover {
+input.vtmn-text-input:not([disabled]):hover {
   box-shadow: inset 0 0 0 rem(1px) var(--vtmn-color_brand-digital);
 }
 
-.vtmn-text-input:not([disabled]):focus,
-.vtmn-text-input:not([disabled]):active {
+input.vtmn-text-input:not([disabled]):focus,
+input.vtmn-text-input:not([disabled]):active {
   outline: none;
   box-shadow: inset 0 0 0 rem(2px) var(--vtmn-color_brand-digital-light-1);
 }
 
-.vtmn-text-input::placeholder {
+input.vtmn-text-input::placeholder {
   color: var(--vtmn-color_grey);
 }
 
-.vtmn-text-input[disabled] {
+input.vtmn-text-input[disabled] {
   cursor: not-allowed;
   background-color: var(--vtmn-color_grey-light-3);
   border-color: var(--vtmn-color_grey-light-1);
   color: var(--vtmn-color_grey-light-1);
 }
 
-.vtmn-text-input[disabled]::placeholder {
+input.vtmn-text-input[disabled]::placeholder {
   color: var(--vtmn-color_grey-light-1);
 }
 
-.vtmn-text-input_label {
+input.vtmn-text-input_label {
   color: var(--vtmn-color_black);
   font-size: rem(16px);
   line-height: 1;
 }
 
-.vtmn-text-input_helper-text {
+input.vtmn-text-input_helper-text {
   color: var(--vtmn-color_grey);
   font-size: rem(14px);
   line-height: 1;
 }
 
-.vtmn-text-input--valid {
+input.vtmn-text-input--valid {
   box-shadow: inset 0 0 0 rem(2px) var(--vtmn-color_success);
 }
 
-.vtmn-text-input--error {
+input.vtmn-text-input--error {
   box-shadow: inset 0 0 0 rem(2px) var(--vtmn-color_danger);
 }


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side).
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

Add more specification on vtmn-text-input, such as what is already done on textarea.
**e.g: .vtmn-text-input => input.vtmn-text-input**

## Does this introduce a breaking change?

- No

## Other information

This enhancement has for objective to improve inputs targeting, which is necessary to override our Cube legacy input css in NFS new account forms, using Vitamin style.

❤️ Thank you!
