### PR TITLE
fix(@vtmn/svelte): fix optional props values

### DIFF
--- a/packages/sources/svelte/src/components/VtmnButton.svelte
+++ b/packages/sources/svelte/src/components/VtmnButton.svelte
@@ -22,21 +22,21 @@
    * @type string
    * @defaultValue undefined
    */
-  export let iconLeft;
+  export let iconLeft = undefined;
 
   /**
    * Icon to display on the right hand side of button
    * @type string
    * @defaultValue undefined
    */
-  export let iconRight;
+  export let iconRight = undefined;
 
   /**
    * Icon to display when it is a button with icon only
    * @type string
    * @defaultValue undefined
    */
-  export let iconAlone;
+  export let iconAlone = undefined;
 
   let className;
   /**


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

In Svelte, optionnal props must have a nullish default value, otherwise the compiler displays warnings like the following :
`<VtmnButton> was created without expected prop 'iconAlone'`.
This PR add a default value (`undefined`) to optionnal props in `<VtmnButton>`.

## Does this introduce a breaking change?

- No

❤️ Thank you!
