### PR TITLE
fix(@vtmn/svelte): allow to use two-way binding on VtmnTextInput

### DIFF
--- a/packages/sources/svelte/src/components/VtmnTextInput.svelte
+++ b/packages/sources/svelte/src/components/VtmnTextInput.svelte
@@ -56,6 +56,12 @@
    * @type {string}
    */
   export let icon;
+
+  /**
+   * The value of the input
+   * @type {string}
+   */
+  export let value;
 </script>
 
 {#if labelText}
@@ -63,6 +69,7 @@
 {/if}
 {#if multiline}
   <textarea
+    bind:value
     class="vtmn-text-input"
     class:vtmn-text-input--error={error}
     class:vtmn-text-input--valid={valid}
@@ -74,6 +81,7 @@
 {:else}
   <div class="vtmn-text-input_container">
     <input
+      bind:value
       class="vtmn-text-input"
       class:vtmn-text-input--valid={valid}
       class:vtmn-text-input--error={error}


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

I tried two-way binding on `<VtmnTextInput />`, with a simple example like this :
```
<VtmnTextInput bind:value={name} />
<h1>Hello {name}!</h1>

```
... but this code doesn't work as expected. When typing a new text in the input, the displayed text in the `h1` is not modified.

This PR fixes this issue by making the `<VtmnTextInput>`'s two-way binding work in one-line (`input type="text"`) and multi-lines mode (`textarea`).

## Does this introduce a breaking change?

- No

❤️ Thank you!
