### PR TITLE
refactor(@vtmn/web-components): text-input component

### DIFF
--- a/packages/showcases/core/csf/components/VtmnTextInput.csf.js
+++ b/packages/showcases/core/csf/components/VtmnTextInput.csf.js
@@ -4,57 +4,91 @@ export const argTypes = {
   identifier: {
     type: { name: 'string', required: true },
     description: 'The id of the input.',
-    defaultValue: 'vtmn-input',
-    control: { type: 'text' },
-  },
-  labelText: {
-    type: { name: 'string', required: false },
-    description: 'The label of the input.',
-    defaultValue: 'Label',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: 'undefined' },
+    },
+    defaultValue: 'undefined',
     control: { type: 'text' },
   },
   placeholder: {
     type: { name: 'string', required: false },
     description: 'The placeholder of the input.',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: 'Placeholder Text' },
+    },
     defaultValue: 'Placeholder Text',
     control: { type: 'text' },
   },
   helperText: {
     type: { name: 'string', required: false },
     description: 'The helper text message of the input.',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: 'Helper text goes here' },
+    },
     defaultValue: 'Helper text goes here',
     control: { type: 'text' },
+  },
+  state: {
+    type: { name: 'string', required: false },
+    description: 'The state of the input.',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: { summary: 'default' },
+    },
+    defaultValue: 'default',
+    control: {
+      type: 'radio',
+      options: ['default', 'valid', 'error'],
+    },
   },
   icon: {
     type: { name: 'string', required: false },
     description: 'The icon of text input.',
-    defaultValue: 'home-fill',
+    table: {
+      type: {
+        summary: 'string',
+        detail: 'VitamixId',
+      },
+      defaultValue: { summary: 'undefined' },
+    },
+    defaultValue: 'undefined',
     control: {
       type: 'select',
       options: ['', ...Object.keys(vitamixIconsList)],
     },
   },
-  multiline: {
+  textarea: {
     type: { name: 'boolean', required: false },
-    description: 'If the component is a textarea or an input.',
+    description: 'Whether the component is a textarea or an input.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: { summary: 'false' },
+    },
     defaultValue: false,
     control: { type: 'boolean' },
   },
   disabled: {
     type: { name: 'boolean', required: false },
     description: 'The disabled state of the input.',
-    defaultValue: false,
-    control: { type: 'boolean' },
-  },
-  valid: {
-    type: { name: 'boolean', required: false },
-    description: 'The valid state of the input.',
-    defaultValue: false,
-    control: { type: 'boolean' },
-  },
-  error: {
-    type: { name: 'boolean', required: false },
-    description: 'The error state of the input.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: { summary: 'false' },
+    },
     defaultValue: false,
     control: { type: 'boolean' },
   },

--- a/packages/showcases/web-components/stories/components/vtmn-text-input/vtmn-text-input.stories.tsx
+++ b/packages/showcases/web-components/stories/components/vtmn-text-input/vtmn-text-input.stories.tsx
@@ -13,7 +13,7 @@ export default {
 };
 
 const Template = (args) =>
-  html`<vtmn-text-input ...=${spread(args)}></vtmn-text-input>`;
+  html`<vtmn-text-input ...=${spread(args)}>Label</vtmn-text-input>`;
 
 export const Overview = Template.bind({});
 Overview.args = {};

