### PR TITLE
feat(@vtmn/css): add icon leading for tag

### DIFF
--- a/packages/showcases/css/stories/components/indicators/tag/examples/overview.html
+++ b/packages/showcases/css/stories/components/indicators/tag/examples/overview.html
@@ -39,3 +39,15 @@
 
   <a href="" class="vtmn-tag vtmn-tag_variant--accent">Interactive Tag</a>
 </div>
+
+<div class="block">
+  <a href="" class="vtmn-tag vtmn-tag_variant--alert"
+    ><span class="vtmx-leaf-fill" role="presentation"></span>Interactive Tag
+    with icon</a
+  >
+
+  <span class="vtmn-tag vtmn-tag_variant--decorative_jade"
+    ><span class="vtmx-leaf-fill" role="presentation"></span>Jade with
+    icon</span
+  >
+</div>

--- a/packages/sources/css/src/components/indicators/tag/src/index.css
+++ b/packages/sources/css/src/components/indicators/tag/src/index.css
@@ -31,6 +31,11 @@ a.vtmn-tag:focus-visible {
   transition: var(--vtmn-transition_focus-visible);
 }
 
+.vtmn-tag > span[class^='vtmx-'] {
+  margin-inline-start: rem(-4px);
+  margin-inline-end: rem(4px);
+}
+
 /* Variants */
 .vtmn-tag_variant--accent {
   background-color: var(--vtmn-semantic-color_background-accent);


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add showcase and a clas to display an icon in a `tag` component

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- A tag can be led by an icon to emphasize meaning

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
