### PR TITLE
fix(@vtmn/svelte): move import style into <style> element

### DIFF
--- a/packages/sources/svelte/src/components/VtmnButton.svelte
+++ b/packages/sources/svelte/src/components/VtmnButton.svelte
@@ -1,5 +1,4 @@
 <script>
-  import '@vtmn/css-button';
   import { cn } from '../utils/classnames';
 
   /** @restProps { button } */
@@ -68,3 +67,7 @@
     <span class={`vtmx-${iconRight}`} />
   {/if}
 </button>
+
+<style lang="css">
+  @import '@vtmn/css-button';
+</style>

--- a/packages/sources/svelte/src/components/VtmnLink.svelte
+++ b/packages/sources/svelte/src/components/VtmnLink.svelte
@@ -1,5 +1,4 @@
 <script>
-  import '@vtmn/css-link';
   import { cn } from '../utils/classnames';
 
   /**
@@ -51,3 +50,7 @@
 </script>
 
 <a {href} {target} class={componentClass} {...$$restProps}><slot /></a>
+
+<style lang="css">
+  @import '@vtmn/css-link';
+</style>

--- a/packages/sources/svelte/src/components/VtmnPopover.svelte
+++ b/packages/sources/svelte/src/components/VtmnPopover.svelte
@@ -1,5 +1,4 @@
 <script>
-  import '@vtmn/css-popover';
   import { cn } from '../utils/classnames';
   import { VTMN_POPOVER_POSITION } from '../utils/enums';
 
@@ -34,3 +33,7 @@
     <p class="vtmn-popover_text"><slot name="body" /></p>
   </div>
 </div>
+
+<style lang="css">
+  @import '@vtmn/css-popover';
+</style>

--- a/packages/sources/svelte/src/components/VtmnTextInput.svelte
+++ b/packages/sources/svelte/src/components/VtmnTextInput.svelte
@@ -1,5 +1,4 @@
 <script>
-  import '@vtmn/css-text-input';
   import { cn } from '../utils/classnames';
 
   /** @restProps { input | textarea } */
@@ -114,3 +113,7 @@
     {helperText}
   </p>
 {/if}
+
+<style lang="css">
+  @import '@vtmn/css-text-input';
+</style>


### PR DESCRIPTION
Refer to #958 

On svelte component (example VtmnButton.svelte), the component import the style on the <script> node.
This type of operation can cause side effects on the generated component on the SSR because is tires to interpret the css as script.

The quick solution is to move the css import into a <style> node.
To go further, during the build, inject the script directly into the component to make it totally autonomous (without node imports)