### PR TITLE
chore(svelte): remove exports + clean css

### DIFF
--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -59,13 +59,5 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "svelte": "src/index.js",
-  "exports": {
-    ".": "./src/components",
-    "./actions/VtmnButton/VtmnButton.svelte": "./dist/VtmnButton.js",
-    "./actions/VtmnLink/VtmnLink.svelte": "./dist/VtmnLink.js",
-    "./forms/VtmnTextInput/VtmnTextInput.svelte": "./dist/VtmnTextInput.js",
-    "./indicators/VtmnPrice/VtmnPrice.svelte": "./dist/VtmnPrice.js",
-    "./overlays/VtmnPopover/VtmnPopover.svelte": "./dist/VtmnPopover.js"
-  }
+  "svelte": "src/index.js"
 }

--- a/packages/sources/svelte/src/index.js
+++ b/packages/sources/svelte/src/index.js
@@ -1,4 +1,2 @@
-import '@vtmn/css-design-tokens';
-
 export * from './components';
 export * from './utils';


### PR DESCRIPTION
This PR fix some issues with svelte build.

- Remove all css on .js files for the SSR rendering
- Thanks to this modification, it is possible to delete in the package.json the exports because no more js file contains css style
- Remove `@vtmn/css-design-token` because is no longer used in the package 