### PR TITLE
docs(@vtmn/css): edit fonts import documentation

### DIFF
--- a/packages/sources/css/README.md
+++ b/packages/sources/css/README.md
@@ -33,12 +33,14 @@ Shown below is a sample link markup used to load from a CDN:
 ```html
 <link
   rel="stylesheet"
-  href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Roboto+Condensed:ital,wght@0,400;0,700;1,700&display=swap"
 />
-<link
-  rel="stylesheet"
-  href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,400;0,700;1,700&display=swap"
-/>
+```
+
+You can also do it via CSS Import:
+
+```css
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Roboto+Condensed:ital,wght@0,400;0,700;1,700&display=swap");
 ```
 
 Otherwise, you can install them with `typeface`:


### PR DESCRIPTION
## Description

Edit the html import, replace the two html links by one that does the same thing.
Add another way of importing by using the css import rule (see [doc](https://developer.mozilla.org/fr/docs/Web/CSS/@import)).


## Does this introduce a breaking change?

- No

