### PR TITLE
fix(@vtmn/react): TS compilation error 

### DIFF
--- a/packages/sources/react/src/components/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/VtmnTextInput/VtmnTextInput.tsx
@@ -79,7 +79,6 @@ export const VtmnTextInput = ({
   icon = undefined,
   identifier,
   labelText,
-
   placeholder,
   valid = false,
   ...props

--- a/packages/sources/react/src/components/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/VtmnTextInput/VtmnTextInput.tsx
@@ -5,8 +5,7 @@ import '@vtmn/css-text-input/dist/index-with-vars.css';
 import { VtmnIcon } from '../VtmnIcon';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 
-export interface VtmnTextInputProps
-  extends React.ComponentPropsWithoutRef<'input'> {
+type VtmnTextInputAdditionalProps = {
   /**
    * ID of the input
    * @type {string}
@@ -59,7 +58,18 @@ export interface VtmnTextInputProps
    * @defaultValue false
    */
   error?: boolean;
-}
+};
+
+type VtmnTextInputMultiline = VtmnTextInputAdditionalProps & {
+  multiline: true;
+} & React.ComponentPropsWithoutRef<'textarea'>;
+type VtmnTextInputSingleLine = VtmnTextInputAdditionalProps & {
+  multiline?: false;
+} & React.ComponentPropsWithoutRef<'input'>;
+
+export type VtmnTextInputProps =
+  | VtmnTextInputMultiline
+  | VtmnTextInputSingleLine;
 
 export const VtmnTextInput = ({
   className,
@@ -69,56 +79,58 @@ export const VtmnTextInput = ({
   icon = undefined,
   identifier,
   labelText,
-  multiline = false,
+
   placeholder,
   valid = false,
   ...props
 }: VtmnTextInputProps) => {
-  return [
-    labelText && (
-      <label className="vtmn-text-input_label" htmlFor={identifier}>
-        {labelText}
-      </label>
-    ),
-    multiline ? (
-      <textarea
-        className={clsx('vtmn-text-input', className, {
-          'vtmn-text-input--error': error,
-          'vtmn-text-input--valid': valid,
-        })}
-        id={identifier}
-        placeholder={placeholder}
-        disabled={disabled}
-        {...props}
-      />
-    ) : (
-      <div className="vtmn-text-input_container">
-        <input
-          className={clsx(
-            'vtmn-text-input',
-            className,
-            { 'vtmn-text-input--valid': valid && !disabled },
-            { 'vtmn-text-input--error': error && !disabled },
-          )}
+  return (
+    <>
+      {labelText && (
+        <label className="vtmn-text-input_label" htmlFor={identifier}>
+          {labelText}
+        </label>
+      )}
+      {props.multiline ? (
+        <textarea
+          className={clsx('vtmn-text-input', className, {
+            'vtmn-text-input--error': error,
+            'vtmn-text-input--valid': valid,
+          })}
           id={identifier}
-          type="text"
           placeholder={placeholder}
           disabled={disabled}
           {...props}
         />
-        {icon && <VtmnIcon value={icon} size={20} />}
-      </div>
-    ),
-    helperText && (
-      <p
-        className={clsx('vtmn-text-input_helper-text', className, {
-          'vtmn-text-input_helper-text--error': error,
-        })}
-      >
-        {helperText}
-      </p>
-    ),
-  ];
+      ) : (
+        <div className="vtmn-text-input_container">
+          <input
+            className={clsx(
+              'vtmn-text-input',
+              className,
+              { 'vtmn-text-input--valid': valid && !disabled },
+              { 'vtmn-text-input--error': error && !disabled },
+            )}
+            id={identifier}
+            type="text"
+            placeholder={placeholder}
+            disabled={disabled}
+            {...props}
+          />
+          {icon && <VtmnIcon value={icon} size={20} />}
+        </div>
+      )}
+      {helperText && (
+        <p
+          className={clsx('vtmn-text-input_helper-text', className, {
+            'vtmn-text-input_helper-text--error': error,
+          })}
+        >
+          {helperText}
+        </p>
+      )}
+    </>
+  );
 };
 
 export default React.memo(VtmnTextInput);

--- a/packages/sources/react/src/components/VtmnToggle/VtmnToggle.tsx
+++ b/packages/sources/react/src/components/VtmnToggle/VtmnToggle.tsx
@@ -5,7 +5,7 @@ import '@vtmn/css-toggle/dist/index-with-vars.css';
 import { VtmnToggleSize } from './types';
 
 export interface VtmnToggleProps
-  extends React.ComponentPropsWithoutRef<'input'> {
+  extends Omit<React.ComponentPropsWithoutRef<'input'>, 'size'> {
   /**
    * ID of the toggle.
    * @type {string}


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X]  Check your code additions will fail neither code linting checks nor unit test.
- [X] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

Fix compilation error for React components ; 

* React.memo doesn't support components returning an array,
  hence rollbacking to fragment syntax.
* `input`s and `textarea`s don't have the same valid HTML attributes.
   As the component uses `multiline` to know when to render one or the other,
   I explicited in the type that if `multiline` is true,
   then the expected attributes are of textarea,
   and that if `multiline` is false, the expected attributes are of input.
* VtmnToggle overrides `size` with its own semantic, 
   it implies that VtmnToggleProps doesn't fully extends HTMLInputProps

Closes #650 

## Does this introduce a breaking change?

- Yes

User of VtmnTextInput  using `multiline=true` and explicitly writing a callback expecting a HTMLInputElement may have to change the type to HTMLTextareaElement.  While this is a "breaking change" for the user - as they have to change their code - it's really a fix, because they were really receiving a HTMLTextareaElement, it was jsut badly typed. 

## Other information

Just a piece of opinion: I suggest to transform TS warns to TS errors (preventing the merge). Of the 3 problems above, at least 2 were real problems that could lead to users bugs.  (I'm not 100% sure about `React.memo`, if the problem really lies with `memo` Or with the type declaration from facebook)

❤️ Thank you!
