### PR TITLE
docs: fix extended toolbar z-index and align z-index overlays

### DIFF
--- a/packages/showcases/css/.storybook/preview-head.html
+++ b/packages/showcases/css/.storybook/preview-head.html
@@ -15,7 +15,7 @@
     border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
     position: fixed;
     width: 100%;
-    z-index: 1;
+    z-index: 100;
     top: 0;
   }
   .extented-toolbar__title {

--- a/packages/showcases/css/.storybook/preview-head.html
+++ b/packages/showcases/css/.storybook/preview-head.html
@@ -15,7 +15,7 @@
     border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
     position: fixed;
     width: 100%;
-    z-index: 100;
+    z-index: 50;
     top: 0;
   }
   .extented-toolbar__title {

--- a/packages/showcases/react/.storybook/preview-head.html
+++ b/packages/showcases/react/.storybook/preview-head.html
@@ -15,7 +15,7 @@
     border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
     position: fixed;
     width: 100%;
-    z-index: 1;
+    z-index: 100;
     top: 0;
   }
   .extented-toolbar__title {

--- a/packages/showcases/react/.storybook/preview-head.html
+++ b/packages/showcases/react/.storybook/preview-head.html
@@ -15,7 +15,7 @@
     border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
     position: fixed;
     width: 100%;
-    z-index: 100;
+    z-index: 50;
     top: 0;
   }
   .extented-toolbar__title {

--- a/packages/showcases/web-components/.storybook/preview-head.html
+++ b/packages/showcases/web-components/.storybook/preview-head.html
@@ -15,7 +15,7 @@
     border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
     position: fixed;
     width: 100%;
-    z-index: 1;
+    z-index: 100;
     top: 0;
   }
   .extented-toolbar__title {

--- a/packages/showcases/web-components/.storybook/preview-head.html
+++ b/packages/showcases/web-components/.storybook/preview-head.html
@@ -15,7 +15,7 @@
     border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
     position: fixed;
     width: 100%;
-    z-index: 100;
+    z-index: 50;
     top: 0;
   }
   .extented-toolbar__title {

--- a/packages/sources/css/src/components/alert/src/index.css
+++ b/packages/sources/css/src/components/alert/src/index.css
@@ -5,6 +5,7 @@
 @import '@vtmn/css-design-tokens/src/opacities';
 @import '@vtmn/css-design-tokens/src/shadows';
 @import '@vtmn/css-design-tokens/src/animations';
+@import '@vtmn/css-design-tokens/src/z-indexes';
 
 .vtmn-alert {
   display: flex;
@@ -22,7 +23,7 @@
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   box-shadow: var(--vtmn-shadow_200);
   border-radius: rem(4px);
-  z-index: 1005;
+  z-index: var(--vtmn-z-index_alert);
 }
 
 .vtmn-alert_content {

--- a/packages/sources/css/src/components/alert/src/index.css
+++ b/packages/sources/css/src/components/alert/src/index.css
@@ -22,7 +22,7 @@
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   box-shadow: var(--vtmn-shadow_200);
   border-radius: rem(4px);
-  z-index: 100;
+  z-index: 1005;
 }
 
 .vtmn-alert_content {

--- a/packages/sources/css/src/components/modal/src/index.css
+++ b/packages/sources/css/src/components/modal/src/index.css
@@ -19,11 +19,10 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 5;
+  z-index: 1006;
 }
 
 .vtmn-modal_content {
-  z-index: 6;
   background-color: var(--vtmn-semantic-color_background-primary);
   border-radius: rem(8px);
   padding: rem(32px);

--- a/packages/sources/css/src/components/modal/src/index.css
+++ b/packages/sources/css/src/components/modal/src/index.css
@@ -5,6 +5,7 @@
 @import '@vtmn/css-design-tokens/src/opacities';
 @import '@vtmn/css-design-tokens/src/shadows';
 @import '@vtmn/css-design-tokens/src/animations';
+@import '@vtmn/css-design-tokens/src/z-indexes';
 
 .vtmn-modal {
   background: hsla(
@@ -19,7 +20,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1006;
+  z-index: var(--vtmn-z-index_modal);
 }
 
 .vtmn-modal_content {

--- a/packages/sources/css/src/components/popover/src/index.css
+++ b/packages/sources/css/src/components/popover/src/index.css
@@ -35,7 +35,7 @@
 
 /* ALL POPOVER */
 .vtmn-popover > [role='tooltip'] {
-  z-index: 1000;
+  z-index: 1002;
   min-width: rem(250px);
   width: auto;
   box-shadow: var(--vtmn-shadow_200);
@@ -49,7 +49,6 @@
 }
 
 .vtmn-popover > [role='tooltip']::after {
-  z-index: 1000;
   border-radius: 0;
   content: ' ';
   height: 0;

--- a/packages/sources/css/src/components/popover/src/index.css
+++ b/packages/sources/css/src/components/popover/src/index.css
@@ -3,6 +3,7 @@
 @import '@vtmn/css-design-tokens/src/shadows';
 @import '@vtmn/css-design-tokens/src/base-colors';
 @import '@vtmn/css-design-tokens/src/themes/default';
+@import '@vtmn/css-design-tokens/src/z-indexes';
 
 .vtmn-popover {
   position: relative;
@@ -35,7 +36,6 @@
 
 /* ALL POPOVER */
 .vtmn-popover > [role='tooltip'] {
-  z-index: 1002;
   min-width: rem(250px);
   width: auto;
   box-shadow: var(--vtmn-shadow_200);
@@ -46,6 +46,7 @@
   position: absolute;
   padding: rem(16px);
   animation: var(--vtmn-animation_fade-in);
+  z-index: var(--vtmn-z-index_popover);
 }
 
 .vtmn-popover > [role='tooltip']::after {

--- a/packages/sources/css/src/components/snackbar/src/index.css
+++ b/packages/sources/css/src/components/snackbar/src/index.css
@@ -21,6 +21,7 @@
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   box-shadow: var(--vtmn-shadow_200);
   border-radius: rem(4px);
+  z-index: 1003;
 }
 
 .vtmn-snackbar.show {

--- a/packages/sources/css/src/components/snackbar/src/index.css
+++ b/packages/sources/css/src/components/snackbar/src/index.css
@@ -5,6 +5,7 @@
 @import '@vtmn/css-design-tokens/src/opacities';
 @import '@vtmn/css-design-tokens/src/shadows';
 @import '@vtmn/css-design-tokens/src/animations';
+@import '@vtmn/css-design-tokens/src/z-indexes';
 
 .vtmn-snackbar {
   display: flex;
@@ -21,7 +22,7 @@
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   box-shadow: var(--vtmn-shadow_200);
   border-radius: rem(4px);
-  z-index: 1003;
+  z-index: var(--vtmn-z-index_snackbar);
 }
 
 .vtmn-snackbar.show {

--- a/packages/sources/css/src/components/toast/src/index.css
+++ b/packages/sources/css/src/components/toast/src/index.css
@@ -21,6 +21,7 @@
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   box-shadow: var(--vtmn-shadow_200);
   border-radius: rem(4px);
+  z-index: 1004;
 }
 
 .vtmn-toast.show {

--- a/packages/sources/css/src/components/toast/src/index.css
+++ b/packages/sources/css/src/components/toast/src/index.css
@@ -5,6 +5,7 @@
 @import '@vtmn/css-design-tokens/src/opacities';
 @import '@vtmn/css-design-tokens/src/shadows';
 @import '@vtmn/css-design-tokens/src/animations';
+@import '@vtmn/css-design-tokens/src/z-indexes';
 
 .vtmn-toast {
   display: flex;
@@ -21,7 +22,7 @@
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   box-shadow: var(--vtmn-shadow_200);
   border-radius: rem(4px);
-  z-index: 1004;
+  z-index: var(--vtmn-z-index_toast);
 }
 
 .vtmn-toast.show {

--- a/packages/sources/css/src/components/tooltip/src/index.css
+++ b/packages/sources/css/src/components/tooltip/src/index.css
@@ -7,6 +7,7 @@
 
 .vtmn-tooltip {
   position: relative;
+  z-index: 1001;
 }
 
 /* Applies to all tooltips */
@@ -25,7 +26,6 @@
 .vtmn-tooltip::before {
   content: '';
   border: rem(8px) solid transparent;
-  z-index: 1000;
 }
 
 .vtmn-tooltip::after {
@@ -39,7 +39,6 @@
   border-radius: rem(4px);
   background-color: var(--vtmn-semantic-color_background-primary-reversed);
   color: var(--vtmn-semantic-color_content-primary-reversed);
-  z-index: 1000;
 }
 
 .vtmn-tooltip:focus-visible {

--- a/packages/sources/css/src/components/tooltip/src/index.css
+++ b/packages/sources/css/src/components/tooltip/src/index.css
@@ -4,15 +4,16 @@
 @import '@vtmn/css-design-tokens/src/animations';
 @import '@vtmn/css-design-tokens/src/base-colors';
 @import '@vtmn/css-design-tokens/src/themes/default';
+@import '@vtmn/css-design-tokens/src/z-indexes';
 
 .vtmn-tooltip {
   position: relative;
-  z-index: 1001;
 }
 
 /* Applies to all tooltips */
 .vtmn-tooltip::before,
 .vtmn-tooltip::after {
+  z-index: var(--vtmn-z-index_tooltip);
   font-family: var(--vtmn-typo_font-family);
   font-size: var(--vtmn-typo_text-3-font-size);
   font-weight: var(--vtmn-typo_font-weight--regular);

--- a/packages/sources/css/src/design-tokens/src/index.css
+++ b/packages/sources/css/src/design-tokens/src/index.css
@@ -1,11 +1,12 @@
 @import './animations';
+@import './base-colors';
 @import './breakpoints';
 @import './legacy-colors';
 @import './opacities';
-@import './shadows.css';
+@import './shadows';
 @import './spacings';
-@import './typography';
-@import './base-colors';
 @import './themes/default';
 @import './themes/core-light';
 @import './themes/core-dark';
+@import './typography';
+@import './z-indexes';

--- a/packages/sources/css/src/design-tokens/src/z-indexes.css
+++ b/packages/sources/css/src/design-tokens/src/z-indexes.css
@@ -1,0 +1,8 @@
+:root {
+  --vtmn-z-index_tooltip: 100;
+  --vtmn-z-index_popover: 200;
+  --vtmn-z-index_snackbar: 300;
+  --vtmn-z-index_toast: 400;
+  --vtmn-z-index_alert: 500;
+  --vtmn-z-index_modal: 600;
+}


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

Close #634 by putting our extented toolbars for CSS, Web Components and React showcases to 100.
I've also take the opportunity to align our z-index by respecting the decision matrix from our documentation (from 1001 to 1006):

![Capture d’écran 2021-09-29 à 01 29 55](https://user-images.githubusercontent.com/9600228/135179540-98cab6cf-2c7f-4d7e-b159-04414f867f99.png)

[Details here](https://www.decathlon.design/726f8c765/p/88386e-overlays).

## Does this introduce a breaking change?

- No

❤️ Thank you!
