### PR TITLE
feat(@vtmn/svelte): add popover component

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+* text eol=lf
+
+*.png binary
+*.jpg binary
+*.ico binary
+*.gif binary
+*.svg binary
+*.eot binary
+*.eot binary
+*.otf binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+[core]
+  ignorecase=false

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && git add -A .
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -95,5 +95,9 @@
     "gitUsername": "Vitamin BOT",
     "gitEmail": "designsystem@decathlon.net",
     "commitMessage": "chore: deploy storybook"
+  },
+  "volta": {
+    "node": "14.17.5",
+    "yarn": "1.22.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "./packages/**/*.css": [
       "yarn stylelint:fix"
     ],
-    "./packages/**/*.{json,js,jsx,ts,tsx}": [
+    "./packages/**/*.{json,js,jsx,ts,tsx,svelte}": [
       "yarn prettier:fix"
     ]
   },
@@ -76,6 +76,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^11.1.0",
     "prettier": "^2.2.1",
+    "prettier-plugin-svelte": "^2.4.0",
     "shx": "^0.3.3",
     "sort-package-json": "^1.48.0"
   },

--- a/packages/showcases/svelte/.storybook/main.js
+++ b/packages/showcases/svelte/.storybook/main.js
@@ -1,9 +1,9 @@
 module.exports = {
   'stories': [
-    '../stories/**/*.stories.mdx',
-    '../stories/**/*.stories.@(js|jsx|ts|tsx)'
+    '../stories/**/*.stories.{js,jsx,ts,tsx,mdx,svelte}'
   ],
   'addons': [
+    '@storybook/addon-svelte-csf',
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     '@whitespace/storybook-addon-html',

--- a/packages/showcases/svelte/package.json
+++ b/packages/showcases/svelte/package.json
@@ -9,6 +9,9 @@
     "build-storybook:docs": "build-storybook --docs",
     "start": "start-storybook -p 6010"
   },
+  "dependencies": {
+    "@storybook/addon-svelte-csf": "^1.1.0"
+  },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.3.7",
     "@storybook/addon-essentials": "^6.3.7",

--- a/packages/showcases/svelte/package.json
+++ b/packages/showcases/svelte/package.json
@@ -9,12 +9,10 @@
     "build-storybook:docs": "build-storybook --docs",
     "start": "start-storybook -p 6010"
   },
-  "dependencies": {
-    "@storybook/addon-svelte-csf": "^1.1.0"
-  },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.3.7",
     "@storybook/addon-essentials": "^6.3.7",
+    "@storybook/addon-svelte-csf": "^1.1.0",
     "@storybook/svelte": "^6.3.7",
     "@vtmn/icons": "*",
     "@vtmn/showcase-core": "*",

