### PR TITLE
feat(@vtmn/svelte): add link component

### DIFF
--- a/packages/showcases/core/src/components/VtmnLink.csf.js
+++ b/packages/showcases/core/src/components/VtmnLink.csf.js
@@ -1,0 +1,52 @@
+export default (component) => ({
+  title: 'Components/VtmnLink',
+  component,
+  argTypes: {
+    href: {
+      type: { name: 'string', required: true },
+      description: 'The href of the link.',
+      defaultValue: '#',
+      control: { type: 'text' },
+    },
+    target: {
+      type: { name: 'string', required: false },
+      description: 'The target of the link.',
+      defaultValue: '_blank',
+      control: { type: 'text' },
+    },
+    size: {
+      type: { name: 'string', required: false },
+      description: 'The size of the link.',
+      defaultValue: 'medium',
+      control: {
+        type: 'select',
+        options: ['small', 'medium', 'large'],
+      },
+    },
+    isStandalone: {
+      type: { name: 'boolean', required: false },
+      description: 'If the component is a standalone or not.',
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    children: {
+      type: { name: 'string', required: false },
+      description: 'The content to render inside the component.',
+      defaultValue: 'Link',
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  parameters: {
+    backgrounds: { default: 'grey' },
+    actions: {
+      handles: ['mouseenter', 'click', 'focusin', 'focusout'],
+    },
+    design: {
+      type: 'figma',
+      url:
+        'https://www.figma.com/file/zDZIyayUlr1yTWrsi7cFoo/Vtmn---Web?node-id=1207%3A8898',
+    },
+  },
+});

--- a/packages/showcases/react/stories/components/VtmnLink/VtmnLink.stories.tsx
+++ b/packages/showcases/react/stories/components/VtmnLink/VtmnLink.stories.tsx
@@ -2,58 +2,9 @@ import { VtmnLink } from '@vtmn/react';
 
 import { Meta, Story } from '@storybook/react';
 
-export default {
-  title: 'Components/VtmnLink',
-  component: VtmnLink,
-  argTypes: {
-    href: {
-      type: { name: 'string', required: true },
-      description: 'The href of the link.',
-      defaultValue: '#',
-      control: { type: 'text' },
-    },
-    target: {
-      type: { name: 'string', required: false },
-      description: 'The target of the link.',
-      defaultValue: '_blank',
-      control: { type: 'text' },
-    },
-    size: {
-      type: { name: 'string', required: false },
-      description: 'The size of the link.',
-      defaultValue: 'medium',
-      control: {
-        type: 'select',
-        options: ['small', 'medium', 'large'],
-      },
-    },
-    isStandalone: {
-      type: { name: 'boolean', required: false },
-      description: 'If the component is a standalone or not.',
-      defaultValue: false,
-      control: { type: 'boolean' },
-    },
-    children: {
-      type: { name: 'string', required: false },
-      description: 'The content to render inside the component.',
-      defaultValue: 'Link',
-      control: {
-        type: 'text',
-      },
-    },
-  },
-  parameters: {
-    backgrounds: { default: 'grey' },
-    actions: {
-      handles: ['mouseenter', 'click', 'focusin', 'focusout'],
-    },
-    design: {
-      type: 'figma',
-      url:
-        'https://www.figma.com/file/zDZIyayUlr1yTWrsi7cFoo/Vtmn---Web?node-id=1207%3A8898',
-    },
-  },
-} as Meta;
+import VtmnLinkCsf from '../../../../core/src/components/VtmnLink.csf';
+
+export default VtmnLinkCsf(VtmnLink) as Meta;
 
 const Template: Story = (args) => <VtmnLink {...args} />;
 

--- a/packages/showcases/svelte/stories/components/VtmnLink/VtmnLink.stories.js
+++ b/packages/showcases/svelte/stories/components/VtmnLink/VtmnLink.stories.js
@@ -1,0 +1,13 @@
+import VtmnLinkView from './VtmnLinkView.svelte';
+import VtmnLink from '@vtmn/svelte/src/components/VtmnLink.svelte';
+import VtmnLinkCsf from '../../../../core/src/components/VtmnLink.csf';
+
+export default VtmnLinkCsf(VtmnLink);
+
+const Template = (args) => ({
+  Component: VtmnLinkView,
+  props: args,
+});
+
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/packages/showcases/svelte/stories/components/VtmnLink/VtmnLinkView.svelte
+++ b/packages/showcases/svelte/stories/components/VtmnLink/VtmnLinkView.svelte
@@ -1,0 +1,11 @@
+<script>
+  /**
+   * @component Link View
+   * @wrapper
+   */
+  import VtmnLink from '@vtmn/svelte/src/components/VtmnLink.svelte';
+
+  export let children = 'Link';
+</script>
+
+<VtmnLink {...$$restProps}>{children}</VtmnLink>

--- a/packages/sources/svelte/rollup.config.js
+++ b/packages/sources/svelte/rollup.config.js
@@ -4,7 +4,7 @@ import css from 'rollup-plugin-css-only';
 import sveltePreprocess from 'svelte-preprocess';
 const preprocessOptions = require('./svelte.config').preprocessOptions;
 
-const components = ['VtmnButton', 'VtmnTextInput'];
+const components = ['VtmnButton', 'VtmnTextInput', 'VtmnLink'];
 
 export default components.map((name) => ({
   input: `src/components/${name}.svelte`,

--- a/packages/sources/svelte/src/components/VtmnLink.svelte
+++ b/packages/sources/svelte/src/components/VtmnLink.svelte
@@ -1,0 +1,23 @@
+<script>
+  import '@vtmn/css-link';
+
+  /**
+   * The size of the link.
+   * @type {string}
+   * @default 'medium'
+   */
+  export let size = 'medium';
+
+  /**
+   * Whether link is standalone or not.
+   * @type {boolean}
+   * @default false
+   */
+  export let isStandalone = false;
+</script>
+
+<a
+  class={['vtmn-link', `vtmn-link_size--${size}`, isStandalone && 'vtmn-link--standalone'].filter(Boolean).join(' ')}
+  {...$$restProps}>
+  <slot></slot>
+</a>


### PR DESCRIPTION
## Description

- init a new format of file `showcases/core/src/components/{component}.csf.js` ([Component Story Format](https://storybook.js.org/docs/react/writing-stories/introduction?_sm_au_=iVV3QqfrFv0vR8JHVWsfvK70kM0Mc#component-story-format)) => first step to have a uniform implementation across frameworks
- add link component version for Svelte 
