### PR TITLE
feat(@vtmn/svelte): add `VtmnModal` component

### DIFF
--- a/packages/showcases/core/csf/components/overlays/modal.csf.js
+++ b/packages/showcases/core/csf/components/overlays/modal.csf.js
@@ -7,3 +7,28 @@ export const parameters = {
     url: 'https://www.figma.com/file/zDZIyayUlr1yTWrsi7cFoo/?node-id=2993%3A12130',
   },
 };
+
+export const argTypes = {
+  title: {
+    type: { name: 'string', required: true },
+    description: 'The printed title',
+    defaultValue: 'Modal title',
+    control: { type: 'text' },
+  },
+  show: {
+    type: { name: 'boolean', required: true },
+    description: 'Display the modal',
+    defaultValue: false,
+    control: {
+      type: 'boolean',
+    },
+  },
+  disableAnimation: {
+    type: { name: 'boolean', require: false },
+    description: 'Disable the fade animation on show',
+    defaultValue: false,
+    control: {
+      type: 'boolean',
+    },
+  },
+};

--- a/packages/showcases/core/csf/components/overlays/modal.csf.js
+++ b/packages/showcases/core/csf/components/overlays/modal.csf.js
@@ -23,7 +23,7 @@ export const argTypes = {
       type: 'boolean',
     },
   },
