### PR TITLE
chore: delete prepare npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ These packages allow the consumption of elements with a higher level of granular
 
 <details>
   <summary>For design tokens</summary>
-  
+
   <table>
     <tr>
       <th>@vtmn/css-design-tokens</th>
@@ -285,18 +285,18 @@ cd vitamin-web
 # install dependencies
 yarn
 
+# build all packages
+yarn build
+
 # start all showcases and build sources in watch mode & hot reload
 yarn start
-# or if you need don't need to launch every packages, you can launch separately:
+# or you can launch separately (recommended)
 yarn start:css
 yarn start:icons
 yarn start:web-components
 yarn start:react
 yarn start:svelte
 yarn start:vue
-
-# build packages
-yarn build
 
 # test packages
 yarn test

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "deploy-storybook": "storybook-to-ghpages --packages packages -o docs --monorepo-index-generator packages/showcases/core/scripts/index-generator.js",
     "postinstall": "is-ci || husky install",
     "pack": "lerna run pack",
-    "prepare": "yarn prettier:fix && yarn stylelint:fix && yarn build && yarn test",
     "prettier": "prettier .",
     "prettier:fix": "prettier . --write",
     "release": "lerna publish --no-verify-access --no-private --no-commit-hooks --yes",


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

The goal of this PR is to delete the `"prepare"` NPM script because we don't need it. Thanks a lot @thollander for the idea.
References:
- https://github.com/Decathlon/vitamin-web/pull/516#issuecomment-907016234
- https://github.com/Decathlon/vitamin-web/pull/516#issuecomment-917117505
- https://github.com/Decathlon/vitamin-web/pull/516#issuecomment-917117505

## Does this introduce a breaking change?

- No
