### PR TITLE
fix(@vtmn/css): change margin holders for quantity and select.

### DIFF
--- a/packages/sources/css/src/components/forms/select/src/index.css
+++ b/packages/sources/css/src/components/forms/select/src/index.css
@@ -15,6 +15,12 @@
   width: min-content;
 }
 
+.vtmn-select_container > label {
+  margin-block-end: rem(4px);
+  display: inline-block;
+  width: fit-content;
+}
+
 .vtmn-select_container select {
   appearance: none;
   padding: rem(12px) rem(40px) rem(12px) rem(12px);
@@ -22,7 +28,6 @@
   box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-inactive);
   border-radius: var(--vtmn-radius_100);
   height: rem(48px);
-  margin-bottom: rem(5px);
   width: min-content;
   background-color: var(--vtmn-semantic-color_background-primary);
   cursor: pointer;
@@ -46,6 +51,9 @@
 
 .vtmn-select_container .vtmn-select_error-text {
   font-size: var(--vtmn-typo_text-3-font-size);
+  line-height: var(--vtmn-typo_text-3-line-height);
+  margin-block-start: rem(4px);
+  display: inline-block;
 }
 
 .vtmn-select_container .vtmn-select_error-text::before {

--- a/packages/sources/css/src/components/forms/text-input/src/index.css
+++ b/packages/sources/css/src/components/forms/text-input/src/index.css
@@ -24,7 +24,7 @@
   border-radius: var(--vtmn-radius_100);
   display: block;
   font-weight: var(--vtmn-typo_font-weight--normal);
-  font-size: rem(16px);
+  font-size: var(--vtmn-typo_text-2-font-size);
   line-height: 1;
   padding: rem(12px) rem(36px) rem(12px) rem(12px);
   color: var(--vtmn-semantic-color_content-primary);
@@ -59,8 +59,8 @@ textarea.vtmn-text-input {
 
 .vtmn-text-input_label {
   color: var(--vtmn-semantic-color_content-primary);
-  font-size: rem(16px);
-  line-height: 1;
+  font-size: var(--vtmn-typo_text-2-font-size);
+  line-height: var(--vtmn-typo_text-2-line-height);
   margin-block-end: rem(4px);
   display: block;
   width: fit-content;
@@ -90,8 +90,8 @@ textarea.vtmn-text-input {
 
 .vtmn-text-input_helper-text {
   color: var(--vtmn-semantic-color_content-secondary);
-  font-size: rem(14px);
-  line-height: 1;
+  font-size: var(--vtmn-typo_text-3-font-size);
+  line-height: var(--vtmn-typo_text-3-line-height);
   margin-block-start: rem(4px);
   width: fit-content;
 }

--- a/packages/sources/css/src/components/selection-controls/quantity/src/index.css
+++ b/packages/sources/css/src/components/selection-controls/quantity/src/index.css
@@ -7,17 +7,24 @@
 @import '@vtmn/css-design-tokens/src/radius';
 
 .vtmn-quantity {
-  font: var(--vtmn-typo_font-family) var(--vtmn-typo_text-2-font-size)
-    var(--vtmn-typo_font-weight--normal);
+  font-family: var(--vtmn-typo_font-family);
+  font-size: var(--vtmn-typo_text-2-font-size);
+  font-weight: var(--vtmn-typo_font-weight--normal);
   color: var(--vtmn-semantic-color_content-primary);
   height: fit-content;
   width: fit-content;
 }
 
+.vtmn-quantity > label {
+  font-size: var(--vtmn-typo_text-2-font-size);
+  line-height: var(--vtmn-typo_text-2-line-height);
+  margin-block-end: rem(4px);
+  display: inline-block;
+  width: fit-content;
+}
+
 .vtmn-quantity_content {
   display: flex;
-  margin-block-start: var(--vtmn-spacing_1);
-  margin-block-end: var(--vtmn-spacing_1);
 }
 
 .vtmn-quantity input[type='number'] {
@@ -95,6 +102,8 @@
 
 .vtmn-quantity_error-text {
   font-size: var(--vtmn-typo_text-3-font-size);
+  line-height: var(--vtmn-typo_text-3-line-height);
+  margin-block-start: rem(4px);
   display: inline-flex;
   align-items: center;
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Re add `line-height` for labels and helper-text in forms component
- Move margin holders from the input to the label and helper-text
- Fix some width that were not semantic already

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Some designers found the label and the helper text too narrow with the text input because we removed the line height in a previous pull request, so I put them put to be identical with the design of the components.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
