### PR TITLE
docs(@vtmn/svelte): add readme plugin for storybook

### DIFF
--- a/packages/showcases/svelte/.storybook/main.js
+++ b/packages/showcases/svelte/.storybook/main.js
@@ -9,6 +9,7 @@ module.exports = {
     '@storybook/addon-a11y',
     '@whitespace/storybook-addon-html',
     'storybook-addon-designs',
+    'storybook-readme'
   ],
   features: {
     postcss: false,

--- a/packages/showcases/svelte/.storybook/preview.js
+++ b/packages/showcases/svelte/.storybook/preview.js
@@ -3,10 +3,12 @@ import { withDesign } from 'storybook-addon-designs';
 import backgrounds from '@vtmn/showcase-core/addons/backgrounds.json';
 import viewports from '@vtmn/showcase-core/addons/viewports.json';
 import DivDecorator from './DivDecorator.svelte';
+import { addReadme } from 'storybook-readme/html';
+
 import '@vtmn/css';
 import '@vtmn/icons/dist/vitamix/font/vitamix.css';
 
-export const decorators = [() => DivDecorator, withDesign];
+export const decorators = [() => DivDecorator, withDesign, addReadme];
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -20,4 +22,7 @@ export const parameters = {
   viewport: {
     viewports,
   },
+  readme: {
+    codeTheme: 'a11y-dark'
+  }
 };

--- a/packages/showcases/svelte/package.json
+++ b/packages/showcases/svelte/package.json
@@ -30,6 +30,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "storybook-addon-designs": "^6.0.0",
+    "storybook-readme": "^5.0.9",
     "svelte": "^3.46.3",
     "svelte-loader": "^3.1.2"
   },

--- a/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
@@ -2,6 +2,8 @@
   import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
   import { vtmnAlertStore, VtmnAlert, VtmnButton } from '@vtmn/svelte';
   import { parameters } from '@vtmn/showcase-core/csf/components/overlays/alert.csf';
+  import README from '@vtmn/svelte/src/components/overlays/VtmnAlert/README.md';
+
   const argTypes = {
     title: {
       type: { name: 'string', required: true },
@@ -40,7 +42,13 @@
   title="Components / Overlays / VtmnAlert"
   component={VtmnAlert}
   {argTypes}
-  {parameters}
+  parameters={{
+    ...parameters,
+    readme: {
+      sidebar: README,
+      readme: README,
+    },
+  }}
 />
 
 <Template let:args>

--- a/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnSnackbar/VtmnSnackbar.stories.svelte
@@ -5,13 +5,20 @@
     parameters,
     argTypes,
   } from '@vtmn/showcase-core/csf/components/overlays/snackbar.csf';
+  import README from '@vtmn/svelte/src/components/overlays/VtmnSnackbar/README.md';
 </script>
 
 <Meta
   title="Components / Overlays / VtmnSnackbar"
   component={VtmnSnackbar}
   {argTypes}
-  {parameters}
+  parameters={{
+    ...parameters,
+    readme: {
+      sidebar: README,
+      readme: README,
+    },
+  }}
 />
 
 <Template let:args>

--- a/packages/showcases/svelte/stories/components/overlays/VtmnToast/VtmnToast.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnToast/VtmnToast.stories.svelte
@@ -5,13 +5,20 @@
     parameters,
     argTypes,
   } from '@vtmn/showcase-core/csf/components/overlays/toast.csf';
+  import README from '@vtmn/svelte/src/components/overlays/VtmnToast/README.md';
 </script>
 
 <Meta
   title="Components / Overlays / VtmnToast"
   component={VtmnToast}
   {argTypes}
-  {parameters}
+  parameters={{
+    ...parameters,
+    readme: {
+      sidebar: README,
+      readme: README,
+    },
+  }}
 />
 
 <Template let:args>

--- a/packages/showcases/svelte/stories/components/selection-controls/VtmnChip/VtmnChip.stories.svelte
+++ b/packages/showcases/svelte/stories/components/selection-controls/VtmnChip/VtmnChip.stories.svelte
@@ -5,12 +5,19 @@
     parameters,
     argTypes,
   } from '@vtmn/showcase-core/csf/components/selection-controls/chip.csf';
+  import README from '@vtmn/svelte/src/components/selection-controls/VtmnChip/README.md';
 </script>
 
 <Meta
   title="Components / Selection controls / VtmnChip"
   component={VtmnChip}
-  {parameters}
+  parameters={{
+    ...parameters,
+    readme: {
+      sidebar: README,
+      readme: README,
+    },
+  }}
   {argTypes}
 />
 

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/README.md
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/README.md
@@ -15,7 +15,7 @@ First, you need to place the `VtmnAlert` component on the top of your applicatio
 
 `app.svelte`
 
-```svelte
+```javascript
 <script>
   import { VtmnAlert } from '@vtmn/svelte';
 </script>
@@ -27,7 +27,7 @@ Once the initialization is done, it is now possible to pass toasts to the compon
 
 `component.svelte`
 
-```svelte
+```javascript
 <script>
   import { vtmnAlertStore, VtmnButton } from '@vtmn/svelte';
   const handleClick = () => {

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/README.md
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/README.md
@@ -15,7 +15,7 @@ First, you need to place the `VtmnSnackbar` component on the top of your applica
 
 `app.svelte`
 
-```svelte
+```javascript
 <script>
   import { VtmnSnackbar } from '@vtmn/svelte';
 </script>
@@ -27,7 +27,7 @@ Once the initialization is done, it is now possible to pass snackbar to the comp
 
 `component.svelte`
 
-```svelte
+```javascript
 <script>
   import { vtmnSnackbarStore, VtmnButton } from '@vtmn/svelte';
   const handleClick = () => {

--- a/packages/sources/svelte/src/components/overlays/VtmnToast/README.md
+++ b/packages/sources/svelte/src/components/overlays/VtmnToast/README.md
@@ -15,7 +15,7 @@ First, you need to place the `VtmnToast` component on the top of your applicatio
 
 `app.svelte`
 
-```svelte
+```javascript
 <script>
   import { VtmnToast } from '@vtmn/svelte';
 </script>
@@ -27,7 +27,7 @@ Once the initialization is done, it is now possible to pass toasts to the compon
 
 `component.svelte`
 
-```svelte
+```javascript
 <script>
   import { vtmnToastStore, VtmnButton } from '@vtmn/svelte';
 

--- a/packages/sources/svelte/src/components/selection-controls/VtmnChip/README.md
+++ b/packages/sources/svelte/src/components/selection-controls/VtmnChip/README.md
@@ -8,7 +8,7 @@ npm install @vtmn/svelte
 
 Now, you can use `VtmnChip` on your svelte file with
 
-```svelte
+```javascript
 <script>
   import { VtmnChip } from '@vtmn/svelte';
 </script>


### PR DESCRIPTION
Add readme-plugin for storybook svelte :  
- Apply by default `11y-dark` theme
- Add README.md Alert / Snackbar / Toast / Chip

![image](https://user-images.githubusercontent.com/2856778/158790210-0807349d-9ff8-4262-b6c3-59c4f3c78138.png)