### PR TITLE
docs(@vtmn/vue): fix storybook docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "commitMessage": "chore: deploy storybook"
   },
   "volta": {
-    "node": "16.3.1",
+    "node": "16.13.2",
     "yarn": "1.22.17"
   },
   "dependencies": {

--- a/packages/showcases/vue/.storybook/preview.js
+++ b/packages/showcases/vue/.storybook/preview.js
@@ -48,14 +48,5 @@ export const parameters = {
   controls: { expanded: true },
   viewport: {
     viewports,
-  },
-  docs: {
-    transformSource(src, ctx) {
-      const match = /\b("')?template\1:\s*`([^`]+)`/.exec(src);
-      if (match) {
-        return templateSourceCode(dedent(match[2]), ctx.args, ctx.argTypes);
-      }
-      return src;
-    },
   }
 };


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Storybook docs were not working for `vue`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Most likely an update that made a piece of code irrelevant. 
In `.storybook/preview.js`
```javascript
export const parameters = {
  actions: { argTypesRegex: '^on[A-Z].*' },
  backgrounds,
  controls: { expanded: true },
  viewport: {
    viewports,
  },
 // match condition is always false
  docs: {
    transformSource(src, ctx) {
      const match = /\b("')?template\1:\s*`([^`]+)`/.exec(src);
      if (match) {
        return templateSourceCode(dedent(match[2]), ctx.args, ctx.argTypes);
      }
      return src;
    },
  }
};
```
The `match` condition was always false wich led to undefined argument, that's why storybook was throwing an error 🥳 !

Another small change, i am also using [volta](https://volta.sh/) wich is a replacement for `nvm`, the current pinned version `node@16.3.1` was not working wich leads to an impossibility to do a `yarn install`

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

https://user-images.githubusercontent.com/29448654/152795542-f87b1531-7c83-413c-a91e-cb1c86f4c909.mov


