### PR TITLE
refactor(@vtmn/css): add a11y markup + fix bug semantic colors border

### DIFF
--- a/packages/showcases/css/stories/components/overlays/tooltip/examples/overview.html
+++ b/packages/showcases/css/stories/components/overlays/tooltip/examples/overview.html
@@ -9,24 +9,30 @@
 >
   <span
     tabindex="0"
+    id="vtmn-tooltip-1"
     class="vtmn-tooltip"
     data-tooltip="Bottom-Right Tooltip"
     data-position="bottom-right"
-    >Bottom-Right</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-1">Bottom-Right</p></span
   >
   <span
     tabindex="0"
+    id="vtmn-tooltip-2"
     class="vtmn-tooltip"
     data-tooltip="Bottom Tooltip"
     data-position="bottom"
-    >Bottom</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-2">Bottom</p></span
   >
   <span
     tabindex="0"
+    id="vtmn-tooltip-3"
     class="vtmn-tooltip"
     data-tooltip="Bottom-Left Tooltip"
     data-position="bottom-left"
-    >Bottom-Left</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-3">Bottom-Left</p></span
   >
 </div>
 
@@ -42,17 +48,21 @@
 >
   <span
     tabindex="0"
+    id="vtmn-tooltip-4"
     class="vtmn-tooltip"
     data-tooltip="Right Tooltip"
     data-position="right"
-    >Right</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-4">Right</p></span
   >
   <span
     tabindex="0"
+    id="vtmn-tooltip-5"
     class="vtmn-tooltip"
     data-tooltip="Left Tooltip"
     data-position="left"
-    >Left</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-5">Left</p></span
   >
 </div>
 
@@ -68,24 +78,30 @@
 >
   <span
     tabindex="0"
+    id="vtmn-tooltip-6"
     class="vtmn-tooltip"
     data-tooltip="Top-Right Tooltip"
     data-position="top-right"
-    >Top-Right</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-6">Top-Right</p></span
   >
   <span
     tabindex="0"
+    id="vtmn-tooltip-7"
     class="vtmn-tooltip"
     data-tooltip="Top Tooltip"
     data-position="top"
-    >Top</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-7">Top</p></span
   >
   <span
     tabindex="0"
+    id="vtmn-tooltip-8"
     class="vtmn-tooltip"
     data-tooltip="Top-Left Tooltip"
     data-position="top-left"
-    >Top-Left</span
+    role="tooltip"
+    ><p aria-describedby="vtmn-tooltip-8">Top-Left</p></span
   >
 </div>
 
@@ -101,23 +117,35 @@
 >
   <span
     tabindex="0"
+    id="vtmn-tooltip-9"
     class="vtmn-tooltip"
-    data-tooltip="Here is a little text to show you how the tooltip is displayed"
+    data-tooltip="Here is a little text"
     data-position="right"
-    ><span class="vtmx-information-line"></span
+    role="tooltip"
+    ><span
+      aria-describedby="vtmn-tooltip-9"
+      class="vtmx-information-line"
+    ></span
   ></span>
   <span
     tabindex="0"
+    id="vtmn-tooltip-10"
     class="vtmn-tooltip"
-    data-tooltip="Here is a little text to show you how the tooltip is displayed"
+    data-tooltip="Here is a little text"
     data-position="bottom"
-    ><span class="vtmx-error-warning-line"></span
+    role="tooltip"
+    ><span
+      aria-describedby="vtmn-tooltip-10"
+      class="vtmx-error-warning-line"
+    ></span
   ></span>
   <span
     tabindex="0"
+    id="vtmn-tooltip-11"
     class="vtmn-tooltip"
-    data-tooltip="Here is a little text to show you how the tooltip is displayed"
+    data-tooltip="Here is a little text"
     data-position="left"
-    ><span class="vtmx-question-line"></span
+    role="tooltip"
+    ><span aria-describedby="vtmn-tooltip-11" class="vtmx-question-line"></span
   ></span>
 </div>

--- a/packages/sources/css/src/components/overlays/tooltip/src/index.css
+++ b/packages/sources/css/src/components/overlays/tooltip/src/index.css
@@ -48,7 +48,8 @@
   box-sizing: border-box;
 }
 
-.vtmn-tooltip:focus-visible {
+.vtmn-tooltip:focus-visible,
+.vtmn-tooltip:focus-visible > * {
   outline: none;
   box-shadow: var(--vtmn-shadow_focus-visible);
 }

--- a/packages/sources/css/src/design-tokens/src/shadows.css
+++ b/packages/sources/css/src/design-tokens/src/shadows.css
@@ -12,6 +12,6 @@
   --vtmn-shadow_400: rem(0) rem(48px) rem(48px) rem(0)
     var(--vtmn-semantic-color_shadow);
   --vtmn-shadow_focus-visible: 0 0 0 rem(4px)
-      var(--vtmn-semantic-color_border-primary-reversed),
-    0 0 0 rem(6px) var(--vtmn-semantic-color_border-primary);
+      var(--vtmn-semantic-color_border-primary),
+    0 0 0 rem(6px) var(--vtmn-semantic-color_border-primary-reversed);
 }

