### PR TITLE
feat(@vtmn/svelte): add `VtmnAlert` component

### DIFF
--- a/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
@@ -1,0 +1,59 @@
+<script>
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+  import { vtmnAlertStore, VtmnAlert, VtmnButton } from '@vtmn/svelte';
+  import { parameters } from '@vtmn/showcase-core/csf/components/overlays/alert.csf';
+  const argTypes = {
+    title: {
+      type: { name: 'string', required: true },
+      description: 'Title of the modal',
+      defaultValue: 'This is the title of the alert',
+      control: { type: 'text' },
+    },
+    description: {
+      type: { name: 'string', required: true },
+      description: 'This is the description of the alert',
+      defaultValue:
+        'Alert are used to draw the users attention to an important information',
+      control: { type: 'text' },
+    },
+    withCloseButton: {
+      type: { name: 'boolean', required: true },
+      description: 'Show close button',
+      defaultValue: false,
+      control: {
+        type: 'boolean',
+      },
+    },
+    variant: {
+      type: { name: 'boolean', required: false },
+      description: 'Variant of the alert',
+      defaultValue: 'info',
+      control: {
+        type: 'select',
+        options: ['info', 'success', 'warning', 'danger'],
+      },
+    },
+  };
+</script>
+
+<Meta
+  title="Components / Overlays / VtmnAlert"
+  component={VtmnAlert}
+  {argTypes}
+  {parameters}
+/>
+
+<Template let:args>
+  <VtmnButton
+    on:click={() => {
+      vtmnAlertStore.send({
+        ...args,
+        'aria-labelledby': 'Storybook',
+        'aria-describedby': args.variant,
+      });
+    }}>Display alert</VtmnButton
+  >
+  <VtmnAlert {...args} />
+</Template>
+
+<Story name="Overview" />

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@vtmn/css-accordion": "^0.2.11",
+    "@vtmn/css-alert": "^0.6.13",
     "@vtmn/css-badge": "^0.10.12",
     "@vtmn/css-button": "^0.11.14",
     "@vtmn/css-chip": "^0.6.13",

