### PR TITLE
fix(@vtmn/svelte): apply font-size on class + story tag with icon

### DIFF
--- a/packages/showcases/svelte/stories/components/indicators/VtmnTag/VtmnTag.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnTag/VtmnTag.stories.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
-  import { VtmnTag } from '@vtmn/svelte';
+  import { VtmnTag, VtmnIcon } from '@vtmn/svelte';
   import {
     parameters,
     argTypes,
@@ -26,3 +26,10 @@
 </Template>
 
 <Story name="Overview" args={{ variant: 'accent' }} />
+
+<Story name="With icon" let:args>
+  <VtmnTag {...args}>
+    <VtmnIcon value="leaf-fill" />
+    {args.slot}
+  </VtmnTag>
+</Story>

--- a/packages/sources/svelte/src/guidelines/iconography/VtmnIcon/VtmnIcon.svelte
+++ b/packages/sources/svelte/src/guidelines/iconography/VtmnIcon/VtmnIcon.svelte
@@ -44,10 +44,12 @@
     }
   };
 
-  $: componentClass = cn(`vtmx-${value}`, className);
+  $: componentClass = cn(`vtmx-${value}`, 'vtmn-icon-size', className);
   $: componentStyle = objectToStyle({
-    color: `var(--vtmn-semantic-color_${retrieveSemanticColor(variant)})`,
-    'font-size': `${size}px`,
+    '--vtmn-icon-semantic-color': `var(--vtmn-semantic-color_${retrieveSemanticColor(
+      variant,
+    )})`,
+    '--vtmn-icon-size': `${size}px`,
   });
 </script>
 
@@ -55,4 +57,8 @@
 
 <style>
   @import '@vtmn/icons/dist/vitamix/font/vitamix.css';
+  .vtmn-icon-size {
+    color: var(--vtmn-icon-semantic-color);
+    font-size: var(--vtmn-icon-size);
+  }
 </style>


### PR DESCRIPTION
Some enhancement + fix on svelte

- Add a story with tag + icon
- VtmnIcon doesn't apply the size on the style but, with a class with a var. More efficient for the weight of class. (same for the color)