### PR TITLE
fix(@vtmn/react): children typing in `VtmnTooltip`

### DIFF
--- a/packages/sources/react/src/components/VtmnTooltip/VtmnTooltip.tsx
+++ b/packages/sources/react/src/components/VtmnTooltip/VtmnTooltip.tsx
@@ -20,7 +20,7 @@ export interface VtmnTooltipProps
    * The tooltip children
    * @defaultValue undefined
    */
-  children: JSX.Element;
+  children: React.ReactNode;
 }
 
 export const VtmnTooltip = ({


### PR DESCRIPTION

## Changes description
fix TS typings on children (this might be needed in multiple places and not just that one change)

## Context
currently, passing multiple elements such as:

```tsx
 <VtmnTooltip tooltip={row.original.error_message} position="right" className="flex aic">
            <VtmnIcon value="information-line" color="brand-digital" size={16} />
            <Box ml="1">{value}</Box>
        </VtmnTooltip>
```

triggers this typescript error (while this is valid JSX)
`This JSX tag's 'children' prop expects a single child of type 'Element', but multiple children were provided.ts(2746)`

current workaround is adding a pointless fragment:
```tsx
 <VtmnTooltip tooltip={row.original.error_message} position="right" className="flex aic">
          <>
            <VtmnIcon value="information-line" color="brand-digital" size={16} />
            <Box ml="1">{value}</Box>
          </>
        </VtmnTooltip>
```

## Does this introduce a breaking change?

- No
