### PR TITLE
feat(@vtmn/web-components): refacto link, change css style order

### DIFF
--- a/packages/showcases/core/csf/components/VtmnLink.csf.js
+++ b/packages/showcases/core/csf/components/VtmnLink.csf.js
@@ -2,6 +2,12 @@ export const argTypes = {
   href: {
     type: { name: 'string', required: true },
     description: 'The href of the link.',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: '#' },
+    },
     defaultValue: '#',
     control: { type: 'text' },
   },
@@ -9,28 +15,53 @@ export const argTypes = {
     type: { name: 'string', required: false },
     description: 'The target of the link.',
     defaultValue: '_self',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: '_self' },
+    },
     control: {
-      type: 'text',
+      type: 'radio',
+      options: ['_self', '_blank', '_parent', '_top'],
     },
   },
   size: {
     type: { name: 'string', required: false },
     description: 'The size of the link.',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: 'medium' },
+    },
     defaultValue: 'medium',
     control: {
-      type: 'select',
+      type: 'radio',
       options: ['small', 'medium', 'large'],
     },
   },
   standalone: {
     type: { name: 'boolean', required: false },
-    description: 'If the component is a standalone or not.',
+    description: 'Whether the component is standalone.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: { summary: 'false' },
+    },
     defaultValue: false,
     control: { type: 'boolean' },
   },
-  iconAlong: {
+  withIcon: {
     type: { name: 'boolean', required: false },
-    description: 'If the component has an icon or not.',
+    description: 'Whether the component has an icon.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: { summary: 'false' },
+    },
     defaultValue: false,
     control: { type: 'boolean' },
   },

--- a/packages/sources/css/src/components/link/src/index.css
+++ b/packages/sources/css/src/components/link/src/index.css
@@ -14,6 +14,12 @@
   text-decoration: none;
 }
 
