### PR TITLE
fix(@vtmn/css): no more hover effect over focus-visible state (checkbox/radio)

### DIFF
--- a/packages/sources/css/src/components/checkbox/src/index.css
+++ b/packages/sources/css/src/components/checkbox/src/index.css
@@ -34,7 +34,7 @@
   border-color: var(--vtmn-color_grey);
 }
 
-.vtmn-checkbox[type='checkbox']:not(:checked):not(:disabled):hover
+.vtmn-checkbox[type='checkbox']:not(:focus-visible):not(:checked):not(:disabled):hover
   + label::before {
   box-shadow: 0 0 0 rem(7px) color-mod(var(--vtmn-color_black) alpha(5%));
 }
@@ -54,7 +54,8 @@
   border-color: var(--vtmn-color_brand-digital);
 }
 
-.vtmn-checkbox[type='checkbox']:checked:not(:disabled):hover + label::before {
+.vtmn-checkbox[type='checkbox']:not(:focus-visible):checked:not(:disabled):hover
+  + label::before {
   box-shadow: 0 0 0 rem(7px)
     color-mod(var(--vtmn-color_brand-digital) alpha(5%));
 }
@@ -92,9 +93,4 @@
 .vtmn-checkbox[type='checkbox']:disabled + label {
   opacity: 0.38;
   cursor: not-allowed;
-}
-
-.vtmn-checkbox[type='checkbox']:focus-visible + label::before {
-  outline: none;
-  box-shadow: 0 0 0 rem(4px) var(--vtmn-color_brand-digital-light-1);
 }

--- a/packages/sources/css/src/components/radio-button/src/index.css
+++ b/packages/sources/css/src/components/radio-button/src/index.css
@@ -33,7 +33,7 @@
   border-color: var(--vtmn-color_grey);
 }
 
-.vtmn-radio-button[type='radio']:not(:checked):not(:disabled):hover
+.vtmn-radio-button[type='radio']:not(:focus-visible):not(:checked):not(:disabled):hover
   + label::before {
   box-shadow: 0 0 0 rem(7px) color-mod(var(--vtmn-color_black) alpha(5%));
 }
@@ -52,7 +52,8 @@
   border-color: var(--vtmn-color_black);
 }
 
-.vtmn-radio-button[type='radio']:checked:not(:disabled):hover + label::before {
+.vtmn-radio-button[type='radio']:not(:focus-visible):checked:not(:disabled):hover
+  + label::before {
   box-shadow: 0 0 0 rem(7px)
     color-mod(var(--vtmn-color_brand-digital) alpha(5%));
 }


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side).
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

- When a radio or checkbox is focus-visible, the hover effect doesn't apply and make the focus-visible state priority.

## Does this introduce a breaking change?

- No


❤️ Thank you!