--- a/packages/sources/svelte/rollup.config.js
+++ b/packages/sources/svelte/rollup.config.js
@@ -20,7 +20,7 @@ const src = {
     },
     {
       folder: 'overlays',
-      components: ['VtmnPopover'],
+      components: ['VtmnAlert', 'VtmnPopover'],
     },
     {
       folder: 'selection-controls',

--- a/packages/sources/svelte/src/components/index.js
+++ b/packages/sources/svelte/src/components/index.js
@@ -13,6 +13,8 @@ export { default as VtmnTag } from './indicators/VtmnTag/VtmnTag.svelte';
 // Navigation
 
 // Overlays
+export { default as VtmnAlert } from './overlays/VtmnAlert/VtmnAlert.svelte';
+export { vtmnAlertStore } from './overlays/VtmnAlert/vtmnAlertStore';
 export { default as VtmnPopover } from './overlays/VtmnPopover/VtmnPopover.svelte';
 
 // Selection controls

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/README.md
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/README.md
@@ -1,0 +1,47 @@
+# Quick start
+
+You need to add `@vtmn/svelte` and `@vtmn/icon` on your `package.json`.
+For `@vtmn/icon` please refer to its Readme.
+
+```
+npm install @vtmn/svelte
+```
+
+Now, you can use `VtmnAlert` on your app.
+
+# How it works
+
+First, you need to place the `VtmnAlert` component on the top of your application
+
+`app.svelte`
+
+```svelte
+<script>
+  import { VtmnAlert } from '@vtmn/svelte';
+</script>
+
+<VtmnAlert />
+```
+
+Once the initialization is done, it is now possible to pass toasts to the component with the `send` method anywhere in the application.
+
+`component.svelte`
+
+```svelte
+<script>
+  import { vtmnAlertStore, VtmnButton } from '@vtmn/svelte';
+  const handleClick = () => {
+    vtmnAlertStore.send({
+      'aria-labelledby': 'Storybook',
+      'aria-describedby': args.variant,
+      description:
+        'Alert are used to draw the users attention to an important information',
+      title: 'This is the title of the alert',
+      variant: 'info',
+      withCloseButton: true,
+    });
+  };
+</script>
+
+<VtmnButton on:click={handleClick}>Send toast</VtmnButton>
+```

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlert.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlert.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { VTMN_ALERT_TIMEOUT } from './enums';
+  import { vtmnAlertStore } from './vtmnAlertStore';
+  import VtmnAlertItem from './VtmnAlertItem.svelte';
+  const closeHandler = (id) => {
+    vtmnAlertStore.close(id);
+  };
+</script>
+
+{#each $vtmnAlertStore.slice(0, 1) as alert (alert.id)}
+  <VtmnAlertItem
+    on:close={() => {
+      closeHandler(alert.id);
+    }}
+    timeout={VTMN_ALERT_TIMEOUT}
+    {...alert}
+  />
+{/each}

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -5,7 +5,7 @@
   import { VTMN_ALERT_VARIANT } from './enums';
 
   /**
-   * @type {'info' | 'success' | 'danger' | 'warning' } variant of the alert
+   * @type {'info'|'success'|'danger'|'warning'} variant of the alert
    * @defaultValue info
    */
   export let variant = VTMN_ALERT_VARIANT.INFO;

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -1,0 +1,77 @@
+<script>
+  import { VtmnButton } from '../../..';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import { cn } from '../../../utils/classnames';
+  import { VTMN_ALERT_VARIANT } from './enums';
+
+  /**
+   * @type {'info' | 'success' | 'danger' | 'warning' } variant of the alert
+   * @defaultValue info
+   */
+  export let variant = VTMN_ALERT_VARIANT.INFO;
+
+  /**
+   * @type {string} title of the alert
+   */
+  export let title;
+
+  /**
+   * @type {string} description of the alert
+   */
+  export let description = '';
+
+  /**
+   * @type {boolean} display with a close button
+   */
+  export let withCloseButton = false;
+
+  /**
+   * @type {number} time (ms) before the alert disappears
+   */
+  export let timeout;
+
+  let className = '';
+  /**
+   * @type {string} Custom classes to apply to the component.
+   */
+  export { className as class };
+  let timeoutId;
+  const dispatch = createEventDispatcher();
+  const closeHandler = () => dispatch('close');
+  const _clearTimeout = () => timeoutId && clearTimeout(timeoutId);
+  const _setTimeout = () => (timeoutId = setTimeout(closeHandler, timeout));
+  onDestroy(_clearTimeout);
+  onMount(_setTimeout);
+  $: componentClass = cn(
+    'vtmn-alert',
+    'show',
+    variant && `vtmn-alert_variant--${variant}`,
+    className,
+  );
+</script>
+
+<div class={componentClass} role="alert" tabindex="-1" {...$$restProps}>
+  <div class="vtmn-alert_content" role="document">
+    <div id="alert-title" class="vtmn-alert_content-title">
+      {title}
+      {#if withCloseButton}
+        <VtmnButton
+          aria-label="Close alert"
+          variant="ghost-reversed"
+          size="small"
+          iconAlone="close-line"
+          on:click={closeHandler}
+        />
+      {/if}
+    </div>
+    {#if description}
+      <p id="alert-text" class="vtmn-alert_content-description">
+        {description}
+      </p>
+    {/if}
+  </div>
+</div>
+
+<style>
+  @import '@vtmn/css-alert';
+</style>

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/enums.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/enums.js
@@ -1,0 +1,8 @@
+export const VTMN_ALERT_TIMEOUT = 8000;
+
+export const VTMN_ALERT_VARIANT = {
+  INFO: 'info',
+  WARNING: 'warning',
+  SUCCESS: 'success',
+  DANGER: 'danger',
+};

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
@@ -1,0 +1,184 @@
+import '@testing-library/jest-dom';
+
+import { fireEvent, waitFor, render } from '@testing-library/svelte';
+
+import VtmnAlertItem from '../VtmnAlertItem.svelte';
+
+const timeout = 5000;
+
+describe('VtmnAlertItem', () => {
+  const getAlert = (container) =>
+    container.getElementsByClassName('vtmn-alert')[0];
+  const getDescription = (container) =>
+    container.getElementsByClassName('vtmn-alert_content-description')[0];
+  const expectedCloseOnElement = async (
+    element,
+    component,
+    expectedClickCount,
+  ) => {
+    const handleClick = jest.fn();
+    component.$on('close', handleClick);
+    await fireEvent.click(element);
+    expect(handleClick).toHaveBeenCalledTimes(expectedClickCount);
+  };
+
+  test("Should be visible with class 'vtmn-alert' and 'show'", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+    });
+    expect(getAlert(container)).toBeVisible();
+    expect(getAlert(container)).toHaveClass('vtmn-alert', 'show');
+  });
+
+  // Si aucun variant est passé, il doit avoir le variant info par défaut
+  test("Should have class 'vtmn-alert_variant--info' if no variant are selected", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+    });
+    expect(getAlert(container)).toHaveClass('vtmn-alert_variant--info');
+  });
+
+  // Show have class vtmn-alert_variant--info if variant = info
+  test("Should have class 'vtmn-alert_variant--info' if variant = info", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      variant: 'info',
+    });
+    expect(getAlert(container)).toHaveClass('vtmn-alert_variant--info');
+  });
+
+  // Show have class vtmn-alert_variant--success if variant = success
+  test("Should have class 'vtmn-alert_variant--success' if variant = success", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      variant: 'success',
+    });
+    expect(getAlert(container)).toHaveClass('vtmn-alert_variant--success');
+  });
+
+  // Show have class vtmn-alert_variant--danger if variant = danger
+  test("Should have class 'vtmn-alert_variant--danger' if variant = danger", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      variant: 'danger',
+    });
+    expect(getAlert(container)).toHaveClass('vtmn-alert_variant--danger');
+  });
+
+  // Show have class vtmn-alert_variant--warning if variant = warning
+  test("Should have class 'vtmn-alert_variant--warning' if variant = warning", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      variant: 'warning',
+    });
+    expect(getAlert(container)).toHaveClass('vtmn-alert_variant--warning');
+  });
+
+  // On doit pouvoir lui passer des custom class
+  test('Should pass custom class into the component', () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      class: 'custom-class',
+    });
+    expect(getAlert(container)).toHaveClass('custom-class');
+  });
+
+  // On doit pouvoir lui passer des attribus 'aria-labelledby'
+  test('Should pass attributes into the component', () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      'aria-labelledby': 'unit-tests',
+    });
+    expect(getAlert(container)).toHaveAttribute(
+      'aria-labelledby',
+      'unit-tests',
+    );
+  });
+
+  // Si un title est défini, il doit être affiché et avoir la classe 'vtmn-alert_content-title'
+  test('Should pass attributes into the component', () => {
+    const { getByText } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      'aria-labelledby': 'unit-tests',
+    });
+    expect(getByText('Alert unit-test')).toBeVisible();
+    expect(getByText('Alert unit-test')).toHaveClass(
+      'vtmn-alert_content-title',
+    );
+  });
+
+  // Par défaut, s'il n'y a pas de description, il n'y a pas de class 'vtmn-alert_content-description'
+  test("Should not have class 'vtmn-alert_content-description' if no description are provide", () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+    });
+    expect(getDescription(container)).toBeUndefined();
+  });
+
+  // Si description est à true, il doit y avoir une class 'vtmn-alert_content-description'
+  test("Should not have class 'vtmn-alert_content-description' if no description are provide", () => {
+    const { getByText } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      description: 'Description',
+    });
+    expect(getByText('Description')).toBeVisible();
+    expect(getByText('Description')).toHaveClass(
+      'vtmn-alert_content-description',
+    );
+  });
+
+  // Par défaut il n'y a pas de bouton
+  test('Should not have a close button by default', () => {
+    const { container } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+    });
+    expect(container.getElementsByClassName('vtmn-btn')[0]).toBeUndefined();
+  });
+
+  // Si with close button est affiché, il doit y avoir un bouton
+  test('Should have a close button if withCloseButton = true', () => {
+    const { getByLabelText } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      withCloseButton: true,
+    });
+    expect(getByLabelText('Close alert')).toBeVisible();
+  });
+
+  // Au click sur le bouton, une action close doit être lancée
+  test('Should trigger close action on click on button', async () => {
+    const { getByLabelText, component } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout,
+      withCloseButton: true,
+    });
+    await expectedCloseOnElement(getByLabelText('Close alert'), component, 1);
+  });
+
+  // Après la fin du timeout, une action close doit être lancée
+  test('Should trigger automatically close action when the timeout are done', async () => {
+    const handleClick = jest.fn();
+    const { getByLabelText, component } = render(VtmnAlertItem, {
+      title: 'Alert unit-test',
+      timeout: 50,
+      withCloseButton: true,
+    });
+    component.$on('close', handleClick);
+    expect(handleClick).toHaveBeenCalledTimes(0);
+    await waitFor(() => expect(handleClick).toHaveBeenCalledTimes(1), {
+      timeout: 100,
+    });
+  });
+});

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
@@ -31,7 +31,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('vtmn-alert', 'show');
   });
 