--- a/packages/showcases/svelte/stories/components/VtmnPopover/VtmnPopover.stories.svelte
+++ b/packages/showcases/svelte/stories/components/VtmnPopover/VtmnPopover.stories.svelte
@@ -1,0 +1,70 @@
+<script>
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import VtmnPopover, {
+    POSITION,
+  } from '@vtmn/svelte/src/components/VtmnPopover.svelte';
+  import VtmnButton from '@vtmn/svelte/src/components/VtmnButton.svelte';
+
+  const popoverArgs = {
+    title: 'This is the title of the popover',
+    body: 'A popover can appear when users click or focus an element to provide his description in details, and often also with a link or button inside. Popovers will automatically close when clicking outside the popover bounds.',
+  };
+</script>
+
+<Meta
+  title="Components/VtmnPopover"
+  component={VtmnPopover}
+  argTypes={{
+    position: {
+      control: 'select',
+      options: Object.keys(POSITION),
+      mapping: POSITION,
+    },
+    title: { control: 'text' },
+    body: { control: 'text' },
+  }}
+/>
+
+<Template let:args>
+  <div class="story-container">
+    <VtmnPopover position={args.position}>
+      <svelte:fragment slot="title">{args.title}</svelte:fragment>
+      <svelte:fragment slot="body">{args.body}</svelte:fragment>
+      <VtmnButton slot="placeholder">{args.position}</VtmnButton>
+    </VtmnPopover>
+  </div>
+</Template>
+
+<Story name="All positions">
+  <div class="story-container">
+    {#each Object.values(POSITION) as position}
+      <VtmnPopover {position}>
+        <svelte:fragment slot="title">{popoverArgs.title}</svelte:fragment>
+        <svelte:fragment slot="body">{popoverArgs.body}</svelte:fragment>
+        <VtmnButton slot="placeholder">{position}</VtmnButton>
+      </VtmnPopover>
+    {/each}
+  </div>
+</Story>
+
+<Story
+  name="With Controls"
+  args={{
+    position: POSITION.BOTTOM,
+    ...popoverArgs,
+  }}
+/>
+
+<style>
+  .story-container {
+    font-size: 1rem;
+
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    gap: 1rem;
+  }
+</style>

--- a/packages/sources/svelte/src/components/VtmnButton.svelte
+++ b/packages/sources/svelte/src/components/VtmnButton.svelte
@@ -1,5 +1,8 @@
 <script>
   import '@vtmn/css-button/dist/index.css';
+  import { cn } from '../utils/classnames';
+
+  /** @restProps { button } */
 
   /**
    * The variant of the button.
@@ -34,27 +37,34 @@
    * @default undefined and therefore not displayed by default
    */
   export let iconAlone;
+
+  let className;
+  /**
+   * @type {string} A custom class to apply to the component.
+   */
+  export { className as class };
+
+  $: componentClass = cn(
+    'vtmn-btn',
+    variant && `vtmn-btn_variant--${variant}`,
+    size && `vtmn-btn_size--${size}`,
+    !iconAlone && iconLeft && 'vtmn-btn--icon-left',
+    !iconAlone && iconRight && 'vtmn-btn--icon-right',
+    iconAlone && 'vtmn-btn--icon-alone',
+    className,
+  );
 </script>
 
-<button
-  type="button"
-  class={['vtmn-btn',
-    `vtmn-btn_variant--${variant}`,
-    `vtmn-btn_size--${size}`,
-    !iconAlone && iconLeft ? 'vtmn-btn--icon-left' : '',
-    !iconAlone && iconRight ? 'vtmn-btn--icon-right' : '',
-    iconAlone ? 'vtmn-btn--icon-alone' : '']
-    .join(' ')}
-  {...$$props}>
+<button type="button" class={componentClass} {...$$restProps}>
   {#if !iconAlone && iconLeft}
-    <span class={`vtmx-${iconLeft}`}></span>
+    <span class={`vtmx-${iconLeft}`} />
   {/if}
   {#if iconAlone}
-    <span class={`vtmx-${iconAlone}`}></span>
+    <span class={`vtmx-${iconAlone}`} />
   {:else}
-    <slot></slot>
+    <slot />
   {/if}
   {#if !iconAlone && iconRight}
-    <span class={`vtmx-${iconRight}`}></span>
+    <span class={`vtmx-${iconRight}`} />
   {/if}
 </button>

--- a/packages/sources/svelte/src/components/VtmnLink.svelte
+++ b/packages/sources/svelte/src/components/VtmnLink.svelte
@@ -1,5 +1,8 @@
 <script>
   import '@vtmn/css-link';
+  import { cn } from '../utils/classnames';
+
+  /** @restProps { a } */
 
   /**
    * The size of the link.
@@ -21,18 +24,22 @@
    * @default false
    */
   export let iconAlong = false;
-</script>
 
-<a
-  class={[
+  let className;
+  /**
+   * @type {string} A custom class to apply to the component.
+   */
+  export { className as class };
+
+  $: componentClass = cn(
     'vtmn-link',
-    `vtmn-link_size--${size}`,
+    size && `vtmn-link_size--${size}`,
     standalone && 'vtmn-link--standalone',
     standalone && iconAlong && 'vtmn-link--icon-along',
-  ]
-    .filter(Boolean)
-    .join(' ')}
-  {...$$props}
->
+    className,
+  );
+</script>
+
+<a class={componentClass} {...$$restProps}>
   <slot />
 </a>

--- a/packages/sources/svelte/src/components/VtmnPopover.svelte
+++ b/packages/sources/svelte/src/components/VtmnPopover.svelte
@@ -1,0 +1,49 @@
+<script context="module">
+  /** @enum */
+  export const POSITION = {
+    TOP_LEFT: 'top-left',
+    TOP: 'top',
+    TOP_RIGHT: 'top-right',
+    RIGHT: 'right',
+    BOTTOM_RIGHT: 'bottom-right',
+    BOTTOM: 'bottom',
+    BOTTOM_LEFT: 'bottom-left',
+    LEFT: 'left',
+  };
+
+  /** @type {POSITION} */
+  export const DEFAULT_POSITION = POSITION.BOTTOM;
+</script>
+
+<script>
+  import '@vtmn/css-popover/dist/index.css';
+  import { cn } from '../utils/classnames';
+
+  /** @type {string} - An unique id */
+  export let id = '';
+  /** @type {POSITION} */
+  export let position = DEFAULT_POSITION;
+
+  let className;
+  /**
+   * @type {string} A custom class to apply to the component.
+   */
+  export { className as class };
+
+  $: componentClass = cn('vtmn-popover', className);
+</script>
+
+<div
+  class={componentClass}
+  data-position={position}
+  aria-describedby={id}
+  tabindex="0"
+  {...$$restProps}
+>
+  <slot name="placeholder" />
+
+  <div {id} role="tooltip">
+    <p class="vtmn-popover_title"><slot name="title" /></p>
+    <p class="vtmn-popover_text"><slot name="body" /></p>
+  </div>
+</div>

--- a/packages/sources/svelte/src/components/VtmnPopover.svelte
+++ b/packages/sources/svelte/src/components/VtmnPopover.svelte
@@ -20,7 +20,7 @@
   import { cn } from '../utils/classnames';
 
   /** @type {string} - An unique id */
-  export let id = '';
+  export let identifier = '';
   /** @type {POSITION} */
   export let position = DEFAULT_POSITION;
 
@@ -36,13 +36,13 @@
 <div
   class={componentClass}
   data-position={position}
-  aria-describedby={id}
+  aria-describedby={identifier}
   tabindex="0"
   {...$$restProps}
 >
   <slot name="placeholder" />
 
-  <div {id} role="tooltip">
+  <div id={identifier} role="tooltip">
     <p class="vtmn-popover_title"><slot name="title" /></p>
     <p class="vtmn-popover_text"><slot name="body" /></p>
   </div>

--- a/packages/sources/svelte/src/components/VtmnTextInput.svelte
+++ b/packages/sources/svelte/src/components/VtmnTextInput.svelte
@@ -1,6 +1,8 @@
 <script>
   import '@vtmn/css-text-input/dist/index.css';
 
+  /** @restProps { input | textarea } */
+
   /**
    * ID of the input
    * @type {string}
@@ -64,10 +66,10 @@
     class="vtmn-text-input"
     class:vtmn-text-input--error={error}
     class:vtmn-text-input--valid={valid}
-    {identifier}
+    id={identifier}
     {disabled}
     {placeholder}
-    {...$$props}
+    {...$$restProps}
   />
 {:else}
   <div class="vtmn-text-input_container">
@@ -76,10 +78,10 @@
       class:vtmn-text-input--valid={valid}
       class:vtmn-text-input--error={error}
       type="text"
-      {identifier}
+      id={identifier}
       {disabled}
       {placeholder}
-      {...$$props}
+      {...$$restProps}
     />
     <span class={icon && `vtmx-${icon}`} />
   </div>

--- a/packages/sources/svelte/src/utils/classnames.js
+++ b/packages/sources/svelte/src/utils/classnames.js
@@ -1,0 +1,10 @@
+/**
+ * @typedef {false|undefined|null|''|0|NaN} FalsyValue
+ */
+
+/**
+ * Concat all classNames, remove falsy or empty ones.
+ * @param {(string|FalsyValue)[]} classNames
+ * @returns {string}
+ */
+export const cn = (...classNames) => classNames.filter(Boolean).join(' ');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,6 +3153,13 @@
   resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-2.0.0.tgz#c40bbe91bacd3f795963dc1ee6ff86be87deeda9"
   integrity sha512-ZhdT++cX+L9LwjhGYggvYUUVQH/MGn2rwbrAwCMzA/f2QTFvkjxzX8nDgMxIhaLCDC+gHIxfJG2wrWN0jkBr3g==
 
+"@storybook/addon-svelte-csf@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-svelte-csf/-/addon-svelte-csf-1.1.0.tgz#1d6674830efdd4fea1ba266457ab2bc91fd19744"
+  integrity sha512-AjP9kxVbbAyucB8vy889WERafjNM020vWel+psCuDJ2vLU+uObqbCLSGKRIznXjeL0BYR73l9ZF+niJfw6QSlg==
+  dependencies:
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-toolbars@6.3.7":
   version "6.3.7"
   resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.3.7.tgz#acd0c9eea7fad056d995a821e34abddd5b065b9b"
@@ -4746,14 +4753,6 @@
     "@typescript-eslint/typescript-estree" "4.29.3"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz#442b0f029d981fa402942715b1718ac7fcd5aa1b"
-  integrity sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==
-  dependencies:
-    "@typescript-eslint/types" "4.29.2"
-    "@typescript-eslint/visitor-keys" "4.29.2"
-
 "@typescript-eslint/scope-manager@4.29.3":
   version "4.29.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz#497dec66f3a22e459f6e306cf14021e40ec86e19"
@@ -4766,11 +4765,6 @@
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
   integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
-
-"@typescript-eslint/types@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.2.tgz#fc0489c6b89773f99109fb0aa0aaddff21f52fcd"
-  integrity sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==
 
 "@typescript-eslint/types@4.29.3":
   version "4.29.3"
@@ -4791,19 +4785,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz#a0ea8b98b274adbb2577100ba545ddf8bf7dc219"
-  integrity sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==
-  dependencies:
-    "@typescript-eslint/types" "4.29.2"
-    "@typescript-eslint/visitor-keys" "4.29.2"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/typescript-estree@4.29.3":
   version "4.29.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz#1bafad610015c4ded35c85a70b6222faad598b40"
@@ -4823,14 +4804,6 @@
   integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
   dependencies:
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/visitor-keys@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz#d2da7341f3519486f50655159f4e5ecdcb2cd1df"
-  integrity sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==
-  dependencies:
-    "@typescript-eslint/types" "4.29.2"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.29.3":
   version "4.29.3"
@@ -17335,6 +17308,11 @@ prettier-linter-helpers@^1.0.0:
   integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
   dependencies:
     fast-diff "^1.1.2"
+
+prettier-plugin-svelte@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.4.0.tgz#482bb6003bf1d5bd7ff002261a42a32b87d42d00"
+  integrity sha512-JwJ9bOz4XHLQtiLnX4mTSSDUdhu12WH8sTwy/XTDCSyPlah6IcV7NWeYBZscPEcceu2YnW8Y9sJCP40Z2UH9GA==
 
 prettier@^1.18.2:
   version "1.19.1"


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

I added : 
- a Svelte component over the `popover` vitamin design :) 
- its stories
- a `classnames` utils, a first step to concatenate classNames and removing falsy ones.

I updated current components in order to use this util. 
Please note that it could be useful in other frameworks, such as React.

I took the liberty to add support for Svelte files in prettier, and for the Svelte CSF story format.

## Does this introduce a breaking change?

- No (I don't think so)

