### PR TITLE
feat(@vtmn/vue): add `VtmnToggle` and `VtmnCheckbox` reactivity

### DIFF
--- a/packages/sources/vue/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.vue
+++ b/packages/sources/vue/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.vue
@@ -1,34 +1,64 @@
 <script lang="ts">
-import '@vtmn/css-checkbox/dist/index-with-vars.css';
-import { defineComponent } from 'vue';
+import { defineComponent, PropType, reactive } from 'vue';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnCheckbox',
   props: {
+    modelValue: {
+      type: [String, Number, Boolean, Array] as PropType<
+        string | number | boolean | []
+      >,
+      default: '',
+    },
     labelText: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     identifier: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     checked: {
-      type: Boolean,
+      type: Boolean as PropType<boolean>,
       default: false,
     },
     value: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     name: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     disabled: {
-      type: Boolean,
+      type: Boolean as PropType<boolean>,
       default: false,
     },
+    standalone: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    props = reactive(props);
+
+    const handleChange = (event: Event) => {
+      if (props.standalone) {
+        if (event && event.target) {
+          return emit(
+            'update:modelValue',
+            (event.target as HTMLInputElement).checked,
+          );
+        }
+      }
+
+      return emit('update:modelValue', props.value);
+    };
+
+    return {
+      handleChange,
+    };
   },
 });
 </script>
@@ -37,12 +67,13 @@ export default /*#__PURE__*/ defineComponent({
   <input
     class="vtmn-checkbox"
     type="checkbox"
-    :checked="this.checked"
-    :id="this.identifier"
-    :name="this.name"
-    :disabled="this.disabled"
-    :value="this.value"
+    :checked="checked"
+    :id="identifier"
+    :name="name"
+    :disabled="disabled"
+    :value="value"
     v-bind="$attrs"
+    @change="handleChange"
   />
-  <label :for="this.identifier">{{ this.labelText }}</label>
+  <label :for="identifier">{{ labelText }}</label>
 </template>

--- a/packages/sources/vue/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.vue
+++ b/packages/sources/vue/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import '@vtmn/css-checkbox/dist/index-with-vars.css';
 import { defineComponent, PropType, reactive } from 'vue';
 
 export default /*#__PURE__*/ defineComponent({

--- a/packages/sources/vue/src/components/selection-controls/VtmnToggle/VtmnToggle.vue
+++ b/packages/sources/vue/src/components/selection-controls/VtmnToggle/VtmnToggle.vue
@@ -1,39 +1,55 @@
 <script lang="ts">
 import '@vtmn/css-toggle/dist/index-with-vars.css';
-import { computed, defineComponent, reactive } from 'vue';
+import { computed, defineComponent, PropType, reactive } from 'vue';
+import { VtmnToggleSize } from './types';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnToggle',
   props: {
+    modelValue: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
     identifier: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     labelText: {
-      type: String,
+      type: String as PropType<string>,
       default: null,
     },
     checked: {
-      type: Boolean,
+      type: Boolean as PropType<boolean>,
       default: false,
     },
     disabled: {
-      type: Boolean,
+      type: Boolean as PropType<boolean>,
       default: false,
     },
     size: {
-      type: String,
-      default: null,
+      type: String as PropType<VtmnToggleSize>,
+      default: 'medium',
     },
   },
-  setup(props) {
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
     props = reactive(props);
+
+    const handleChange = (event: Event) => {
+      if (event && event.target) {
+        return emit(
+          'update:modelValue',
+          (event.target as HTMLInputElement).checked,
+        );
+      }
+    };
 
     return {
       classes: computed(() => ({
         'vtmn-toggle': true,
         [`vtmn-toggle_size--${props.size}`]: props.size,
       })),
+      handleChange,
     };
   },
 });
@@ -44,12 +60,13 @@ export default /*#__PURE__*/ defineComponent({
     <div class="vtmn-toggle_switch">
       <input
         type="checkbox"
-        :id="this.identifier"
-        :checked="this.checked"
-        :disabled="this.disabled"
+        :id="identifier"
+        :checked="checked"
+        :disabled="disabled"
+        @change="handleChange"
       />
       <span aria-hidden="true"></span>
     </div>
-    <label :for="this.identifier">{{ this.labelText }}</label>
+    <label :for="identifier">{{ labelText }}</label>
   </div>
 </template>

--- a/packages/sources/vue/src/components/selection-controls/VtmnToggle/types.ts
+++ b/packages/sources/vue/src/components/selection-controls/VtmnToggle/types.ts
@@ -1,0 +1,1 @@
+export type VtmnToggleSize = 'small' | 'medium';


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Update `VtmnToggle` and `VtmnCheckbox` components to make them ready to use in a Vue 3 project with reactivity.

Also add `VtmnCheckbox` standalone props to make it useable according to the design system. More explanation in Context section below.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
I added a standalone props for `VtmnCheckbox` in order to be able to use it in all the possible context.

You only need this props when you want to display only one checkbox for example accepting or not the general condition in an ecommerce context. In this case we need our component to emit a true or false value and not the value that it would contain that would be pushed in an array when using multiple checkbox.

I know VTMN DS aim to release stateless component but in our case it's not possible to avoid this props and to emit the update:modelValue with the value when we need true or false based on checked state of input checkbox.

Feel free to reach me if you need more information or a live demo to better understand the trick.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

