### PR TITLE
fix(@vtmn/css): change the text input marge holders

### DIFF
--- a/packages/sources/css/src/components/forms/text-input/src/index.css
+++ b/packages/sources/css/src/components/forms/text-input/src/index.css
@@ -92,7 +92,7 @@ textarea.vtmn-text-input {
   color: var(--vtmn-semantic-color_content-secondary);
   font-size: rem(14px);
   line-height: 1;
-  margin-top: rem(4px);
+  margin-block-start: rem(4px);
   width: fit-content;
 }
 

--- a/packages/sources/css/src/components/forms/text-input/src/index.css
+++ b/packages/sources/css/src/components/forms/text-input/src/index.css
@@ -61,7 +61,7 @@ textarea.vtmn-text-input {
   color: var(--vtmn-semantic-color_content-primary);
   font-size: rem(16px);
   line-height: 1;
-  margin-bottom: rem(4px);
+  margin-block-end: rem(4px);
   display: block;
   width: fit-content;
 }

--- a/packages/sources/css/src/components/forms/text-input/src/index.css
+++ b/packages/sources/css/src/components/forms/text-input/src/index.css
@@ -26,8 +26,6 @@
   font-weight: var(--vtmn-typo_font-weight--normal);
   font-size: rem(16px);
   line-height: 1;
-  margin-bottom: rem(4px);
-  margin-top: rem(4px);
   padding: rem(12px) rem(36px) rem(12px) rem(12px);
   color: var(--vtmn-semantic-color_content-primary);
   min-height: rem(48px);
@@ -63,6 +61,7 @@ textarea.vtmn-text-input {
   color: var(--vtmn-semantic-color_content-primary);
   font-size: rem(16px);
   line-height: 1;
+  margin-bottom: rem(4px);
   display: block;
   width: fit-content;
 }
@@ -77,7 +76,7 @@ textarea.vtmn-text-input {
   position: absolute;
   font-size: var(--vtmn-typo_title-5-font-size);
   right: rem(11px);
-  bottom: rem(19px);
+  bottom: rem(15px);
   color: var(--vtmn-semantic-color_content-primary);
 }
 
@@ -93,18 +92,16 @@ textarea.vtmn-text-input {
   color: var(--vtmn-semantic-color_content-secondary);
   font-size: rem(14px);
   line-height: 1;
-  margin-top: 0;
+  margin-top: rem(4px);
   width: fit-content;
 }
 
 .vtmn-text-input_helper-text--error {
   color: var(--vtmn-semantic-color_content-primary);
-  margin-top: rem(-2px);
   width: fit-content;
 }
 
 .vtmn-text-input_helper-text--error::before {
-  position: relative;
   content: '';
   mask: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M1.333 8a6.667 6.667 0 1 0 13.333 0A6.667 6.667 0 0 0 1.333 8zm12 0A5.333 5.333 0 1 1 2.667 8a5.333 5.333 0 0 1 10.666 0zm-4.666 2v1.333H7.333V10h1.334zm0-1.333v-4H7.333v4h1.334z'/></svg>");
   mask-size: cover;
@@ -112,7 +109,7 @@ textarea.vtmn-text-input {
   background-color: var(--vtmn-semantic-color_content-negative);
   height: rem(14px);
   width: rem(14px);
-  top: rem(2px);
+  vertical-align: top;
   margin-right: rem(5px);
 }
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Move margins from the input to the label and the helper text to avoid useless margins when no label OR/AND helper text

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Text input has default margin even without label and text helper
- Close #946 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->