### PR TITLE
refactor(@vtmn/react): VtmnTooltipPosition props from enum to type

### DIFF
--- a/packages/showcases/react/stories/components/VtmnTooltip/VtmnTooltip.stories.tsx
+++ b/packages/showcases/react/stories/components/VtmnTooltip/VtmnTooltip.stories.tsx
@@ -5,7 +5,6 @@ import {
   argTypes,
   parameters,
 } from '@vtmn/showcase-core/csf/components/VtmnTooltip.csf';
-import { VtmnTooltipPosition } from '@vtmn/react/src/components/VtmnTooltip/types';
 
 export default {
   title: 'Components/VtmnTooltip',
@@ -20,5 +19,5 @@ export const TooltipText = Template.bind({});
 TooltipText.args = {
   tooltip: 'I am a tooltip example',
   children: 'Tooltip Example',
-  position: VtmnTooltipPosition.RIGHT,
+  position: 'right',
 };

--- a/packages/sources/react/src/components/VtmnTooltip/VtmnTooltip.tsx
+++ b/packages/sources/react/src/components/VtmnTooltip/VtmnTooltip.tsx
@@ -24,7 +24,7 @@ export interface VtmnTooltipProps
 
 export const VtmnTooltip = ({
   children,
-  position = VtmnTooltipPosition.TOP,
+  position = 'top',
   tooltip,
   className,
   ...props

--- a/packages/sources/react/src/components/VtmnTooltip/types.ts
+++ b/packages/sources/react/src/components/VtmnTooltip/types.ts
@@ -1,7 +1,7 @@
 export type VtmnTooltipPosition =
   | 'bottom-left'
   | 'bottom'
-  | 'bottom - right'
+  | 'bottom-right'
   | 'left'
   | 'right'
   | 'top-left'

--- a/packages/sources/react/src/components/VtmnTooltip/types.ts
+++ b/packages/sources/react/src/components/VtmnTooltip/types.ts
@@ -1,10 +1,9 @@
-export enum VtmnTooltipPosition {
-  BOTTOM_LEFT = 'bottom-left',
-  BOTTOM = 'bottom',
-  BOTTOM_RIGHT = 'bottom-right',
-  LEFT = 'left',
-  RIGHT = 'right',
-  TOP_LEFT = 'top-left',
-  TOP = 'top',
-  TOP_RIGHT = 'top-right',
-}
+export type VtmnTooltipPosition =
+  | 'bottom-left'
+  | 'bottom'
+  | 'bottom - right'
+  | 'left'
+  | 'right'
+  | 'top-left'
+  | 'top'
+  | 'top-right';


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

Refacto of the position tooltip props, from an enum to a type to comply with current vtmn react component behaviour, as it will be easier to modify components props from sending the position directly as a string value from an authorized range declare in the position exported Type 

As seen in my issue https://github.com/Decathlon/vitamin-web/issues/719 i don't think this is a breaking change but maybe I'm wrong ?

## Does this introduce a breaking change?

- No


## Other information

The position of tooltip is now modifiable easily by users because before as it was an enum, developers must create the enum in their local architecture, now it complies with the behaviour if current vtmn react components, the props which must receive certain string values are declared as a Type.

❤️ Thank you!
