### PR TITLE
feat(@vtmn/css): fix alignements  + font style shortcut

### DIFF
--- a/packages/showcases/css/stories/components/badge/examples/overview.html
+++ b/packages/showcases/css/stories/components/badge/examples/overview.html
@@ -1,7 +1,7 @@
 <div class="block">
   <span class="vtmn-badge"></span>
 
-  <span class="vtmn-badge">6</span>
+  <span class="vtmn-badge">1</span>
 
   <span class="vtmn-badge">99+</span>
 </div>

--- a/packages/sources/css/src/components/badge/src/index.css
+++ b/packages/sources/css/src/components/badge/src/index.css
@@ -3,8 +3,9 @@
 @import '@vtmn/css-design-tokens/src/typography';
 
 .vtmn-badge {
-  font: var(--vtmn-typo_font-family) var(--vtmn-typo_text-3-font-size)
-    var(--vtmn-typo_font-weight--normal);
+  font-family: var(--vtmn-typo_font-family);
+  font-size: var(--vtmn-typo_text-3-font-size);
+  font-weight: var(--vtmn-typo_font-weight--normal);
   line-height: var(--vtmn-typo_text-3-line-height);
   display: inline-flex;
   height: rem(20px);

--- a/packages/sources/css/src/components/chip/src/index.css
+++ b/packages/sources/css/src/components/chip/src/index.css
@@ -23,6 +23,7 @@
   font-family: var(--vtmn-typo_font-family);
   font-size: var(--vtmn-typo_text-2-font-size);
   font-weight: var(--vtmn-typo_font-weight--bold);
+  line-height: 1;
   outline: none;
   height: rem(40px);
   box-sizing: border-box;
@@ -110,11 +111,11 @@
 
 .vtmn-chip_variant--filter > .vtmn-badge {
   font-weight: var(--vtmn-typo_font-weight--normal);
-  transform: translateX(rem(6px));
+  transform: translateX(rem(5px));
 }
 
 .vtmn-chip_variant--filter.vtmn-chip_size--medium > .vtmn-badge {
-  transform: translateX(rem(6px));
+  transform: translateX(rem(5px));
 }
 
 .vtmn-chip_variant--filter.vtmn-chip--selected {
@@ -174,11 +175,19 @@
 .vtmn-chip_variant--input > span[class^='vtmx-'],
 .vtmn-chip_variant--input > svg {
   transform: translateX(rem(-6px));
+  font-size: rem(20px);
+}
+
+.vtmn-chip_variant--input.vtmn-chip_size--small > span[class^='vtmx-'],
+.vtmn-chip_variant--input.vtmn-chip_size--small > svg {
+  transform: translateX(rem(-4px));
+  font-size: rem(16px);
 }
 
 .vtmn-chip_variant--input.vtmn-chip_size--medium > span[class^='vtmx-'],
 .vtmn-chip_variant--input.vtmn-chip_size--medium > svg {
   transform: translateX(rem(-6px));
+  font-size: rem(20px);
 }
 
 .vtmn-chip_variant--input > img {
@@ -189,7 +198,7 @@
 }
 
 .vtmn-chip_variant--input.vtmn-chip_size--small > img {
-  transform: translateX(rem(-8px));
+  transform: translateX(rem(-6px));
 }
 
 .vtmn-chip_variant--input.vtmn-chip_size--medium > img {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
- Fix alignements  + font style shortcut

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
- Badge component had font styes shortcut and it seems it bugs so I separated them like before to avoid design flaws.
- Chip component had some minor misalignments, I corrected them.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request your main!
- [X] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [X] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it's a new component, please ask for design review.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