+.vtmn-link:visited,
+.vtmn-link--standalone:visited {
+  color: var(--vtmn-semantic-color_content-visited);
+  text-decoration: none;
+}
+
 .vtmn-link:hover,
 .vtmn-link--standalone:hover {
   color: var(--vtmn-semantic-color_hover-brand);
@@ -24,12 +30,6 @@
 .vtmn-link--standalone:active {
   color: var(--vtmn-semantic-color_active-brand);
   text-decoration: underline;
-}
-
-.vtmn-link:visited,
-.vtmn-link--standalone:visited {
-  color: var(--vtmn-semantic-color_content-visited);
-  text-decoration: none;
 }
 
 .vtmn-link:focus-visible {
@@ -51,16 +51,16 @@
   background-color: var(--vtmn-semantic-color_content-action);
 }
 
+.vtmn-link--icon-along:visited::after {
+  background-color: var(--vtmn-semantic-color_content-visited);
+}
+
 .vtmn-link--icon-along:hover::after {
   background-color: var(--vtmn-semantic-color_hover-brand);
 }
 
 .vtmn-link--icon-along:active::after {
   background-color: var(--vtmn-semantic-color_active-brand);
-}
-
-.vtmn-link--icon-along:visited::after {
-  background-color: var(--vtmn-semantic-color_content-visited);
 }
 
 .vtmn-link_size--small {

--- a/packages/sources/web-components/src/components.d.ts
+++ b/packages/sources/web-components/src/components.d.ts
@@ -88,29 +88,34 @@ export namespace Components {
     interface VtmnLink {
         /**
           * The hypertext link
+          * @type {string}
           * @defaultValue '#'
          */
         "href": string;
         /**
-          * Is the link has an icon or not
-          * @defaultValue undefined
+          * The size of the link
+          * @type {string}
+          * @defaultValue 'medium'
          */
-        "iconAlong": boolean;
+        "size"?: 'small' | 'medium' | 'large';
         /**
-          * The size of the link.
-          * @defaultValue undefined
+          * Whether the link is standalone
+          * @type {boolean}
+          * @defaultValue false
          */
-        "size": 'small' | 'medium' | 'large';
-        /**
-          * Is the link standalone or not
-          * @defaultValue undefined
-         */
-        "standalone": boolean;
+        "standalone"?: boolean;
         /**
           * The target of the link
-          * @defaultValue null
+          * @type {string}
+          * @defaultValue '_self'
          */
-        "target": string;
+        "target"?: string;
+        /**
+          * Whether the link has an icon
+          * @type {boolean}
+          * @defaultValue false
+         */
+        "withIcon": boolean;
     }
     interface VtmnLoader {
         /**
@@ -353,29 +358,34 @@ declare namespace LocalJSX {
     interface VtmnLink {
         /**
           * The hypertext link
+          * @type {string}
           * @defaultValue '#'
          */
         "href"?: string;
         /**
-          * Is the link has an icon or not
-          * @defaultValue undefined
-         */
-        "iconAlong"?: boolean;
-        /**
-          * The size of the link.
-          * @defaultValue undefined
+          * The size of the link
+          * @type {string}
+          * @defaultValue 'medium'
          */
         "size"?: 'small' | 'medium' | 'large';
         /**
-          * Is the link standalone or not
-          * @defaultValue undefined
+          * Whether the link is standalone
+          * @type {boolean}
+          * @defaultValue false
          */
         "standalone"?: boolean;
         /**
           * The target of the link
-          * @defaultValue null
+          * @type {string}
+          * @defaultValue '_self'
          */
         "target"?: string;
+        /**
+          * Whether the link has an icon
+          * @type {boolean}
+          * @defaultValue false
+         */
+        "withIcon"?: boolean;
     }
     interface VtmnLoader {
         /**

--- a/packages/sources/web-components/src/components/vtmn-link/README.md
+++ b/packages/sources/web-components/src/components/vtmn-link/README.md
@@ -5,13 +5,13 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                    | Type                             | Default     |
-| ------------ | ------------ | ------------------------------ | -------------------------------- | ----------- |
-| `href`       | `href`       | The hypertext link             | `string`                         | `'#'`       |
-| `iconAlong`  | `iconalong`  | Is the link has an icon or not | `boolean`                        | `undefined` |
-| `size`       | `size`       | The size of the link.          | `"large" \| "medium" \| "small"` | `undefined` |
-| `standalone` | `standalone` | Is the link standalone or not  | `boolean`                        | `undefined` |
-| `target`     | `target`     | The target of the link         | `string`                         | `undefined` |
+| Property     | Attribute    | Description                    | Type                             | Default    |
+| ------------ | ------------ | ------------------------------ | -------------------------------- | ---------- |
+| `href`       | `href`       | The hypertext link             | `string`                         | `'#'`      |
+| `size`       | `size`       | The size of the link           | `"large" \| "medium" \| "small"` | `'medium'` |
+| `standalone` | `standalone` | Whether the link is standalone | `boolean`                        | `false`    |
+| `target`     | `target`     | The target of the link         | `string`                         | `'_self'`  |
+| `withIcon`   | `withicon`   | Whether the link has an icon   | `boolean`                        | `false`    |
 
 
 ----------------------------------------------

--- a/packages/sources/web-components/src/components/vtmn-link/vtmn-link.tsx
+++ b/packages/sources/web-components/src/components/vtmn-link/vtmn-link.tsx
@@ -6,34 +6,39 @@ import { Component, Prop, h, ComponentInterface } from '@stencil/core';
 })
 export class VtmnLink implements ComponentInterface {
   /**
-   * The size of the link.
-   * @defaultValue undefined
-   */
-  @Prop() size: 'small' | 'medium' | 'large';
-
-  /**
-   * Is the link standalone or not
-   * @defaultValue undefined
-   */
-  @Prop() standalone: boolean;
-
-  /**
-   * Is the link has an icon or not
-   * @defaultValue undefined
-   */
-  @Prop({ attribute: 'iconalong' }) iconAlong: boolean;
-
-  /**
    * The hypertext link
+   * @type {string}
    * @defaultValue '#'
    */
   @Prop() href: string = '#';
 
   /**
    * The target of the link
-   * @defaultValue null
+   * @type {string}
+   * @defaultValue '_self'
    */
-  @Prop() target: string;
+  @Prop() target?: string = '_self';
+
+  /**
+   * The size of the link
+   * @type {string}
+   * @defaultValue 'medium'
+   */
+  @Prop() size?: 'small' | 'medium' | 'large' = 'medium';
+
+  /**
+   * Whether the link is standalone
+   * @type {boolean}
+   * @defaultValue false
+   */
+  @Prop() standalone?: boolean = false;
+
+  /**
+   * Whether the link has an icon
+   * @type {boolean}
+   * @defaultValue false
+   */
+  @Prop({ attribute: 'withicon' }) withIcon: boolean = false;
 
   render() {
     return (
@@ -44,7 +49,7 @@ export class VtmnLink implements ComponentInterface {
           'vtmn-link',
           `vtmn-link_size--${this.size}`,
           this.standalone && 'vtmn-link--standalone',
-          this.standalone && this.iconAlong && 'vtmn-link--icon-along',
+          this.standalone && this.withIcon && 'vtmn-link--icon-along',
         ]
           .filter(Boolean)
           .join(' ')}


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.


## Description

- Improve csf file with table definition and default
- Change CSS link style order in order to keep hovering effect over the visited

## Does this introduce a breaking change?

- Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Attribute ```iconAlong``` has been renamed into ```withIcon```

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

❤️ Thank you!
