### PR TITLE
fix(@vtmn/svelte): add on:click on VtmnButton to handle click events

### DIFF
--- a/packages/sources/svelte/src/components/VtmnButton.svelte
+++ b/packages/sources/svelte/src/components/VtmnButton.svelte
@@ -55,7 +55,7 @@
   );
 </script>
 
-<button type="button" class={componentClass} {...$$restProps}>
+<button on:click type="button" class={componentClass} {...$$restProps}>
   {#if !iconAlone && iconLeft}
     <span class={`vtmx-${iconLeft}`} />
   {/if}


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

I tried to use the Svelte `<VtmnButton>` in my project as following :
```
<VtmnButton on:click={handler}>My button</VtmnButton>
```
But it doesn't work as expected. When I click on the button, the handler function is never called. 🤔 

➡️  By looking at the source code of the component I found that the `on:click` attribute was not set on the `button` tag. If not set, the component cannot emit the click event.

![image](https://user-images.githubusercontent.com/6984856/135490817-3b75d95e-407a-45c5-83a0-6dc2ac4f2caa.png)

This PR fixes this issue.

## Does this introduce a breaking change?

- No


❤️ Thank you!
