### PR TITLE
feat(@vtmn/svelte): add price component

### DIFF
--- a/packages/showcases/svelte/stories/components/indicators/VtmnPrice/VtmnPrice.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnPrice/VtmnPrice.stories.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import { VtmnPrice } from '@vtmn/svelte';
+  import { parameters } from '@vtmn/showcase-core/csf/components/forms/text-input.csf';
+
+  const priceArgs = {
+    id: 'my-price',
+    labelText: 'Label',
+    size: 'medium',
+    variant: 'default',
+  };
+</script>
+
+<Meta
+  title="Components / Indicators / VtmnPrice"
+  component={VtmnPrice}
+  {parameters}
+/>
+
+<Template let:args>
+  <VtmnPrice {...args}>250,00€</VtmnPrice>
+</Template>
+
+<Story name="Overview" args={priceArgs} />

--- a/packages/showcases/svelte/stories/components/indicators/VtmnPrice/VtmnPrice.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnPrice/VtmnPrice.stories.svelte
@@ -4,8 +4,6 @@
   import { parameters } from '@vtmn/showcase-core/csf/components/forms/text-input.csf';
 
   const priceArgs = {
-    id: 'my-price',
-    labelText: 'Label',
     size: 'medium',
     variant: 'default',
   };
@@ -14,11 +12,18 @@
 <Meta
   title="Components / Indicators / VtmnPrice"
   component={VtmnPrice}
+  argTypes={{
+    slot: {
+      control: 'text',
+      description: 'Content of the slot',
+      defaultValue: '250,00€',
+    },
+  }}
   {parameters}
 />
 
 <Template let:args>
-  <VtmnPrice {...args}>250,00€</VtmnPrice>
+  <VtmnPrice {...args}>{args.slot}</VtmnPrice>
 </Template>
 
 <Story name="Overview" args={priceArgs} />

--- a/packages/showcases/svelte/stories/components/indicators/VtmnPrice/VtmnPrice.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnPrice/VtmnPrice.stories.svelte
@@ -16,7 +16,7 @@
     slot: {
       control: 'text',
       description: 'Content of the slot',
-      defaultValue: '250,00€',
+      defaultValue: '250,00 €',
     },
   }}
   {parameters}

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -65,7 +65,7 @@
     "./actions/VtmnButton/VtmnButton.svelte": "./dist/VtmnButton.js",
     "./actions/VtmnLink/VtmnLink.svelte": "./dist/VtmnLink.js",
     "./forms/VtmnTextInput/VtmnTextInput.svelte": "./dist/VtmnTextInput.js",
-    "./overlays/VtmnPopover/VtmnPopover.svelte": "./dist/VtmnPopover.js",
-    "./indicators/VtmnPrice/VtmnPrice.svelte": "./dist/VtmnPrice.js"
+    "./indicators/VtmnPrice/VtmnPrice.svelte": "./dist/VtmnPrice.js",
+    "./overlays/VtmnPopover/VtmnPopover.svelte": "./dist/VtmnPopover.js"
   }
 }

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -65,6 +65,7 @@
     "./actions/VtmnButton/VtmnButton.svelte": "./dist/VtmnButton.js",
     "./actions/VtmnLink/VtmnLink.svelte": "./dist/VtmnLink.js",
     "./forms/VtmnTextInput/VtmnTextInput.svelte": "./dist/VtmnTextInput.js",
-    "./overlays/VtmnPopover/VtmnPopover.svelte": "./dist/VtmnPopover.js"
+    "./overlays/VtmnPopover/VtmnPopover.svelte": "./dist/VtmnPopover.js",
+    "./indicators/VtmnPrice/VtmnPrice.svelte": "./dist/VtmnPrice.js"
   }
 }

--- a/packages/sources/svelte/rollup.config.js
+++ b/packages/sources/svelte/rollup.config.js
@@ -21,6 +21,10 @@ const components = [
     folder: 'overlays',
     name: 'VtmnPopover',
   },