-  disableAnimation: {
+  animationDisabled: {
     type: { name: 'boolean', require: false },
     description: 'Disable the fade animation on show',
     defaultValue: true,

--- a/packages/showcases/core/csf/components/overlays/modal.csf.js
+++ b/packages/showcases/core/csf/components/overlays/modal.csf.js
@@ -26,7 +26,7 @@ export const argTypes = {
   disableAnimation: {
     type: { name: 'boolean', require: false },
     description: 'Disable the fade animation on show',
-    defaultValue: false,
+    defaultValue: true,
     control: {
       type: 'boolean',
     },

--- a/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
@@ -69,8 +69,19 @@
       in quia?
     </p>
     <div slot="actions" class="vtmn-modal_content_actions">
-      <VtmnButton variant="secondary">Go Back</VtmnButton>
-      <VtmnButton variant="primary">Yes, I understand</VtmnButton>
+      <VtmnButton
+        variant="secondary"
+        on:click={() => {
+          console.log('Go back');
+          show = false;
+        }}>Go Back</VtmnButton
+      >
+      <VtmnButton
+        variant="primary"
+        on:click={() => {
+          console.log('Yes, I understand'), (show = false);
+        }}>Yes, I understand</VtmnButton
+      >
     </div>
   </VtmnModal>
 </Story>

--- a/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
@@ -9,16 +9,16 @@
       defaultValue: 'Modal title',
       control: { type: 'text' },
     },
-    visible: {
+    show: {
       type: { name: 'boolean', required: true },
       description: 'Display the modal',
       defaultValue: 'false',
       control: {
-        visible: 'boolean',
+        type: 'boolean',
       },
     },
   };
-  let visible = false;
+  let show = false;
 </script>
 
 <Meta
@@ -31,16 +31,16 @@
 <Story name="Overview">
   <VtmnButton
     on:click={() => {
-      visible = true;
+      show = true;
     }}>Display modal</VtmnButton
   >
   <VtmnModal
     title="Modal title"
     aria-labelledby="vtmn-modal-title"
     aria-describedby="vtmn-modal-description"
-    {visible}
+    {show}
     on:cancel={() => {
-      visible = false;
+      show = false;
     }}
   >
     <p
@@ -90,16 +90,16 @@
 <Story name="Without actions">
   <VtmnButton
     on:click={() => {
-      visible = true;
+      show = true;
     }}>Display modal</VtmnButton
   >
   <VtmnModal
     title="Modal title"
     aria-labelledby="vtmn-modal-title"
     aria-describedby="vtmn-modal-description"
-    {visible}
+    {show}
     on:cancel={() => {
-      visible = false;
+      show = false;
     }}
   >
     <div

--- a/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
@@ -23,7 +23,7 @@
   >
   <VtmnModal
     title={args.title}
-    disableAnimation={args.disableAnimation}
+    animationDisabled={args.animationDisabled}
     aria-labelledby="vtmn-modal-title"
     aria-describedby="vtmn-modal-description"
     {show}
@@ -96,7 +96,7 @@
     title={args.title}
     aria-labelledby="vtmn-modal-title"
     aria-describedby="vtmn-modal-description"
-    disableAnimation={args.disableAnimation}
+    animationDisabled={args.animationDisabled}
     {show}
     on:cancel={() => {
       show = false;

--- a/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
@@ -1,23 +1,10 @@
 <script>
-  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import { Meta, Story } from '@storybook/addon-svelte-csf';
   import { VtmnModal, VtmnButton } from '@vtmn/svelte';
-  import { parameters } from '@vtmn/showcase-core/csf/components/overlays/modal.csf';
-  const argTypes = {
-    title: {
-      type: { name: 'string', required: true },
-      description: 'The printed title',
-      defaultValue: 'Modal title',
-      control: { type: 'text' },
-    },
-    show: {
-      type: { name: 'boolean', required: true },
-      description: 'Display the modal',
-      defaultValue: 'false',
-      control: {
-        type: 'boolean',
-      },
-    },
-  };
+  import {
+    parameters,
+    argTypes,
+  } from '@vtmn/showcase-core/csf/components/overlays/modal.csf';
   let show = false;
 </script>
 
@@ -28,14 +15,15 @@
   {parameters}
 />
 
-<Story name="Overview">
+<Story name="Overview" let:args>
   <VtmnButton
     on:click={() => {
       show = true;
     }}>Display modal</VtmnButton
   >
   <VtmnModal
-    title="Modal title"
+    title={args.title}
+    disableAnimation={args.disableAnimation}
     aria-labelledby="vtmn-modal-title"
     aria-describedby="vtmn-modal-description"
     {show}
@@ -87,16 +75,17 @@
   </VtmnModal>
 </Story>
 
-<Story name="Without actions">
+<Story name="Without actions" let:args>
   <VtmnButton
     on:click={() => {
       show = true;
     }}>Display modal</VtmnButton
   >
   <VtmnModal
-    title="Modal title"
+    title={args.title}
     aria-labelledby="vtmn-modal-title"
     aria-describedby="vtmn-modal-description"
+    disableAnimation={args.disableAnimation}
     {show}
     on:cancel={() => {
       show = false;

--- a/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnModal/VtmnModal.stories.svelte
@@ -1,0 +1,143 @@
+<script>
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import { VtmnModal, VtmnButton } from '@vtmn/svelte';
+  import { parameters } from '@vtmn/showcase-core/csf/components/overlays/modal.csf';
+  const argTypes = {
+    title: {
+      type: { name: 'string', required: true },
+      description: 'The printed title',
+      defaultValue: 'Modal title',
+      control: { type: 'text' },
+    },
+    visible: {
+      type: { name: 'boolean', required: true },
+      description: 'Display the modal',
+      defaultValue: 'false',
+      control: {
+        visible: 'boolean',
+      },
+    },
+  };
+  let visible = false;
+</script>
+
+<Meta
+  title="Components / Overlays / VtmnModal"
+  component={VtmnModal}
+  {argTypes}
+  {parameters}
+/>
+
+<Story name="Overview">
+  <VtmnButton
+    on:click={() => {
+      visible = true;
+    }}>Display modal</VtmnButton
+  >
+  <VtmnModal
+    title="Modal title"
+    aria-labelledby="vtmn-modal-title"
+    aria-describedby="vtmn-modal-description"
+    {visible}
+    on:cancel={() => {
+      visible = false;
+    }}
+  >
+    <p
+      slot="description"
+      id="vtmn-modal-description"
+      class="vtmn-modal_content_body--text"
+    >
+      Lorem ipsum dolor, sit amet consectetur adipisicing elit. Numquam,
+      assumenda? Asperiores rem nulla odit saepe dolores molestias
+      exercitationem accusamus perferendis est aut repudiandae optio vel dicta
+      reprehenderit ad, repellendus officiis cumque omnis labore in quia? Lorem
+      ipsum dolor, sit amet consectetur adipisicing elit. Numquam, assumenda?
+      Asperiores rem nulla odit saepe dolores molestias exercitationem accusamus
+      perferendis est aut repudiandae optio vel dicta reprehenderit ad,
+      repellendus officiis cumque omnis labore in quia? Lorem ipsum dolor, sit
+      amet consectetur adipisicing elit. Numquam, assumenda? Asperiores rem
+      nulla odit saepe dolores molestias exercitationem accusamus perferendis
+      est aut repudiandae optio vel dicta reprehenderit ad, repellendus officiis
+      cumque omnis labore in quia? Lorem ipsum dolor, sit amet consectetur
+      adipisicing elit. Numquam, assumenda? Asperiores rem nulla odit saepe
+      dolores molestias exercitationem accusamus perferendis est aut repudiandae
+      optio vel dicta reprehenderit ad, repellendus officiis cumque omnis labore
+      in quia? Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+      Numquam, assumenda? Asperiores rem nulla odit saepe dolores molestias
+      exercitationem accusamus perferendis est aut repudiandae optio vel dicta
+      reprehenderit ad, repellendus officiis cumque omnis labore in quia? Lorem
+      ipsum dolor, sit amet consectetur adipisicing elit. Numquam, assumenda?
+      Asperiores rem nulla odit saepe dolores molestias exercitationem accusamus
+      perferendis est aut repudiandae optio vel dicta reprehenderit ad,
+      repellendus officiis cumque omnis labore in quia? Lorem ipsum dolor, sit
+      amet consectetur adipisicing elit. Numquam, assumenda? Asperiores rem
+      nulla odit saepe dolores molestias exercitationem accusamus perferendis
+      est aut repudiandae optio vel dicta reprehenderit ad, repellendus officiis
+      cumque omnis labore in quia? Lorem ipsum dolor, sit amet consectetur
+      adipisicing elit. Numquam, assumenda? Asperiores rem nulla odit saepe
+      dolores molestias exercitationem accusamus perferendis est aut repudiandae
+      optio vel dicta reprehenderit ad, repellendus officiis cumque omnis labore
+      in quia?
+    </p>
+    <div slot="actions" class="vtmn-modal_content_actions">
+      <VtmnButton variant="secondary">Go Back</VtmnButton>
+      <VtmnButton variant="primary">Yes, I understand</VtmnButton>
+    </div>
+  </VtmnModal>
+</Story>
+
+<Story name="Without actions">
+  <VtmnButton
+    on:click={() => {
+      visible = true;
+    }}>Display modal</VtmnButton
+  >
+  <VtmnModal
+    title="Modal title"
+    aria-labelledby="vtmn-modal-title"
+    aria-describedby="vtmn-modal-description"
+    {visible}
+    on:cancel={() => {
+      visible = false;
+    }}
+  >
+    <div
+      slot="description"
+      id="vtmn-modal-description"
+      class="vtmn-modal_content_body--text"
+    >
+      Lorem ipsum dolor, sit amet consectetur adipisicing elit. Numquam,
+      assumenda? Asperiores rem nulla odit saepe dolores molestias
+      exercitationem accusamus perferendis est aut repudiandae optio vel dicta
+      reprehenderit ad, repellendus officiis cumque omnis labore in quia? Lorem
+      ipsum dolor, sit amet consectetur adipisicing elit. Numquam, assumenda?
+      Asperiores rem nulla odit saepe dolores molestias exercitationem accusamus
+      perferendis est aut repudiandae optio vel dicta reprehenderit ad,
+      repellendus officiis cumque omnis labore in quia? Lorem ipsum dolor, sit
+      amet consectetur adipisicing elit. Numquam, assumenda? Asperiores rem
+      nulla odit saepe dolores molestias exercitationem accusamus perferendis
+      est aut repudiandae optio vel dicta reprehenderit ad, repellendus officiis
+      cumque omnis labore in quia? Lorem ipsum dolor, sit amet consectetur
+      adipisicing elit. Numquam, assumenda? Asperiores rem nulla odit saepe
+      dolores molestias exercitationem accusamus perferendis est aut repudiandae
+      optio vel dicta reprehenderit ad, repellendus officiis cumque omnis labore
+      in quia? Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+      Numquam, assumenda? Asperiores rem nulla odit saepe dolores molestias
+      exercitationem accusamus perferendis est aut repudiandae optio vel dicta
+      reprehenderit ad, repellendus officiis cumque omnis labore in quia? Lorem
+      ipsum dolor, sit amet consectetur adipisicing elit. Numquam, assumenda?
+      Asperiores rem nulla odit saepe dolores molestias exercitationem accusamus
+      perferendis est aut repudiandae optio vel dicta reprehenderit ad,
+      repellendus officiis cumque omnis labore in quia? Lorem ipsum dolor, sit
+      amet consectetur adipisicing elit. Numquam, assumenda? Asperiores rem
+      nulla odit saepe dolores molestias exercitationem accusamus perferendis
+      est aut repudiandae optio vel dicta reprehenderit ad, repellendus officiis
+      cumque omnis labore in quia? Lorem ipsum dolor, sit amet consectetur
+      adipisicing elit. Numquam, assumenda? Asperiores rem nulla odit saepe
+      dolores molestias exercitationem accusamus perferendis est aut repudiandae
+      optio vel dicta reprehenderit ad, repellendus officiis cumque omnis labore
+      in quia?
+    </div>
+  </VtmnModal>
+</Story>

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -42,6 +42,7 @@
     "@vtmn/css-divider": "^0.1.21",
     "@vtmn/css-link": "^0.6.15",
     "@vtmn/css-list": "^0.2.17",
+    "@vtmn/css-modal": "^0.5.4",
     "@vtmn/css-popover": "^0.5.13",
     "@vtmn/css-rating": "^0.3.11",
     "@vtmn/css-tag": "^0.3.10",

--- a/packages/sources/svelte/rollup.config.js
+++ b/packages/sources/svelte/rollup.config.js
@@ -20,7 +20,7 @@ const src = {
     },
     {
       folder: 'overlays',
-      components: ['VtmnAlert', 'VtmnPopover'],
+      components: ['VtmnAlert', 'VtmnModal', 'VtmnPopover'],
     },
     {
       folder: 'selection-controls',

--- a/packages/sources/svelte/src/components/index.js
+++ b/packages/sources/svelte/src/components/index.js
@@ -16,6 +16,7 @@ export { default as VtmnTag } from './indicators/VtmnTag/VtmnTag.svelte';
 // Overlays
 export { default as VtmnAlert } from './overlays/VtmnAlert/VtmnAlert.svelte';
 export { vtmnAlertStore } from './overlays/VtmnAlert/vtmnAlertStore';
+export { default as VtmnModal } from './overlays/VtmnModal/VtmnModal.svelte';
 export { default as VtmnPopover } from './overlays/VtmnPopover/VtmnPopover.svelte';
 
 // Selection controls

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -20,7 +20,7 @@
    * @type {boolean} Enable the show animation.
    * Default true
    */
-  export let disableAnimation = false;
+  export let animationDisabled = false;
 
   let className = '';
   /**
@@ -28,7 +28,7 @@
    */
   export { className as class };
 
-  $: componentClass = cn('vtmn-modal', !disableAnimation && 'show', className);
+  $: componentClass = cn('vtmn-modal', !animationDisabled && 'show', className);
 
   const handleCancel = () => {
     dispatch('cancel', { show });

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -13,7 +13,7 @@
   /**
    * Display or hide the modal
    */
-  export let visible = false;
+  export let show = false;
 
   let className;
   /**
@@ -28,7 +28,7 @@
   };
 </script>
 
-{#if visible}
+{#if show}
   <div class={componentClass} role="dialog" aria-modal="true" {...$$restProps}>
     <div
       id="vtmn-modal-background"

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -6,30 +6,30 @@
   const dispatch = createEventDispatcher();
 
   /**
-   * Title of the modal
+   * @type {string} Title of the modal
    */
   export let title;
 
   /**
-   * Display or hide the modal
+   * @type {boolean} Display or hide the modal
    */
   export let show = false;
 
-  let className;
+  let className = '';
   /**
    * @type {string} Custom classes to apply to the component.
    */
   export { className as class };
 
-  $: componentClass = cn('vtmn-modal', className);
+  $: componentClass = cn('vtmn-modal', 'show', className);
 
   const handleCancel = () => {
-    dispatch('cancel');
+    dispatch('cancel', { show });
   };
 </script>
 
 {#if show}
-  <div class={componentClass} role="dialog" aria-modal="true" {...$$restProps}>
+  <div class={componentClass} role="dialog" aria-modal="true">
     <div
       id="vtmn-modal-background"
       class="vtmn-modal_background-overlay"

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -1,0 +1,63 @@
+<script>
+  import { cn } from '../../../utils/classnames';
+  import { VtmnButton } from '../../../index';
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
+  /**
+   * Title of the modal
+   */
+  export let title;
+
+  /**
+   * Display or hide the modal
+   */
+  export let visible = false;
+
+  let className;
+  /**
+   * @type {string} Custom classes to apply to the component.
+   */
+  export { className as class };
+
+  $: componentClass = cn('vtmn-modal', className);
+
+  const handleCancel = () => {
+    dispatch('cancel');
+  };
+</script>
+
+{#if visible}
+  <div class={componentClass} role="dialog" aria-modal="true" {...$$restProps}>
+    <div
+      id="vtmn-modal-background"
+      class="vtmn-modal_background-overlay"
+      on:click={handleCancel}
+    />
+    <div class="vtmn-modal_content">
+      <div class="vtmn-modal_content_title">
+        <span id="vtmn-modal-title" class="vtmn-modal_content_title--text"
+          >{title}</span
+        >
+        <VtmnButton
+          aria-label="close"
+          variant="ghost"
+          iconAlone="close-line"
+          on:click={handleCancel}
+        />
+      </div>
+      <div class="vtmn-modal_content_body">
+        <slot name="description" />
+        {#if $$slots.actions}
+          <div class="vtmn-modal_content_body--overflow-indicator" />
+        {/if}
+      </div>
+      <slot name="actions" />
+    </div>
+  </div>
+{/if}
+
+<style>
+  @import '@vtmn/modal';
+</style>

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -12,8 +12,15 @@
 
   /**
    * @type {boolean} Display or hide the modal
+   * Default false
    */
   export let show = false;
+
+  /**
+   * @type {boolean} Enable the show animation.
+   * Default true
+   */
+  export let disableAnimation = false;
 
   let className = '';
   /**
@@ -21,7 +28,7 @@
    */
   export { className as class };
 
-  $: componentClass = cn('vtmn-modal', 'show', className);
+  $: componentClass = cn('vtmn-modal', !disableAnimation && 'show', className);
 
   const handleCancel = () => {
     dispatch('cancel', { show });
@@ -29,7 +36,18 @@
 </script>
 
 {#if show}
-  <div class={componentClass} role="dialog" aria-modal="true">
+  <style>
+    body {
+      overflow: hidden;
+    }
+  </style>
+  <div
+    class={componentClass}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={$$restProps['aria-labelledby']}
+    aria-describedby={$$restProps['aria-describedby']}
+  >
     <div
       id="vtmn-modal-background"
       class="vtmn-modal_background-overlay"

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
@@ -53,6 +53,15 @@ describe('VtmnModal', () => {
       expect(getModal(container)).toBeVisible();
       expect(getModal(container)).toHaveClass('show');
     });
+    test('Should not have class show if disableAnimation is true', () => {
+      const { container } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+        disableAnimation: true,
+      });
+      expect(getModal(container)).toBeVisible();
+      expect(getModal(container)).not.toHaveClass('show');
+    });
     test('Should pass custom class to modal', () => {
       const { container } = render(VtmnModal, {
         show: true,

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
@@ -1,0 +1,154 @@
+import '@testing-library/jest-dom';
+
+import { fireEvent, render } from '@testing-library/svelte';
+
+import VtmnModal from '../VtmnModal.svelte';
+import VtmnModalWithDescription from './VtmnModalWithDescription.svelte';
+import VtmnModalWithSlots from './VtmnModalWithSlots.svelte';
+
+const expectedCancelOnElement = async (
+  element,
+  component,
+  expectedClickCount,
+) => {
+  const handleClick = jest.fn();
+  component.$on('cancel', handleClick);
+  await fireEvent.click(element);
+  expect(handleClick).toHaveBeenCalledTimes(expectedClickCount);
+};
+
+describe('VtmnModal', () => {
+  const getModal = (container) =>
+    container.getElementsByClassName('vtmn-modal')[0];
+  const getOverlay = (container) =>
+    container.getElementsByClassName('vtmn-modal_background-overlay')[0];
+  const getCloseButton = (container) =>
+    container.querySelector('button[aria-label="close"]');
+  const getOverFlow = (container) =>
+    container.getElementsByClassName(
+      'vtmn-modal_content_body--overflow-indicator',
+    )[0];
+
+  const getSlotDescription = (container) =>
+    container.querySelector('[slot="description"]');
+  const getSlotActions = (container) =>
+    container.querySelector('[slot="actions"]');
+
+  describe('show = false', () => {
+    test('Should have no content', () => {
+      const { container } = render(VtmnModal, {
+        show: false,
+        title: 'Unit-test',
+      });
+      expect(getModal(container)).toBeUndefined();
+    });
+  });
+
+  describe('show = true', () => {
+    test('Should have no content', () => {
+      const { container } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      expect(getModal(container)).toBeVisible();
+      expect(getModal(container)).toHaveClass('show');
+    });
+    test('Should pass custom class to modal', () => {
+      const { container } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+        class: 'unit-test',
+      });
+      expect(getModal(container)).toHaveClass('unit-test');
+    });
+    test('Should trigger cancel if user click on overlay', async () => {
+      const { container, component } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      await expectedCancelOnElement(getOverlay(container), component, 1);
+    });
+
+    test('Should have title if propertie title are defined', () => {
+      const { getByText } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      expect(getByText('Unit-test')).toBeVisible();
+      expect(getByText('Unit-test')).toHaveClass(
+        'vtmn-modal_content_title--text',
+      );
+    });
+    test('Should have a cancel button', () => {
+      const { container } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      expect(getCloseButton(container)).toBeVisible();
+    });
+    test('Should trigger cancel on click close button', async () => {
+      const { container, component } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      await expectedCancelOnElement(getCloseButton(container), component, 1);
+    });
+
+    test('Should not have a slot description', () => {
+      const { container } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      expect(getSlotDescription(container)).toBeNull();
+    });
+
+    test('Should not have a slot actions', () => {
+      const { container } = render(VtmnModal, {
+        show: true,
+        title: 'Unit-test',
+      });
+      expect(getSlotActions(container)).toBeNull();
+    });
+
+    describe('With slot description', () => {
+      test('Should have a slot description', () => {
+        const { container } = render(VtmnModalWithDescription, {
+          show: true,
+          title: 'Unit-test',
+        });
+        expect(getSlotDescription(container)).toBeVisible();
+      });
+      test('Should not have a slot description', () => {
+        const { container } = render(VtmnModalWithDescription, {
+          show: true,
+          title: 'Unit-test',
+        });
+        expect(getSlotActions(container)).toBeNull();
+      });
+      test("Should not have a class 'vtmn-modal_content_body--overflow-indicator'", () => {
+        const { container } = render(VtmnModalWithDescription, {
+          show: true,
+          title: 'Unit-test',
+        });
+        expect(getOverFlow(container)).toBeUndefined();
+      });
+    });
+
+    describe('With slot description and actions', () => {
+      test("Should have a class 'vtmn-modal_content_body--overflow-indicator'", () => {
+        const { container } = render(VtmnModalWithSlots, {
+          show: true,
+          title: 'Unit-test',
+        });
+        expect(getOverFlow(container)).toBeVisible();
+      });
+      test('Should have a slot actions', () => {
+        const { container } = render(VtmnModalWithSlots, {
+          show: true,
+          title: 'Unit-test',
+        });
+        expect(getSlotActions(container)).toBeVisible();
+      });
+    });
+  });
+});

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
@@ -53,11 +53,11 @@ describe('VtmnModal', () => {
       expect(getModal(container)).toBeVisible();
       expect(getModal(container)).toHaveClass('show');
     });
-    test('Should not have class show if disableAnimation is true', () => {
+    test('Should not have class show if animationDisabled is true', () => {
       const { container } = render(VtmnModal, {
         show: true,
         title: 'Unit-test',
-        disableAnimation: true,
+        animationDisabled: true,
       });
       expect(getModal(container)).toBeVisible();
       expect(getModal(container)).not.toHaveClass('show');

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModalWithDescription.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModalWithDescription.svelte
@@ -1,0 +1,7 @@
+<script>
+  import VtmnModal from '../VtmnModal.svelte';
+</script>
+
+<VtmnModal {...$$restProps}>
+  <p slot="description">description</p>
+</VtmnModal>

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModalWithSlots.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModalWithSlots.svelte
@@ -1,0 +1,8 @@
+<script>
+  import VtmnModal from '../VtmnModal.svelte';
+</script>
+
+<VtmnModal {...$$restProps}>
+  <p slot="description">description</p>
+  <div slot="actions">actions</div>
+</VtmnModal>


### PR DESCRIPTION
Add a new component svelte `VtmnModal`

- Add tests on the component
- Workaround for a css issue (#1039)
- Add `animation` properties set at `true` by default. You can disable the show animation. We have some issues with this one on chrome.