### PR TITLE
fix(@vtmn/react): add missing className prop in `VtmnProgressbar`

### DIFF
--- a/packages/sources/react/src/components/indicators/VtmnProgressbar/VtmnProgressbar.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnProgressbar/VtmnProgressbar.tsx
@@ -7,7 +7,8 @@ import {
   VtmnProgressbarStatus,
 } from './types';
 
-export interface VtmnProgressbarProps {
+export interface VtmnProgressbarProps
+  extends React.ComponentPropsWithoutRef<'div'> {
   /**
    * The variant of the progress bar.
    * @type {VtmnProgressbarVariant}
@@ -66,6 +67,7 @@ export const VtmnProgressbar = ({
   imageSrc = undefined,
   imageAlt = undefined,
   loadingText = 'Loading',
+  className,
 }: VtmnProgressbarProps) => {
   return (
     <div
@@ -76,6 +78,7 @@ export const VtmnProgressbar = ({
         // Only add size attribute when variant is linear or size is small in circular mode
         (variant == 'linear' || size == 'small') &&
           `vtmn-progressbar_size--${size}`,
+        className,
       )}
       role="progressbar"
       aria-label="progress bar"


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- This PR aims to add the missing `className` prop for `VtmnProgressbar`

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- This prop is required in order to provide custom classes

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
