### PR TITLE
fix(@vtmn/css): modal radius + overview fix

### DIFF
--- a/packages/showcases/css/stories/components/overlays/modal/examples/overview.html
+++ b/packages/showcases/css/stories/components/overlays/modal/examples/overview.html
@@ -1,9 +1,15 @@
+<style>
+  @media screen and (min-width: 599px) {
+    .vtmn-modal_content {
+      position: static;
+      transform: translate(0, 0);
+    }
+  }
+</style>
+
 <div class="block">
   <div class="vtmn-modal" id="modal-1" aria-hidden="true">
-    <div
-      class="vtmn-modal_content"
-      style="position: static; transform: translate(0, 0)"
-    >
+    <div class="vtmn-modal_content">
       <div class="vtmn-modal_content_title">
         <p class="vtmn-modal_content_title--text">What is a modal?</p>
         <button

--- a/packages/sources/css/src/components/overlays/modal/src/index.css
+++ b/packages/sources/css/src/components/overlays/modal/src/index.css
@@ -126,6 +126,7 @@
     bottom: 0;
     left: 0;
     transform: translate(0, 0);
+    border-radius: var(--vtmn-radius_200) var(--vtmn-radius_200) 0 0;
   }
 
   .vtmn-modal_content_actions {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- remove `border-radius` for the bottom of the modal on mobile devices
- The overview showcase turns correctly into mobile responsive

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
