### PR TITLE
fix(@vtmn/css): button line-height + primary-reversed border

### DIFF
--- a/packages/sources/css/src/components/actions/button/src/index.css
+++ b/packages/sources/css/src/components/actions/button/src/index.css
@@ -15,6 +15,7 @@
   position: relative;
   height: rem(48px);
   border: 0;
+  line-height: 1;
   width: max-content;
   padding: rem(14px) rem(24px);
   font-family: var(--vtmn-typo_font-family);
@@ -71,7 +72,7 @@
 
 /* Primary reversed button */
 .vtmn-btn_variant--primary-reversed {
-  box-shadow: inset 0 0 0 rem(2px) transparent;
+  box-shadow: none;
   background-color: var(
     --vtmn-semantic-color_background-brand-primary-reversed
   );
@@ -83,22 +84,19 @@
   background-color: var(
     --vtmn-semantic-color_hover-tertiary-reversed-transparent
   );
-  box-shadow: inset 0 0 0 rem(2px)
-    var(--vtmn-semantic-color_border-primary-reversed);
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary);
 }
 
 .vtmn-btn_variant--primary-reversed:not(:disabled):active {
   background-color: var(
     --vtmn-semantic-color_active-brand-reversed-transparent
   );
-  box-shadow: inset 0 0 0 rem(2px)
-    var(--vtmn-semantic-color_border-primary-reversed);
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary);
 }
 
 .vtmn-btn_variant--primary-reversed:not(:disabled):focus-visible {
   outline: none;
-  box-shadow: inset 0 0 0 rem(2px)
-      var(--vtmn-semantic-color_border-primary-reversed),
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary),
     0 0 0 rem(4px) var(--vtmn-semantic-color_border-primary),
     0 0 0 rem(6px) var(--vtmn-semantic-color_border-primary-reversed);
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add `line-height: 1;` for `button` component to have a better alignment with icons
- `primary-reversed` border color changed from `vtmn-semantic-color_border-primary-reversed` to `vtmn-semantic-color_border-primary` 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

