### PR TITLE
feat(@vtmn/svelte): add `VtmnSnackbar` component

### DIFF
--- a/packages/showcases/core/csf/components/overlays/snackbar.csf.js
+++ b/packages/showcases/core/csf/components/overlays/snackbar.csf.js
@@ -11,7 +11,7 @@ export const parameters = {
 export const argTypes = {
   content: {
     type: { name: 'string', required: true },
-    description: 'Text display on the snackbar',
+    description: 'Text displayed on the snackbar',
     defaultValue: 'This is the content of a snackbar',
     control: { type: 'text' },
   },

--- a/packages/showcases/core/csf/components/overlays/snackbar.csf.js
+++ b/packages/showcases/core/csf/components/overlays/snackbar.csf.js
@@ -7,3 +7,37 @@ export const parameters = {
     url: 'https://www.figma.com/file/zDZIyayUlr1yTWrsi7cFoo/?node-id=2796%3A12600',
   },
 };
+
+export const argTypes = {
+  content: {
+    type: { name: 'string', required: true },
+    description: 'Text display on the snackbar',
+    defaultValue: 'This is the content of a snackbar',
+    control: { type: 'text' },
+  },
+  show: {
+    type: { name: 'boolean', required: true },
+    description: 'Display the snackbar',
+    defaultValue: false,
+    control: {
+      type: 'boolean',
+    },
+  },
+  timeout: {
+    type: { name: 'number', require: false },
+    description: 'Timeout before the snackbar disappear',
+    defaultValue: 5000,
+    control: {
+      type: 'number',
+      min: 0,
+    },
+  },
+  displayCloseButton: {
+    type: { name: 'boolean', required: true },
+    description: 'Show close button',
+    defaultValue: false,
+    control: {
+      type: 'boolean',
+    },
+  },
+};

--- a/packages/showcases/core/csf/components/overlays/snackbar.csf.js
+++ b/packages/showcases/core/csf/components/overlays/snackbar.csf.js
@@ -15,29 +15,20 @@ export const argTypes = {
     defaultValue: 'This is the content of a snackbar',
     control: { type: 'text' },
   },
-  show: {
-    type: { name: 'boolean', required: true },
-    description: 'Display the snackbar',
-    defaultValue: false,
-    control: {
-      type: 'boolean',
-    },
-  },
-  timeout: {
-    type: { name: 'number', require: false },
-    description: 'Timeout before the snackbar disappear',
-    defaultValue: 5000,
-    control: {
-      type: 'number',
-      min: 0,
-    },
-  },
-  displayCloseButton: {
+  withCloseButton: {
     type: { name: 'boolean', required: true },
     description: 'Show close button',
     defaultValue: false,
     control: {
       type: 'boolean',
+    },
+  },
+  actionLabel: {
+    type: { name: 'string', required: false },
+    describe: 'Label of the action. If set, it display action button',
+    defaultValue: 'Action',
+    control: {
+      type: 'text',
     },
   },
 };

--- a/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
@@ -1,0 +1,45 @@
+<script>
+  import { Meta, Story } from '@storybook/addon-svelte-csf';
+  import { VtmnSnackbar, VtmnButton } from '@vtmn/svelte';
+  import {
+    parameters,
+    argTypes,
+  } from '@vtmn/showcase-core/csf/components/overlays/snackbar.csf';
+  let show = false;
+</script>
+
+<Meta
+  title="Components / Overlays / VtmnSnackbar"
+  component={VtmnSnackbar}
+  {argTypes}
+  {parameters}
+/>
+
+<Story name="Overview" let:args>
+  <VtmnButton
+    on:click={() => {
+      show = true;
+    }}>Display snackbar</VtmnButton
+  >
+  <VtmnSnackbar {...args} bind:show />
+</Story>
+
+<Story name="With close button" let:args>
+  <VtmnButton
+    on:click={() => {
+      show = true;
+    }}>Display snackbar</VtmnButton
+  >
+  <VtmnSnackbar {...args} bind:show displayCloseButton />
+</Story>
+
+<Story name="With action button" let:args>
+  <VtmnButton
+    on:click={() => {
+      show = true;
+    }}>Display snackbar</VtmnButton
+  >
+  <VtmnSnackbar {...args} bind:show displayCloseButton>
+    <VtmnButton variant="ghost-reversed" size="small">Action</VtmnButton>
+  </VtmnSnackbar>
+</Story>

--- a/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
@@ -1,11 +1,10 @@
 <script>
-  import { Meta, Story } from '@storybook/addon-svelte-csf';
-  import { VtmnSnackbar, VtmnButton } from '@vtmn/svelte';
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import { vtmnSnackbarStore, VtmnSnackbar, VtmnButton } from '@vtmn/svelte';
   import {
     parameters,
     argTypes,
   } from '@vtmn/showcase-core/csf/components/overlays/snackbar.csf';
-  let show = false;
 </script>
 
 <Meta
@@ -15,31 +14,22 @@
   {parameters}
 />
 
-<Story name="Overview" let:args>
+<Template let:args>
   <VtmnButton
     on:click={() => {
-      show = true;
+      console.log('Display snackbar');
+      vtmnSnackbarStore.send({
+        ...args,
+        action: {
+          label: args.actionLabel,
+          execute: () => {
+            console.log('Execute action');
+          },
+        },
+      });
     }}>Display snackbar</VtmnButton
   >
-  <VtmnSnackbar {...args} bind:show />
-</Story>
+  <VtmnSnackbar />
+</Template>
 
-<Story name="With close button" let:args>
-  <VtmnButton
-    on:click={() => {
-      show = true;
-    }}>Display snackbar</VtmnButton
-  >
-  <VtmnSnackbar {...args} bind:show displayCloseButton />
-</Story>
-
-<Story name="With action button" let:args>
-  <VtmnButton
-    on:click={() => {
-      show = true;
-    }}>Display snackbar</VtmnButton
-  >
-  <VtmnSnackbar {...args} bind:show displayCloseButton>
-    <VtmnButton variant="ghost-reversed" size="small">Action</VtmnButton>
-  </VtmnSnackbar>
-</Story>
+<Story name="Overview" />

--- a/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
@@ -17,7 +17,6 @@
 <Template let:args>
   <VtmnButton
     on:click={() => {
-      console.log('Display snackbar');
       vtmnSnackbarStore.send({
         ...args,
         action: {

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -46,6 +46,7 @@
     "@vtmn/css-rating": "^0.3.11",
     "@vtmn/css-tag": "^0.3.10",
     "@vtmn/css-text-input": "^0.13.14",
+    "@vtmn/css-snackbar": "^0.5.13",
     "@vtmn/css-toggle": "^0.6.12",
     "@vtmn/icons": "^0.12.1"
   },

--- a/packages/sources/svelte/rollup.config.js
+++ b/packages/sources/svelte/rollup.config.js
@@ -20,7 +20,7 @@ const src = {
     },
     {
       folder: 'overlays',
-      components: ['VtmnAlert', 'VtmnPopover'],
+      components: ['VtmnAlert', 'VtmnPopover', 'VtmnSnackbar'],
     },
     {
       folder: 'selection-controls',

--- a/packages/sources/svelte/src/components/index.js
+++ b/packages/sources/svelte/src/components/index.js
@@ -18,6 +18,7 @@ export { default as VtmnAlert } from './overlays/VtmnAlert/VtmnAlert.svelte';
 export { vtmnAlertStore } from './overlays/VtmnAlert/vtmnAlertStore';
 export { default as VtmnPopover } from './overlays/VtmnPopover/VtmnPopover.svelte';
 export { default as VtmnSnackbar } from './overlays/VtmnSnackbar/VtmnSnackbar.svelte';
+export { vtmnSnackbarStore } from './overlays/VtmnSnackbar/vtmnSnackbarStore';
 
 // Selection controls
 export { default as VtmnCheckbox } from './selection-controls/VtmnCheckbox/VtmnCheckbox.svelte';

--- a/packages/sources/svelte/src/components/index.js
+++ b/packages/sources/svelte/src/components/index.js
@@ -17,6 +17,7 @@ export { default as VtmnTag } from './indicators/VtmnTag/VtmnTag.svelte';
 export { default as VtmnAlert } from './overlays/VtmnAlert/VtmnAlert.svelte';
 export { vtmnAlertStore } from './overlays/VtmnAlert/vtmnAlertStore';
 export { default as VtmnPopover } from './overlays/VtmnPopover/VtmnPopover.svelte';
+export { default as VtmnSnackbar } from './overlays/VtmnSnackbar/VtmnSnackbar.svelte';
 
 // Selection controls
 export { default as VtmnCheckbox } from './selection-controls/VtmnCheckbox/VtmnCheckbox.svelte';

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/README.md
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/README.md
@@ -1,6 +1,7 @@
 # Quick start
 
-You need to add `@vtmn/svelte` on your `package.json`
+You need to add `@vtmn/svelte` and `@vtmn/icon` on your `package.json`
+For `@vtmn/icon` please refer to its Readme.
 
 ```
 npm install @vtmn/svelte
@@ -10,7 +11,7 @@ Now, you can use `VtmnSnackbar` on your app.
 
 # How it works
 
-First, you need to place the `VtmnSnackbar` component preferably at your
+First, you need to place the `VtmnSnackbar` component on the top of your application
 
 `app.svelte`
 

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/README.md
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/README.md
@@ -1,0 +1,47 @@
+# Quick start
+
+You need to add `@vtmn/svelte` on your `package.json`
+
+```
+npm install @vtmn/svelte
+```
+
+Now, you can use `VtmnSnackbar` on your app.
+
+# How it works
+
+First, you need to place the `VtmnSnackbar` component preferably at your
+
+`app.svelte`
+
+```svelte
+<script>
+  import { VtmnSnackbar } from '@vtmn/svelte';
+</script>
+
+<VtmnSnackbar />
+```
+
+Once the initialization is done, it is now possible to pass snackbar to the component with the `send` method anywhere in the application.
+
+`component.svelte`
+
+```svelte
+<script>
+  import { vtmnSnackbarStore, VtmnButton } from '@vtmn/svelte';
+  const handleClick = () => {
+    vtmnSnackbarStore.send({
+      content: 'Hello world',
+      withCloseButton: true,
+      action: {
+        label: 'Action',
+        execute: () => {
+          console.log('Hello world for the action');
+        },
+      },
+    });
+  };
+</script>
+
+<VtmnButton on:click={handleClick}>Send toast</VtmnButton>
+```

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbar.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbar.svelte
@@ -1,70 +1,17 @@
 <script>
-  import { cn } from '../../../utils/classnames';
-  import { VtmnButton } from '../../..';
-
-  /**
-   * @type {string} text write into the snackbar
-   */
-  export let content;
-
-  /**
-   * @type {boolean} display the snackbar
-   * Default false
-   */
-  export let show = false;
-
-  /**
-   * @type {number} timeout before the snackbar disappear
-   * Default 5000
-   */
-  export let timeout = 5000;
-
-  /**
-   * @type {boolean} display close button
-   * Default false
-   */
-  export let displayCloseButton = false;
-
-  let className = '';
-  /**
-   * @type {string} Custom classes to apply to the component.
-   */
-  export { className as class };
-
-  let timeoutId;
-  const closeHandler = () => {
-    timeoutId && clearTimeout(timeoutId);
-    show = false;
-  };
-
-  $: componentClass = cn('vtmn-snackbar', 'show', className);
-  $: {
-    if (show && timeout) {
-      timeoutId = setTimeout(() => {
-        show = false;
-      }, timeout);
-    }
-  }
+  import { VTMN_SNACKBAR_TIMEOUT } from './enum';
+  import VtmnSnackbarItem from './VtmnSnackbarItem.svelte';
+  import { vtmnSnackbarStore } from './vtmnSnackbarStore';
+  const closeHandler = () => vtmnSnackbarStore.close();
 </script>
 
-{#if show}
-  <div class={componentClass} role="status">
-    <div class="vtmn-snackbar_content">
-      {content}
-    </div>
-    <slot />
-    {#if displayCloseButton}
-      <VtmnButton
-        on:click={closeHandler}
-        aria-label="Close alert"
-        variant="ghost-reversed"
-        size="small"
-        iconAlone="close-line"
-      />
-    {/if}
-  </div>
-{/if}
-
-<style>
-  @import '@vtmn/css-snackbar';
-</style>
+{#each $vtmnSnackbarStore as snackbar (snackbar.id)}
+  <VtmnSnackbarItem
+    timeout={VTMN_SNACKBAR_TIMEOUT}
+    content={snackbar.content}
+    withCloseButton={snackbar.withCloseButton}
+    actionLabel={snackbar.action.label}
+    on:action={snackbar.action.execute}
+    on:close={closeHandler}
+  />
+{/each}

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbar.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbar.svelte
@@ -1,0 +1,70 @@
+<script>
+  import { cn } from '../../../utils/classnames';
+  import { VtmnButton } from '../../..';
+
+  /**
+   * @type {string} text write into the snackbar
+   */
+  export let content;
+
+  /**
+   * @type {boolean} display the snackbar
+   * Default false
+   */
+  export let show = false;
+
+  /**
+   * @type {number} timeout before the snackbar disappear
+   * Default 5000
+   */
+  export let timeout = 5000;
+
+  /**
+   * @type {boolean} display close button
+   * Default false
+   */
+  export let displayCloseButton = false;
+
+  let className = '';
+  /**
+   * @type {string} Custom classes to apply to the component.
+   */
+  export { className as class };
+
+  let timeoutId;
+  const closeHandler = () => {
+    timeoutId && clearTimeout(timeoutId);
+    show = false;
+  };
+
+  $: componentClass = cn('vtmn-snackbar', 'show', className);
+  $: {
+    if (show && timeout) {
+      timeoutId = setTimeout(() => {
+        show = false;
+      }, timeout);
+    }
+  }
+</script>
+
+{#if show}
+  <div class={componentClass} role="status">
+    <div class="vtmn-snackbar_content">
+      {content}
+    </div>
+    <slot />
+    {#if displayCloseButton}
+      <VtmnButton
+        on:click={closeHandler}
+        aria-label="Close alert"
+        variant="ghost-reversed"
+        size="small"
+        iconAlone="close-line"
+      />
+    {/if}
+  </div>
+{/if}
+
+<style>
+  @import '@vtmn/css-snackbar';
+</style>

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
@@ -1,0 +1,69 @@
+<script>
+  import { cn } from '../../../utils/classnames';
+  import { VtmnButton } from '../../..';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+
+  /**
+   * @type {string} text write into the snackbar
+   */
+  export let content;
+
+  /**
+   * @type {boolean} display close button
+   * Default false
+   */
+  export let withCloseButton = false;
+
+  /**
+   * @type {string} label of the action. If defined, it display an action button.
+   */
+  export let actionLabel = '';
+
+  /**
+   * @type {number} timeout before the component execute the close action.
+   */
+  export let timeout;
+
+  let className = '';
+  /**
+   * @type {string} Custom classes to apply to the component.
+   */
+  export { className as class };
+
+  let timeoutId;
+
+  const dispatch = createEventDispatcher();
+  const closeHandler = () => dispatch('close');
+  const actionHandler = () => dispatch('action');
+  const _clearTimeout = () => timeoutId && clearTimeout(timeoutId);
+  const _setTimeout = () => (timeoutId = setTimeout(closeHandler, timeout));
+
+  onDestroy(_clearTimeout);
+  onMount(_setTimeout);
+
+  $: componentClass = cn('vtmn-snackbar', 'show', className);
+</script>
+
+<div class={componentClass} role="status">
+  <div class="vtmn-snackbar_content">
+    {content}
+  </div>
+  {#if actionLabel}
+    <VtmnButton on:click={actionHandler} variant="ghost-reversed" size="small">
+      {actionLabel}
+    </VtmnButton>
+  {/if}
+  {#if withCloseButton}
+    <VtmnButton
+      on:click={closeHandler}
+      aria-label="Close alert"
+      variant="ghost-reversed"
+      size="small"
+      iconAlone="close-line"
+    />
+  {/if}
+</div>
+
+<style>
+  @import '@vtmn/css-snackbar';
+</style>

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
@@ -10,7 +10,7 @@
 
   /**
    * @type {boolean} display close button
-   * Default false
+   * @defaultValue 'false'
    */
   export let withCloseButton = false;
 

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/enum.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/enum.js
@@ -1,0 +1,1 @@
+export const VTMN_SNACKBAR_TIMEOUT = 5000;

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbar.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbar.spec.js
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom';
+
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+import VtmnSnackbar from '../VtmnSnackbar.svelte';
+import VtmnSnackbarWithSlots from './VtmnSnackbarWithSlots.svelte';
+
+describe('VtmnSnackbar', () => {
+  const getSnackbar = (container) =>
+    container.getElementsByClassName('vtmn-snackbar')[0];
+  describe('show = false', () => {
+    test('Should have no content', () => {
+      const { container } = render(VtmnSnackbar, {
+        show: false,
+        content: 'Unit-test',
+      });
+      expect(getSnackbar(container)).toBeUndefined();
+    });
+  });
+
+  describe('show = true', () => {
+    test("Should have a snackbar with class 'vtmn-snackbar' and 'show'", () => {
+      const { container } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+      });
+      expect(getSnackbar(container)).toBeVisible();
+      expect(getSnackbar(container)).toHaveClass('show');
+    });
+    test('Should apply custom class to snackbar', () => {
+      const { container } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+        class: 'custom-class',
+      });
+      expect(getSnackbar(container)).toHaveClass('custom-class');
+    });
+    test('Should display the content on the snackbar', () => {
+      const { getByText } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+      });
+      expect(getByText('Unit-test')).toBeVisible();
+      expect(getByText('Unit-test')).toHaveClass('vtmn-snackbar_content');
+    });
+    test('Should disappear after the timeout expire', async () => {
+      const { container } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+        timeout: 100,
+      });
+      await waitFor(() => expect(getSnackbar(container)).toBeUndefined(), {
+        timeout: 200,
+      });
+    });
+    test('Should disappear after the timeout expire', async () => {
+      const { container } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+        timeout: 100,
+      });
+      await waitFor(() => expect(getSnackbar(container)).toBeUndefined(), {
+        timeout: 200,
+      });
+    });
+    test('Should trigger event on click button', async () => {
+      const { getByLabelText } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+        displayCloseButton: true,
+      });
+      expect(getByLabelText('Close alert')).toBeVisible();
+      expect(getByLabelText('Close alert')).toHaveClass('vtmn-btn');
+    });
+    test('Should trigger event on click button', async () => {
+      const { getByLabelText, container } = render(VtmnSnackbar, {
+        show: true,
+        content: 'Unit-test',
+        displayCloseButton: true,
+      });
+      await fireEvent.click(getByLabelText('Close alert'));
+      expect(getSnackbar(container)).toBeUndefined();
+    });
+
+    test('Should show the slot', () => {
+      const { getByText } = render(VtmnSnackbarWithSlots, {
+        show: true,
+        content: 'Unit-test',
+      });
+      expect(getByText('Action')).toBeVisible();
+    });
+  });
+});

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbar.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbar.spec.js
@@ -2,92 +2,75 @@ import '@testing-library/jest-dom';
 
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 
-import VtmnSnackbar from '../VtmnSnackbar.svelte';
-import VtmnSnackbarWithSlots from './VtmnSnackbarWithSlots.svelte';
+import VtmnSnackbarItem from '../VtmnSnackbarItem.svelte';
 
 describe('VtmnSnackbar', () => {
+  const timeout = 1000;
   const getSnackbar = (container) =>
     container.getElementsByClassName('vtmn-snackbar')[0];
-  describe('show = false', () => {
-    test('Should have no content', () => {
-      const { container } = render(VtmnSnackbar, {
-        show: false,
-        content: 'Unit-test',
-      });
-      expect(getSnackbar(container)).toBeUndefined();
+
+  test("Should have a snackbar with class 'vtmn-snackbar' and 'show'", () => {
+    const { container } = render(VtmnSnackbarItem, {
+      content: 'Unit-test',
+      timeout,
     });
+    expect(getSnackbar(container)).toBeVisible();
+    expect(getSnackbar(container)).toHaveClass('show');
   });
 
-  describe('show = true', () => {
-    test("Should have a snackbar with class 'vtmn-snackbar' and 'show'", () => {
-      const { container } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-      });
-      expect(getSnackbar(container)).toBeVisible();
-      expect(getSnackbar(container)).toHaveClass('show');
+  test('Should apply custom class to snackbar', () => {
+    const { container } = render(VtmnSnackbarItem, {
+      content: 'Unit-test',
+      class: 'custom-class',
+      timeout,
     });
-    test('Should apply custom class to snackbar', () => {
-      const { container } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-        class: 'custom-class',
-      });
-      expect(getSnackbar(container)).toHaveClass('custom-class');
+    expect(getSnackbar(container)).toHaveClass('custom-class');
+  });
+  test('Should display the content on the snackbar', () => {
+    const { getByText } = render(VtmnSnackbarItem, {
+      content: 'Unit-test',
+      timeout,
     });
-    test('Should display the content on the snackbar', () => {
-      const { getByText } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-      });
-      expect(getByText('Unit-test')).toBeVisible();
-      expect(getByText('Unit-test')).toHaveClass('vtmn-snackbar_content');
+    expect(getByText('Unit-test')).toBeVisible();
+    expect(getByText('Unit-test')).toHaveClass('vtmn-snackbar_content');
+  });
+  test('Should disappear after the timeout expire', async () => {
+    const handleClick = jest.fn();
+    const { component } = render(VtmnSnackbarItem, {
+      content: 'Unit-test',
+      timeout: 50,
     });
-    test('Should disappear after the timeout expire', async () => {
-      const { container } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-        timeout: 100,
-      });
-      await waitFor(() => expect(getSnackbar(container)).toBeUndefined(), {
-        timeout: 200,
-      });
+    component.$on('close', handleClick);
+    expect(handleClick).toHaveBeenCalledTimes(0);
+    await waitFor(() => expect(handleClick).toHaveBeenCalledTimes(1), {
+      timeout: 100,
     });
-    test('Should disappear after the timeout expire', async () => {
-      const { container } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-        timeout: 100,
-      });
-      await waitFor(() => expect(getSnackbar(container)).toBeUndefined(), {
-        timeout: 200,
-      });
+  });
+  test('Should trigger event on click button close', async () => {
+    const handleClick = jest.fn();
+    const { getByLabelText, component } = render(VtmnSnackbarItem, {
+      content: 'Unit-test',
+      withCloseButton: true,
+      timeout,
     });
-    test('Should trigger event on click button', async () => {
-      const { getByLabelText } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-        displayCloseButton: true,
-      });
-      expect(getByLabelText('Close alert')).toBeVisible();
-      expect(getByLabelText('Close alert')).toHaveClass('vtmn-btn');
-    });
-    test('Should trigger event on click button', async () => {
-      const { getByLabelText, container } = render(VtmnSnackbar, {
-        show: true,
-        content: 'Unit-test',
-        displayCloseButton: true,
-      });
-      await fireEvent.click(getByLabelText('Close alert'));
-      expect(getSnackbar(container)).toBeUndefined();
-    });
+    component.$on('close', handleClick);
+    expect(getByLabelText('Close alert')).toBeVisible();
+    expect(getByLabelText('Close alert')).toHaveClass('vtmn-btn');
+    await fireEvent.click(getByLabelText('Close alert'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
 
-    test('Should show the slot', () => {
-      const { getByText } = render(VtmnSnackbarWithSlots, {
-        show: true,
-        content: 'Unit-test',
-      });
-      expect(getByText('Action')).toBeVisible();
+  test('Should trigger event on click button action', async () => {
+    const handleClick = jest.fn();
+    const { getByText, component } = render(VtmnSnackbarItem, {
+      content: 'Unit-test',
+      actionLabel: 'Action',
+      timeout,
     });
+    component.$on('action', handleClick);
+    expect(getByText('Action')).toBeVisible();
+    expect(getByText('Action')).toHaveClass('vtmn-btn');
+    await fireEvent.click(getByText('Action'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbarWithSlots.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbarWithSlots.svelte
@@ -1,8 +1,0 @@
-<script>
-  import { VtmnButton } from '../../../';
-  import VtmnSnackbar from '../VtmnSnackbar.svelte';
-</script>
-
-<VtmnSnackbar {...$$restProps}>
-  <VtmnButton variant="ghost-reversed" size="small">Action</VtmnButton>
-</VtmnSnackbar>

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbarWithSlots.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/test/VtmnSnackbarWithSlots.svelte
@@ -1,0 +1,8 @@
+<script>
+  import { VtmnButton } from '../../../';
+  import VtmnSnackbar from '../VtmnSnackbar.svelte';
+</script>
+
+<VtmnSnackbar {...$$restProps}>
+  <VtmnButton variant="ghost-reversed" size="small">Action</VtmnButton>
+</VtmnSnackbar>

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/vtmnSnackbarStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/vtmnSnackbarStore.js
@@ -1,0 +1,26 @@
+import { writable } from 'svelte/store';
+
+class VtmnSnackbarStore {
+  constructor() {
+    this._snackbar = writable([]);
+    this._id = 0;
+  }
+
+  get newId() {
+    return ++this._id;
+  }
+
+  send({ content, withCloseButton, action }) {
+    this._snackbar.set([{ content, withCloseButton, action, id: this.newId }]);
+  }
+
+  close() {
+    this._snackbar.set([]);
+  }
+
+  subscribe(run) {
+    return this._snackbar.subscribe(run);
+  }
+}
+
+export const vtmnSnackbarStore = new VtmnSnackbarStore();


### PR DESCRIPTION
Add `VtmnSnackbar` component for svelte

How it works :

- VtmnSnackbar need to be put on the main body of the application.
- VtmnSnackbarItem are used by the VtmnSnackbar to display toasts
- A store vtmnSnackbarStore can be imported everywhere on the application, you can use the function `vtmnSnackbarStore.send({ content: 'Hello world!', })` to send toast to diplay
```svelte
vtmnSnackbarStore.send({ 
  content: 'Hello world!', 
  withCloseButton: true,
  action: {
    label: 'action',
    execute: () => {
      console.log('Trigger action');
    },
  },
});
```

<img width="681" alt="image" src="https://user-images.githubusercontent.com/2856778/157989437-23ac74d6-e850-4e05-8af5-057e55322659.png">
