### PR TITLE
fix(@vtmn/css): animation alert disapearing

### DIFF
--- a/packages/sources/css/src/components/alert/src/index.css
+++ b/packages/sources/css/src/components/alert/src/index.css
@@ -103,7 +103,7 @@
   display: flex;
   position: fixed;
   top: rem(32px);
-  right: 0;
+  right: rem(16px);
   animation: var(--vtmn-animation_alert);
 }
 
@@ -115,7 +115,7 @@
 
   .vtmn-alert.show {
     top: initial;
-    right: 0;
+    right: rem(16px);
     bottom: rem(32px);
     left: rem(16px);
     animation: var(--vtmn-animation_alert-mobile);

--- a/packages/sources/css/src/components/alert/src/index.css
+++ b/packages/sources/css/src/components/alert/src/index.css
@@ -103,7 +103,7 @@
   display: flex;
   position: fixed;
   top: rem(32px);
-  right: rem(16px);
+  right: 0;
   animation: var(--vtmn-animation_alert);
 }
 
@@ -115,7 +115,7 @@
 
   .vtmn-alert.show {
     top: initial;
-    right: rem(16px);
+    right: 0;
     bottom: rem(32px);
     left: rem(16px);
     animation: var(--vtmn-animation_alert-mobile);

--- a/packages/sources/css/src/design-tokens/src/animations.css
+++ b/packages/sources/css/src/design-tokens/src/animations.css
@@ -6,7 +6,7 @@
   --vtmn-animation_alert: fade-in 200ms ease-in forwards,
     slide-left 0.2s ease-in forwards, slide-right 0.2s 7.5s ease-in forwards;
   --vtmn-animation_alert-mobile: fade_in 200ms ease-in forwards,
-    slide-down 0.2s ease-in forwards, slide-up 0.2s 7.5s ease-in forwards;
+    slide-up 0.2s ease-in forwards, slide-down 0.2s 7.5s ease-in forwards;
   --vtmn-animation_fade-in: fade-in 200ms ease-in-out forwards;
   --vtmn-animation_show-up: show-up 400ms ease-in-out forwards;
   --vtmn-animation_overlay: fade-in 0.5s ease-in-out forwards,
@@ -33,7 +33,7 @@
 
 @keyframes slide-left {
   from {
-    transform: translateX(100%);
+    transform: translateX(120%);
   }
 
   to {
@@ -47,23 +47,23 @@
   }
 
   to {
-    transform: translateX(100%);
+    transform: translateX(120%);
   }
 }
 
 @keyframes slide-down {
   from {
-    transform: translateY(100%);
+    transform: translateY(0);
   }
 
   to {
-    transform: translateY(0);
+    transform: translateY(120%);
   }
 }
 
 @keyframes slide-up {
   from {
-    transform: translateY(100%);
+    transform: translateY(120%);
   }
 
   to {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

## Context
<!--- Why is this change required? What problem does it solve? -->
When the alert animation is triggered, the alert can be visible before and after the start/end of it.
<!--- If it fixes an opened issue, please link to the issue here. -->
Close #761 

## Checklist

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks.
- [X] Check PR name, it must follow the https://www.conventionalcommits.org pattern.
- [X] If it's a new component, please ask for design review.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information


