### PR TITLE
feat(@vtmn/icons): change default display of vtmx sprites

### DIFF
--- a/packages/sources/icons/src/templates/css.hbs
+++ b/packages/sources/icons/src/templates/css.hbs
@@ -4,7 +4,8 @@
 }
 
 [class^="{{prefix}}-"], [class*=" {{prefix}}-"] {
-    display: inline-flex;
+    display: flex;
+    align-items: center;
 }
 
 {{# if selector }}


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

- Vitamix icons sprites are now flex and vertically aligned by default (previously: inline-flex). Enabling the centering of the sprites in div and preventing the height of the icon to be higher than the sprite.

## Does this introduce a breaking change?

- Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- If you translate manually your icons with an absolute position or by using transform property, you may need to remove these code lines and use display-flex properties to center or align your icon.


❤️ Thank you!
