### PR TITLE
refactor(@vtmn/css): add mobile screen in tailwind configuration

### DIFF
--- a/packages/sources/css/config/tailwind/tailwind.config.js
+++ b/packages/sources/css/config/tailwind/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
   darkMode: false, // or 'media' or 'class',
   theme: {
     screens: {
-      mb: { max: '599px' },
+      mobile: { max: '599px' },
       tablet: { min: '600px', max: '899px' },
       'small-desktop': { min: '900px', max: '1199px' },
       'medium-desktop': { min: '1200px', max: '1799px' },

--- a/packages/sources/css/config/tailwind/tailwind.config.js
+++ b/packages/sources/css/config/tailwind/tailwind.config.js
@@ -5,10 +5,10 @@ module.exports = {
   theme: {
     screens: {
       mb: { max: '599px' },
-      tb: { min: '600px', max: '899px' },
-      sd: { min: '900px', max: '1199px' },
-      md: { min: '1200px', max: '1799px' },
-      ld: { min: '1800px' },
+      tablet: { min: '600px', max: '899px' },
+      'small-desktop': { min: '900px', max: '1199px' },
+      'medium-desktop': { min: '1200px', max: '1799px' },
+      'large-desktop': { min: '1800px' },
     },
     colors: {
       brand: 'var(--vtmn-color_brand)',


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side).
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

This PR aims to provide a shorten version of vtmn screens prefixes as long as a new screen scope for mobile only styles.

## Does this introduce a breaking change?

Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

As this PR change the existing screen names we would need to rename them everywhere they are being used.

- tablet = tb
- small desktop = sd
- medium-desktop = md
- large-desktop = ld

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

❤️ Thank you!
