### PR TITLE
chore(package): add exports on package.json

### DIFF
--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -59,5 +59,12 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "svelte": "src/index.js"
+  "svelte": "src/index.js",
+  "exports": {
+    ".": "./src/components",
+    "./VtmnButton.svelte": "./dist/VtmnButton.js",
+    "./VtmnLink.svelte": "./dist/VtmnLink.js",
+    "./VtmnPopover.svelte": "./dist/VtmnPopover.js",
+    "./VtmnTextInput.svelte": "./dist/VtmnTextInput.js"
+  }
 }


### PR DESCRIPTION
Following the PR #960 it is now possible using a VtmnButton import from `@vtmn/svelte/src/component/VtmnButton.svelte` to import the component.

However, this operation can be cumbersome later on and does not use the compiled files in the `dist` folder.

To remedy this problem, it is necessary to add an `exports` node in the `package.json` file.

This one will have for goal : 
- When using an `import { VtmnButton } from '@vtmn/svelte'` to point the export from `@vtmn/svelte` to the `src/components` folder 
- When exporting `*.svelte` files, to point to those generated in the `dist`folder. 