--- a/packages/sources/css/src/design-tokens/src/themes/core-dark.css
+++ b/packages/sources/css/src/design-tokens/src/themes/core-dark.css
@@ -135,9 +135,9 @@
   --vtmn-semantic-color_border-information--s: var(--vtmn-base-color_blue300--s);
   --vtmn-semantic-color_border-information--l: var(--vtmn-base-color_blue300--l);
   --vtmn-semantic-color_border-information: hsl(var(--vtmn-semantic-color_border-information--h), var(--vtmn-semantic-color_border-information--s), var(--vtmn-semantic-color_border-information--l));
-  --vtmn-semantic-color_border-primary-reversed--h: var(--vtmn-base-color_black--h);
-  --vtmn-semantic-color_border-primary-reversed--s: var(--vtmn-base-color_black--s);
-  --vtmn-semantic-color_border-primary-reversed--l: var(--vtmn-base-color_black--l);
+  --vtmn-semantic-color_border-primary-reversed--h: var(--vtmn-base-color_white--h);
+  --vtmn-semantic-color_border-primary-reversed--s: var(--vtmn-base-color_white--s);
+  --vtmn-semantic-color_border-primary-reversed--l: var(--vtmn-base-color_white--l);
   --vtmn-semantic-color_border-primary-reversed: hsl(var(--vtmn-semantic-color_border-primary-reversed--h), var(--vtmn-semantic-color_border-primary-reversed--s), var(--vtmn-semantic-color_border-primary-reversed--l));
   --vtmn-semantic-color_hover-primary--h: var(--vtmn-base-color_blue700--h);
   --vtmn-semantic-color_hover-primary--s: var(--vtmn-base-color_blue700--s);

--- a/packages/sources/css/src/design-tokens/src/themes/core-light.css
+++ b/packages/sources/css/src/design-tokens/src/themes/core-light.css
@@ -135,9 +135,9 @@
   --vtmn-semantic-color_border-information--s: var(--vtmn-base-color_blue400--s);
   --vtmn-semantic-color_border-information--l: var(--vtmn-base-color_blue400--l);
   --vtmn-semantic-color_border-information: hsl(var(--vtmn-semantic-color_border-information--h), var(--vtmn-semantic-color_border-information--s), var(--vtmn-semantic-color_border-information--l));
-  --vtmn-semantic-color_border-primary-reversed--h: var(--vtmn-base-color_white--h);
-  --vtmn-semantic-color_border-primary-reversed--s: var(--vtmn-base-color_white--s);
-  --vtmn-semantic-color_border-primary-reversed--l: var(--vtmn-base-color_white--l);
+  --vtmn-semantic-color_border-primary-reversed--h: var(--vtmn-base-color_black--h);
+  --vtmn-semantic-color_border-primary-reversed--s: var(--vtmn-base-color_black--s);
+  --vtmn-semantic-color_border-primary-reversed--l: var(--vtmn-base-color_black--l);
   --vtmn-semantic-color_border-primary-reversed: hsl(var(--vtmn-semantic-color_border-primary-reversed--h), var(--vtmn-semantic-color_border-primary-reversed--s), var(--vtmn-semantic-color_border-primary-reversed--l));
   --vtmn-semantic-color_hover-primary--h: var(--vtmn-base-color_blue50--h);
   --vtmn-semantic-color_hover-primary--s: var(--vtmn-base-color_blue50--s);

--- a/packages/sources/css/src/design-tokens/src/themes/default.css
+++ b/packages/sources/css/src/design-tokens/src/themes/default.css
@@ -136,9 +136,9 @@
   --vtmn-semantic-color_border-information--s: var(--vtmn-base-color_blue400--s);
   --vtmn-semantic-color_border-information--l: var(--vtmn-base-color_blue400--l);
   --vtmn-semantic-color_border-information: hsl(var(--vtmn-semantic-color_border-information--h), var(--vtmn-semantic-color_border-information--s), var(--vtmn-semantic-color_border-information--l));
-  --vtmn-semantic-color_border-primary-reversed--h: var(--vtmn-base-color_white--h);
-  --vtmn-semantic-color_border-primary-reversed--s: var(--vtmn-base-color_white--s);
-  --vtmn-semantic-color_border-primary-reversed--l: var(--vtmn-base-color_white--l);
+  --vtmn-semantic-color_border-primary-reversed--h: var(--vtmn-base-color_black--h);
+  --vtmn-semantic-color_border-primary-reversed--s: var(--vtmn-base-color_black--s);
+  --vtmn-semantic-color_border-primary-reversed--l: var(--vtmn-base-color_black--l);
   --vtmn-semantic-color_border-primary-reversed: hsl(var(--vtmn-semantic-color_border-primary-reversed--h), var(--vtmn-semantic-color_border-primary-reversed--s), var(--vtmn-semantic-color_border-primary-reversed--l));
   --vtmn-semantic-color_hover-primary--h: var(--vtmn-base-color_blue50--h);
   --vtmn-semantic-color_hover-primary--s: var(--vtmn-base-color_blue50--s);


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add a `role="tooltip"` and an `aria-describedby` for the tooltip component
- `Primary reversed` goes from `white` to `black` in light theme
- `Primary reversed` goes from `black` to `white` in dark theme

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Design token in dev didin't match the correct value in the [figma file](https://www.figma.com/file/ItP6IOCNwSWlskFgpGw7TU/Vitamin---Core-theme-(Dark-mode)-(v0)?node-id=563%3A531https://www.figma.com/file/ItP6IOCNwSWlskFgpGw7TU/Vitamin---Core-theme-(Dark-mode)-(v0)?node-id=563%3A531)
- Enhance accessibility of the `tooltip`

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

