### PR TITLE
feat(@vtmn/vue): add types and props to`VtmnButton` component

### DIFF
--- a/packages/showcases/core/csf/components/actions/button.csf.js
+++ b/packages/showcases/core/csf/components/actions/button.csf.js
@@ -37,6 +37,27 @@ export const argTypes = {
       options: ['small', 'medium', 'large', 'stretched'],
     },
   },
+  type: {
+    type: { name: 'string', required: false },
+    description: 'The type of the button.',
+    defaultValue: 'button',
+    control: {
+      type: 'select',
+      options: ['button', 'submit'],
+    },
+  },
+  isDisabled: {
+    type: { name: 'boolean', required: false },
+    description: 'Whether the button is disabled.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: { summary: 'false' },
+    },
+    defaultValue: false,
+    control: { type: 'boolean' },
+  },
   iconLeft: {
     type: { name: 'string', required: false },
     description: 'The icon to display on the left hand side of button.',

--- a/packages/showcases/core/csf/components/actions/button.csf.js
+++ b/packages/showcases/core/csf/components/actions/button.csf.js
@@ -37,16 +37,7 @@ export const argTypes = {
       options: ['small', 'medium', 'large', 'stretched'],
     },
   },
-  type: {
-    type: { name: 'string', required: false },
-    description: 'The type of the button.',
-    defaultValue: 'button',
-    control: {
-      type: 'select',
-      options: ['button', 'submit'],
-    },
-  },
-  isDisabled: {
+  disabled: {
     type: { name: 'boolean', required: false },
     description: 'Whether the button is disabled.',
     table: {

--- a/packages/sources/vue/src/components/VtmnButton/VtmnButton.vue
+++ b/packages/sources/vue/src/components/VtmnButton/VtmnButton.vue
@@ -26,11 +26,7 @@ export default /*#__PURE__*/ defineComponent({
       validator: (val: VtmnButtonSize) =>
         ['small', 'medium', 'large', 'stretched'].includes(val),
     },
-    type: {
-      type: String as PropType<VtmnButtonType>,
-      default: 'button',
-    },
-    isDisabled: {
+    disabled: {
       type: Boolean as PropType<boolean>,
       default: false,
     },
@@ -74,16 +70,10 @@ export default /*#__PURE__*/ defineComponent({
 </script>
 
 <template>
-  <button :type="type" :class="classes" v-bind="$attrs" :disabled="isDisabled">
-    <span
-      :v-if="!this.iconAlone && this.iconLeft"
-      :class="iconLeftClass"
-    ></span>
-    <span :v-if="this.iconAlone" :class="iconAloneClass"></span>
-    <slot :v-if="!this.iconAlone" />
-    <span
-      :v-if="!this.iconAlone && this.iconRight"
-      :class="iconRightClass"
-    ></span>
+  <button :class="classes" v-bind="$attrs" :disabled="disabled">
+    <span :v-if="!iconAlone && iconLeft" :class="iconLeftClass"></span>
+    <span :v-if="iconAlone" :class="iconAloneClass"></span>
+    <slot :v-if="!iconAlone" />
+    <span :v-if="!iconAlone && iconRight" :class="iconRightClass"></span>
   </button>
 </template>

--- a/packages/sources/vue/src/components/VtmnButton/VtmnButton.vue
+++ b/packages/sources/vue/src/components/VtmnButton/VtmnButton.vue
@@ -1,14 +1,15 @@
 <script lang="ts">
 import '@vtmn/css-button/dist/index-with-vars.css';
-import { reactive, computed, defineComponent } from 'vue';
+import { reactive, computed, defineComponent, PropType } from 'vue';
+import { VtmnButtonSize, VtmnButtonType, VtmnButtonVariant } from './types';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnButton',
   props: {
     variant: {
-      type: String,
+      type: String as PropType<VtmnButtonVariant>,
       default: 'primary',
-      validator: (val: string) =>
+      validator: (val: VtmnButtonVariant) =>
         [
           'primary',
           'primary-reversed',
@@ -20,21 +21,29 @@ export default /*#__PURE__*/ defineComponent({
         ].includes(val),
     },
     size: {
-      type: String,
+      type: String as PropType<VtmnButtonSize>,
       default: 'medium',
-      validator: (val: string) =>
+      validator: (val: VtmnButtonSize) =>
         ['small', 'medium', 'large', 'stretched'].includes(val),
     },
+    type: {
+      type: String as PropType<VtmnButtonType>,
+      default: 'button',
+    },
+    isDisabled: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
     iconLeft: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     iconRight: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     iconAlone: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
   },
@@ -65,13 +74,13 @@ export default /*#__PURE__*/ defineComponent({
 </script>
 
 <template>
-  <button type="button" :class="classes" v-bind="$attrs">
+  <button :type="type" :class="classes" v-bind="$attrs" :disabled="isDisabled">
     <span
       :v-if="!this.iconAlone && this.iconLeft"
       :class="iconLeftClass"
     ></span>
     <span :v-if="this.iconAlone" :class="iconAloneClass"></span>
-    <slot :v-if="!this.iconAlone"></slot>
+    <slot :v-if="!this.iconAlone" />
     <span
       :v-if="!this.iconAlone && this.iconRight"
       :class="iconRightClass"

--- a/packages/sources/vue/src/components/VtmnButton/types.ts
+++ b/packages/sources/vue/src/components/VtmnButton/types.ts
@@ -1,0 +1,12 @@
+export type VtmnButtonVariant =
+  | 'primary'
+  | 'primary-reversed'
+  | 'secondary'
+  | 'tertiary'
+  | 'ghost'
+  | 'ghost-reversed'
+  | 'conversion';
+
+export type VtmnButtonSize = 'small' | 'medium' | 'large' | 'stretched';
+
+export type VtmnButtonType = 'button' | 'submit';


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Add type and isDisabled props and better Typescript definition with types.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

We will still need to update VtmnButton component with VtmnIcon when this component will be ready.