-  // Si aucun variant est passé, il doit avoir le variant info par défaut
   test("Should have class 'vtmn-alert_variant--info' if no variant are selected", () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -40,7 +39,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('vtmn-alert_variant--info');
   });
 
-  // Show have class vtmn-alert_variant--info if variant = info
   test("Should have class 'vtmn-alert_variant--info' if variant = info", () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -50,7 +48,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('vtmn-alert_variant--info');
   });
 
-  // Show have class vtmn-alert_variant--success if variant = success
   test("Should have class 'vtmn-alert_variant--success' if variant = success", () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -60,7 +57,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('vtmn-alert_variant--success');
   });
 
-  // Show have class vtmn-alert_variant--danger if variant = danger
   test("Should have class 'vtmn-alert_variant--danger' if variant = danger", () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -70,7 +66,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('vtmn-alert_variant--danger');
   });
 
-  // Show have class vtmn-alert_variant--warning if variant = warning
   test("Should have class 'vtmn-alert_variant--warning' if variant = warning", () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -80,7 +75,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('vtmn-alert_variant--warning');
   });
 
-  // On doit pouvoir lui passer des custom class
   test('Should pass custom class into the component', () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -90,7 +84,6 @@ describe('VtmnAlertItem', () => {
     expect(getAlert(container)).toHaveClass('custom-class');
   });
 
-  // On doit pouvoir lui passer des attribus 'aria-labelledby'
   test('Should pass attributes into the component', () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -103,7 +96,6 @@ describe('VtmnAlertItem', () => {
     );
   });
 
-  // Si un title est défini, il doit être affiché et avoir la classe 'vtmn-alert_content-title'
   test('Should pass attributes into the component', () => {
     const { getByText } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -116,7 +108,6 @@ describe('VtmnAlertItem', () => {
     );
   });
 
-  // Par défaut, s'il n'y a pas de description, il n'y a pas de class 'vtmn-alert_content-description'
   test("Should not have class 'vtmn-alert_content-description' if no description are provide", () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -125,7 +116,6 @@ describe('VtmnAlertItem', () => {
     expect(getDescription(container)).toBeUndefined();
   });
 
-  // Si description est à true, il doit y avoir une class 'vtmn-alert_content-description'
   test("Should not have class 'vtmn-alert_content-description' if no description are provide", () => {
     const { getByText } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -138,7 +128,6 @@ describe('VtmnAlertItem', () => {
     );
   });
 
-  // Par défaut il n'y a pas de bouton
   test('Should not have a close button by default', () => {
     const { container } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -147,7 +136,6 @@ describe('VtmnAlertItem', () => {
     expect(container.getElementsByClassName('vtmn-btn')[0]).toBeUndefined();
   });
 
-  // Si with close button est affiché, il doit y avoir un bouton
   test('Should have a close button if withCloseButton = true', () => {
     const { getByLabelText } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -157,7 +145,6 @@ describe('VtmnAlertItem', () => {
     expect(getByLabelText('Close alert')).toBeVisible();
   });
 
-  // Au click sur le bouton, une action close doit être lancée
   test('Should trigger close action on click on button', async () => {
     const { getByLabelText, component } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
@@ -167,7 +154,6 @@ describe('VtmnAlertItem', () => {
     await expectedCloseOnElement(getByLabelText('Close alert'), component, 1);
   });
 
-  // Après la fin du timeout, une action close doit être lancée
   test('Should trigger automatically close action when the timeout are done', async () => {
     const handleClick = jest.fn();
     const { getByLabelText, component } = render(VtmnAlertItem, {

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
@@ -1,0 +1,39 @@
+import { writable } from 'svelte/store';
+
+class VtmnAlertStore {
+  constructor() {
+    this._alerts = writable([]);
+    this._id = 0;
+  }
+
+  get newId() {
+    return ++this._id;
+  }
+
+  send({ variant, title, description, withCloseButton, ...attributes }) {
+    this._alerts.update((state) => [
+      ...state,
+      {
+        ...attributes,
+        variant,
+        title,
+        description,
+        withCloseButton,
+        id: this.newId,
+      },
+    ]);
+  }
+
+  close(alertId) {
+    this._alerts.update((n) => {
+      const removedToast = n.filter((i) => i.id !== alertId);
+      return removedToast;
+    });
+  }
+
+  subscribe(run) {
+    return this._alerts.subscribe(run);
+  }
+}
+
+export const vtmnAlertStore = new VtmnAlertStore();


### PR DESCRIPTION
Create a new `VtmnAlert` component for svelte

How it works :

- VtmnAlert need to be put on the main body of the application.
- VtmnAlertItem are used by the VtmnAlert to display toasts
- A store vtmnAlertStore can be imported everywhere on the application, you can use the function `vtmnAlertStore.send({ title: 'Hello world!' })` to send alert to display

```svelte
vtmnAlertStore.send({
        'title': 'This is the title of the alert',
        'description': 'Alert are used to draw the users attention to an important information',
        'withCloseButton': true,
        'variant': 'info',
        'aria-labelledby': 'Storybook',
        'aria-describedby': args.variant,
      });
```

The component wait 8 seconds before display the next alert and so one ...
We need to up all elements on an array. The trick here is to take the first element of the array and use the id for the key.
If we don't do that, the same div are use for each key and all alert share the same timeout.

![image](https://user-images.githubusercontent.com/2856778/158224078-3046a645-b2d2-4f00-bac5-216fc5382ae8.png)