--- a/packages/sources/web-components/src/components.d.ts
+++ b/packages/sources/web-components/src/components.d.ts
@@ -151,40 +151,46 @@ export namespace Components {
     interface VtmnTextInput {
         /**
           * The disabled state of the text-input.
+          * @type {boolean}
+          * @defaultValue false
          */
-        "disabled": boolean;
-        /**
-          * The error variant state of the text-input.
-         */
-        "error": boolean;
+        "disabled"?: boolean;
         /**
           * The helper text of the text input.
+          * @type {string}
+          * @defaultValue 'Helper text goes here'
          */
-        "helperText": string;
+        "helperText"?: string;
         /**
           * The icon to be displayed
+          * @type {VitamixId}
+          * @defaultValue undefined
          */
-        "icon": string;
+        "icon"?: string;
         /**
           * The id of the text input.
+          * @type {string}
+          * @defaultValue undefined
          */
         "identifier": string;
         /**
-          * The label text of the text input.
-         */
-        "labelText": string;
-        /**
-          * Is the text-input multiline or not.
-         */
-        "multiline": boolean;
-        /**
           * The placeholder of the text input.
+          * @type {string}
+          * @defaultValue 'My placeholder'
          */
-        "placeholder": string;
+        "placeholder"?: string;
         /**
           * The valid variant state of the text-input.
+          * @type {string}
+          * @defaultValue 'default'
          */
-        "valid": boolean;
+        "state"?: 'default' | 'valid' | 'error';
+        /**
+          * Is the text-input multiline or not.
+          * @type {boolean}
+          * @defaultValue false
+         */
+        "textarea"?: boolean;
     }
     interface VtmnToggle {
         /**
@@ -416,40 +422,46 @@ declare namespace LocalJSX {
     interface VtmnTextInput {
         /**
           * The disabled state of the text-input.
+          * @type {boolean}
+          * @defaultValue false
          */
         "disabled"?: boolean;
         /**
-          * The error variant state of the text-input.
-         */
-        "error"?: boolean;
-        /**
           * The helper text of the text input.
+          * @type {string}
+          * @defaultValue 'Helper text goes here'
          */
-        "helperText": string;
+        "helperText"?: string;
         /**
           * The icon to be displayed
+          * @type {VitamixId}
+          * @defaultValue undefined
          */
         "icon"?: string;
         /**
           * The id of the text input.
+          * @type {string}
+          * @defaultValue undefined
          */
         "identifier": string;
         /**
-          * The label text of the text input.
-         */
-        "labelText": string;
-        /**
-          * Is the text-input multiline or not.
-         */
-        "multiline"?: boolean;
-        /**
           * The placeholder of the text input.
+          * @type {string}
+          * @defaultValue 'My placeholder'
          */
-        "placeholder": string;
+        "placeholder"?: string;
         /**
           * The valid variant state of the text-input.
+          * @type {string}
+          * @defaultValue 'default'
          */
-        "valid"?: boolean;
+        "state"?: 'default' | 'valid' | 'error';
+        /**
+          * Is the text-input multiline or not.
+          * @type {boolean}
+          * @defaultValue false
+         */
+        "textarea"?: boolean;
     }
     interface VtmnToggle {
         /**

--- a/packages/sources/web-components/src/components/vtmn-text-input/README.md
+++ b/packages/sources/web-components/src/components/vtmn-text-input/README.md
@@ -5,17 +5,15 @@
 
 ## Properties
 
-| Property                   | Attribute     | Description                                | Type      | Default     |
-| -------------------------- | ------------- | ------------------------------------------ | --------- | ----------- |
-| `disabled`                 | `disabled`    | The disabled state of the text-input.      | `boolean` | `undefined` |
-| `error`                    | `error`       | The error variant state of the text-input. | `boolean` | `undefined` |
-| `helperText` _(required)_  | `helpertext`  | The helper text of the text input.         | `string`  | `undefined` |
-| `icon`                     | `icon`        | The icon to be displayed                   | `string`  | `undefined` |
-| `identifier` _(required)_  | `identifier`  | The id of the text input.                  | `string`  | `undefined` |
-| `labelText` _(required)_   | `labeltext`   | The label text of the text input.          | `string`  | `undefined` |
-| `multiline`                | `multiline`   | Is the text-input multiline or not.        | `boolean` | `undefined` |
-| `placeholder` _(required)_ | `placeholder` | The placeholder of the text input.         | `string`  | `undefined` |
-| `valid`                    | `valid`       | The valid variant state of the text-input. | `boolean` | `undefined` |
+| Property                  | Attribute     | Description                                | Type                              | Default                   |
+| ------------------------- | ------------- | ------------------------------------------ | --------------------------------- | ------------------------- |
+| `disabled`                | `disabled`    | The disabled state of the text-input.      | `boolean`                         | `false`                   |
+| `helperText`              | `helpertext`  | The helper text of the text input.         | `string`                          | `'Helper text goes here'` |
+| `icon`                    | `icon`        | The icon to be displayed                   | `string`                          | `undefined`               |
+| `identifier` _(required)_ | `identifier`  | The id of the text input.                  | `string`                          | `undefined`               |
+| `placeholder`             | `placeholder` | The placeholder of the text input.         | `string`                          | `'My placeholder'`        |
+| `state`                   | `state`       | The valid variant state of the text-input. | `"default" \| "error" \| "valid"` | `'default'`               |
+| `textarea`                | `textarea`    | Is the text-input multiline or not.        | `boolean`                         | `false`                   |
 
 
 ----------------------------------------------

--- a/packages/sources/web-components/src/components/vtmn-text-input/vtmn-text-input.tsx
+++ b/packages/sources/web-components/src/components/vtmn-text-input/vtmn-text-input.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, ComponentInterface } from '@stencil/core';
+import { Component, Prop, h, ComponentInterface, Host } from '@stencil/core';
 
 @Component({
   tag: 'vtmn-text-input',
@@ -7,108 +7,116 @@ import { Component, Prop, h, ComponentInterface } from '@stencil/core';
 export class VtmnTextInput implements ComponentInterface {
   /**
    * The id of the text input.
+   * @type {string}
+   * @defaultValue undefined
    */
   @Prop() identifier!: string;
 
   /**
-   * The label text of the text input.
-   */
-  @Prop({ attribute: 'labeltext' }) labelText!: string;
-
-  /**
    * The placeholder of the text input.
+   * @type {string}
+   * @defaultValue 'My placeholder'
    */
-  @Prop() placeholder!: string;
+  @Prop() placeholder?: string = 'My placeholder';
 
   /**
    * The helper text of the text input.
+   * @type {string}
+   * @defaultValue 'Helper text goes here'
    */
-  @Prop({ attribute: 'helpertext' }) helperText!: string;
+  @Prop({ attribute: 'helpertext' }) helperText?: string =
+    'Helper text goes here';
 
   /**
    * Is the text-input multiline or not.
+   * @type {boolean}
+   * @defaultValue false
    */
-  @Prop() multiline: boolean;
+  @Prop() textarea?: boolean = false;
 
   /**
    * The valid variant state of the text-input.
+   * @type {string}
+   * @defaultValue 'default'
    */
-  @Prop() valid: boolean;
-
-  /**
-   * The error variant state of the text-input.
-   */
-  @Prop() error: boolean;
+  @Prop() state?: 'default' | 'valid' | 'error' = 'default';
 
   /**
    * The disabled state of the text-input.
+   * @type {boolean}
+   * @defaultValue false
    */
-  @Prop() disabled: boolean;
+  @Prop() disabled?: boolean = false;
 
   /**
    * The icon to be displayed
+   * @type {VitamixId}
+   * @defaultValue undefined
    */
-  @Prop() icon: string;
+  @Prop() icon?: string;
 
   render() {
-    return [
-      <label class="vtmn-text-input_label" htmlFor={this.identifier}>
-        {this.labelText}
-      </label>,
+    return (
+      <Host>
+        <label class="vtmn-text-input_label" htmlFor={this.identifier}>
+          <slot />
+        </label>
 
-      this.multiline
-        ? [
-            <textarea
-              class={[
-                'vtmn-text-input',
-                this.error && 'vtmn-text-input--error',
-                this.valid && 'vtmn-text-input--valid',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-              id={this.identifier}
-              placeholder={this.placeholder}
-              disabled={this.disabled}
-            ></textarea>,
-            <p
-              class={[
-                'vtmn-text-input_helper-text',
-                this.error && 'vtmn-text-input_helper-text--error',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-            >
-              {this.helperText}
-            </p>,
-          ]
-        : [
-            <div class="vtmn-text-input_container">
-              <input
-                type="text"
+        {this.textarea
+          ? [
+              <textarea
                 class={[
                   'vtmn-text-input',
-                  this.valid && 'vtmn-text-input--valid',
-                  this.error && 'vtmn-text-input--error',
+                  this.state !== 'default' && `vtmn-text-input--${this.state}`,
                 ]
                   .filter(Boolean)
                   .join(' ')}
                 id={this.identifier}
                 placeholder={this.placeholder}
                 disabled={this.disabled}
-              />
-              {this.icon ? <span class={`vtmx-${this.icon}`}></span> : null}
-            </div>,
-            <p
-              class={[
-                'vtmn-text-input_helper-text',
-                this.error && 'vtmn-text-input_helper-text--error',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-            >
-              {this.helperText}
-            </p>,
-          ],
-    ];
+              ></textarea>,
+              <p
+                class={[
+                  'vtmn-text-input_helper-text',
+                  this.state === 'error' &&
+                    'vtmn-text-input_helper-text--error',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                {this.helperText}
+              </p>,
+            ]
+          : [
+              <div class="vtmn-text-input_container">
+                <input
+                  type="text"
+                  class={[
+                    'vtmn-text-input',
+                    this.state !== 'default' &&
+                      `vtmn-text-input--${this.state}`,
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  id={this.identifier}
+                  placeholder={this.placeholder}
+                  disabled={this.disabled}
+                />
+                {this.icon ? <span class={`vtmx-${this.icon}`}></span> : null}
+              </div>,
+              <p
+                class={[
+                  'vtmn-text-input_helper-text',
+                  this.state === 'error' &&
+                    'vtmn-text-input_helper-text--error',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                {this.helperText}
+              </p>,
+            ]}
+      </Host>
+    );
   }
 }


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

## Description

- Valid and error are gathered into one attribute ```state```
- The label has become a slot child to simplify consistency and code
- isMultiline has been renamed into textarea, it's more understandable
- The custom component is now ```Host```ed as it should have  been since the beginning


## Does this introduce a breaking change?

- Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- The label is now a slot child of the component, you need to remove the label attribute and repalce it between the component tags.

❤️ Thank you!
