### PR TITLE
feat(@vtmn/react): update icon variants

### DIFF
--- a/packages/showcases/core/csf/components/VtmnIcon.csf.js
+++ b/packages/showcases/core/csf/components/VtmnIcon.csf.js
@@ -50,6 +50,7 @@ export const argTypes = {
         'information',
         'warning',
         'danger',
+        'neutral',
       ],
     },
   },

--- a/packages/showcases/core/csf/components/VtmnIcon.csf.js
+++ b/packages/showcases/core/csf/components/VtmnIcon.csf.js
@@ -50,7 +50,6 @@ export const argTypes = {
         'information',
         'warning',
         'negative',
-        'neutral',
       ],
     },
   },

--- a/packages/showcases/core/csf/components/VtmnIcon.csf.js
+++ b/packages/showcases/core/csf/components/VtmnIcon.csf.js
@@ -49,7 +49,7 @@ export const argTypes = {
         'positive',
         'information',
         'warning',
-        'danger',
+        'negative',
         'neutral',
       ],
     },

--- a/packages/sources/react/src/components/VtmnIcon/VtmnIcon.tsx
+++ b/packages/sources/react/src/components/VtmnIcon/VtmnIcon.tsx
@@ -50,16 +50,14 @@ export const VtmnIcon: React.FC<VtmnIconProps> = ({
         return 'content-warning';
       case 'negative':
         return 'content-negative';
-      case 'neutral':
-        return '';
     }
   };
 
   const getIconColor = () => {
-    let iconColor = 'inherit';
+    let iconColor = undefined;
     if (color) {
       iconColor = `var(--vtmn-color_${color})`;
-    } else if (variant !== 'neutral') {
+    } else if (variant !== 'default') {
       iconColor = `var(--vtmn-semantic-color_${retrieveSemanticColor(
         variant,
       )})`;

--- a/packages/sources/react/src/components/VtmnIcon/VtmnIcon.tsx
+++ b/packages/sources/react/src/components/VtmnIcon/VtmnIcon.tsx
@@ -48,8 +48,8 @@ export const VtmnIcon: React.FC<VtmnIconProps> = ({
         return 'content-information';
       case 'warning':
         return 'content-warning';
-      case 'danger':
-        return 'content-danger';
+      case 'negative':
+        return 'content-negative';
       case 'neutral':
         return '';
     }

--- a/packages/sources/react/src/components/VtmnIcon/VtmnIcon.tsx
+++ b/packages/sources/react/src/components/VtmnIcon/VtmnIcon.tsx
@@ -50,7 +50,22 @@ export const VtmnIcon: React.FC<VtmnIconProps> = ({
         return 'content-warning';
       case 'danger':
         return 'content-danger';
+      case 'neutral':
+        return '';
     }
+  };
+
+  const getIconColor = () => {
+    let iconColor = 'inherit';
+    if (color) {
+      iconColor = `var(--vtmn-color_${color})`;
+    } else if (variant !== 'neutral') {
+      iconColor = `var(--vtmn-semantic-color_${retrieveSemanticColor(
+        variant,
+      )})`;
+    }
+
+    return iconColor;
   };
 
   return (
@@ -58,9 +73,7 @@ export const VtmnIcon: React.FC<VtmnIconProps> = ({
       className={`vtmx-${value} ${className ? className : ''}`}
       style={{
         fontSize: size,
-        color: color
-          ? `var(--vtmn-color_${color})`
-          : `var(--vtmn-semantic-color_${retrieveSemanticColor(variant)})`,
+        color: getIconColor(),
         ...style,
       }}
       {...props}

--- a/packages/sources/react/src/components/VtmnIcon/types.ts
+++ b/packages/sources/react/src/components/VtmnIcon/types.ts
@@ -14,7 +14,7 @@ export type VtmnIconVariant =
   | 'positive'
   | 'information'
   | 'warning'
-  | 'danger'
+  | 'negative'
   | 'neutral';
 
 export type VtmnIconSize = 16 | 20 | 24 | 32 | 64;

--- a/packages/sources/react/src/components/VtmnIcon/types.ts
+++ b/packages/sources/react/src/components/VtmnIcon/types.ts
@@ -14,7 +14,6 @@ export type VtmnIconVariant =
   | 'positive'
   | 'information'
   | 'warning'
-  | 'negative'
-  | 'neutral';
+  | 'negative';
 
 export type VtmnIconSize = 16 | 20 | 24 | 32 | 64;

--- a/packages/sources/react/src/components/VtmnIcon/types.ts
+++ b/packages/sources/react/src/components/VtmnIcon/types.ts
@@ -14,6 +14,7 @@ export type VtmnIconVariant =
   | 'positive'
   | 'information'
   | 'warning'
-  | 'danger';
+  | 'danger'
+  | 'neutral';
 
 export type VtmnIconSize = 16 | 20 | 24 | 32 | 64;


### PR DESCRIPTION
## Pull Request checklist

🚨 Please review the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern
- [x] If it's a new component in CSS, ask for design review

## Description

This is an update to react [icon component](https://github.com/Decathlon/vitamin-web/issues/717) variants
- **It allows icons to have an inherited color.**
_Why_ : This makes sense as icons doesn't have color restrictions, and when associated with text, an icon should be able to hold the same color.
_How_ : This PR propose a `neutral` variant keyword, when stated outputted inline color value is `inherit`

- **It changes the variant keyword `danger` as `negative`**
and output color value as `var(--vtmn-semantic-color_content-negative)`,
rather than `var(--vtmn-semantic-color_content-danger)` (that doesn't exist - stating a `danger` variant right now output a black color)

## Does this introduce a breaking change?

- Yes

`danger` wording variant, if ever used...
```tsx
<VtmnIcon variant="danger" value="home-fill" />
```
...should be update to `negative`
```tsx
<VtmnIcon variant="negative" value="home-fill" />
```


❤️ Thank you!