+  {
+    folder: 'indicators',
+    name: 'VtmnPrice',
+  },
 ];
 
 export default components.map(({ folder, name }) => ({

--- a/packages/sources/svelte/src/components/index.js
+++ b/packages/sources/svelte/src/components/index.js
@@ -6,6 +6,7 @@ export { default as VtmnLink } from './actions/VtmnLink/VtmnLink.svelte';
 export { default as VtmnTextInput } from './forms/VtmnTextInput/VtmnTextInput.svelte';
 
 // Indicators
+export { default as VtmnPrice } from './indicators/VtmnPrice/VtmnPrice.svelte';
 
 // Navigation
 

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -1,6 +1,6 @@
 <script>
   import { cn } from '../../../utils/classnames';
-  import { VARIANT } from './enums';
+  import { VARIANT, SIZE } from './enums';
 
   /**
    * Size of the price

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -1,0 +1,53 @@
+<script>
+  import { cn } from '../../../utils/classnames';
+  import { VARIANT } from './enums';
+
+  /**
+   * ID of the price
+   * @type {string}
+   * @defaultValue undefined
+   */
+  export let id;
+
+  /**
+   * Label apply on the component
+   * @type {string}
+   * @defaultValue undefined
+   */
+  export let label;
+
+  /**
+   * Size of the price
+   * @type {'small' | 'medium' | 'large' }
+   * @defaultValue undefined
+   */
+  export let size;
+
+  /**
+   * Variant of the price
+   * @type {'default' | 'accent' | 'alert' | 'strikethrough'}
+   * @defaultValue 'default'
+   */
+  export let variant = VARIANT.DEFAULT;
+
+  let className;
+  /**
+   * @type {string} Custom classes to apply to the component.
+   */
+  export { className as class };
+
+  $: componentClass = cn(
+    'vtmn-price',
+    size && `vtmn-price_size--${size}`,
+    variant && `vtmn-price_variant--${variant}`,
+    className,
+  );
+</script>
+
+<span {id} class={componentClass} aria-label={label}>
+  <slot />
+</span>
+
+<style lang="css">
+  @import '@vtmn/css-price';
+</style>

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -5,7 +5,7 @@
   /**
    * Size of the price
    * @type {'small' | 'medium' | 'large' }
-   * @defaultValue undefined
+   * @defaultValue 'medium'
    */
   export let size = SIZE.MEDIUM;
 

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -3,20 +3,6 @@
   import { VARIANT } from './enums';
 
   /**
-   * ID of the price
-   * @type {string}
-   * @defaultValue undefined
-   */
-  export let id;
-
-  /**
-   * Label apply on the component
-   * @type {string}
-   * @defaultValue undefined
-   */
-  export let label;
-
-  /**
    * Size of the price
    * @type {'small' | 'medium' | 'large' }
    * @defaultValue undefined
@@ -44,7 +30,7 @@
   );
 </script>
 
-<span {id} class={componentClass} aria-label={label}>
+<span class={componentClass} {...$$restProps}>
   <slot />
 </span>
 

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -7,7 +7,7 @@
    * @type {'small' | 'medium' | 'large' }
    * @defaultValue undefined
    */
-  export let size;
+  export let size = SIZE.MEDIUM;
 
   /**
    * Variant of the price

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/enums.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/enums.js
@@ -1,0 +1,12 @@
+export const SIZE = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+};
+
+export const VARIANT = {
+  DEFAULT: 'default',
+  ACCENT: 'accent',
+  ALERT: 'alert',
+  STRIKETHROUGH: 'strikethrough',
+};


### PR DESCRIPTION
Creation of the component VtmnPrice.
The component will accept as props:
- size (default value: `medium`)
- variant (default value: `default`)

Todo list : 
- [x] Create a `VtmnPrice.svelte` component
- [x] Add the input definitions of the component
- [x] Add the component in the exports of the `package.json`
- [x] Integrate the component in the rollup
- [x] Create a storybook for the component