### PR TITLE
feat(@vtmn/css): remove margin from input into label/helper-text

### DIFF
--- a/packages/sources/css/src/components/forms/text-input/src/index.css
+++ b/packages/sources/css/src/components/forms/text-input/src/index.css
@@ -26,8 +26,6 @@
   font-weight: var(--vtmn-typo_font-weight--normal);
   font-size: rem(16px);
   line-height: 1;
-  margin-bottom: rem(4px);
-  margin-top: rem(4px);
   padding: rem(12px) rem(36px) rem(12px) rem(12px);
   color: var(--vtmn-semantic-color_content-primary);
   min-height: rem(48px);
@@ -65,6 +63,7 @@ textarea.vtmn-text-input {
   line-height: 1;
   display: block;
   width: fit-content;
+  margin-block-end: rem(4px);
 }
 
 .vtmn-text-input_container {
@@ -93,13 +92,12 @@ textarea.vtmn-text-input {
   color: var(--vtmn-semantic-color_content-secondary);
   font-size: rem(14px);
   line-height: 1;
-  margin-top: 0;
+  margin-block-start: rem(4px);
   width: fit-content;
 }
 
 .vtmn-text-input_helper-text--error {
   color: var(--vtmn-semantic-color_content-primary);
-  margin-top: rem(-2px);
   width: fit-content;
 }
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Move margins from the input to the label and the helper text to avoid useless margins when no label OR/AND helper text

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Text input has default margin even without label and text helper
- Close #946 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
