### PR TITLE
feat(@vtmn/vue): add reactivity to `VtmnRadioButton` component

### DIFF
--- a/packages/sources/vue/src/components/VtmnRadioButton/VtmnRadioButton.vue
+++ b/packages/sources/vue/src/components/VtmnRadioButton/VtmnRadioButton.vue
@@ -1,35 +1,36 @@
 <script lang="ts">
 import '@vtmn/css-radio-button/dist/index-with-vars.css';
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnRadioButton',
   props: {
+    modelValue: {
+      type: [String, Number] as PropType<string | number>,
+      default: ''
+    },
     identifier: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     labelText: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     name: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     value: {
-      type: String,
+      type: [String, Number] as PropType<string | number>,
       default: null,
     },
-    checked: {
-      type: Boolean,
-      default: false,
-    },
     disabled: {
-      type: Boolean,
+      type: Boolean as PropType<boolean>,
       default: false,
     },
   },
+  emits: ['update:modelValue']
 });
 </script>
 
@@ -37,12 +38,13 @@ export default /*#__PURE__*/ defineComponent({
   <input
     class="vtmn-radio-button"
     type="radio"
-    :id="this.identifier"
-    :name="this.name"
-    :value="this.value"
-    :checked="this.checked"
-    :disabled="this.disabled"
+    :id="identifier"
+    :name="name"
+    :value="value"
+    :checked="modelValue === value"
+    :disabled="disabled"
     v-bind="$attrs"
+    @change="$emit('update:modelValue', value)"
   />
-  <label :for="this.identifier">{{ this.labelText }}</label>
+  <label :for="identifier">{{ labelText }}</label>
 </template>

--- a/packages/sources/vue/src/components/VtmnRadioButton/VtmnRadioButton.vue
+++ b/packages/sources/vue/src/components/VtmnRadioButton/VtmnRadioButton.vue
@@ -25,6 +25,10 @@ export default /*#__PURE__*/ defineComponent({
       type: [String, Number] as PropType<string | number>,
       default: null,
     },
+    checked: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
     disabled: {
       type: Boolean as PropType<boolean>,
       default: false,
@@ -41,7 +45,7 @@ export default /*#__PURE__*/ defineComponent({
     :id="identifier"
     :name="name"
     :value="value"
-    :checked="modelValue === value"
+    :checked="checked"
     :disabled="disabled"
     v-bind="$attrs"
     @change="$emit('update:modelValue', value)"


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Make radio button component reactive and ready to use in a Vue project.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Currently the component can't be use in a Vue form.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes

I removed the 'checked' prop because it's not useful in a Vue context. With this new way to check or not the radio button we ensure the reactive v-model value match with the input value which make more sense in a form. Feel free to reach me if you need more information about this breaking change.
