### PR TITLE
fix(@vtmn/react): bad props type given to DOM in `VtmnTextInput`

### DIFF
--- a/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
@@ -90,6 +90,9 @@ export const VtmnTextInput = ({
   onIconClick,
   ...props
 }: VtmnTextInputProps) => {
+  const propsToString = Object.keys(props).map((propKey) =>
+    props[propKey].toString(),
+  );
   return (
     <>
       {labelText && (
@@ -110,7 +113,7 @@ export const VtmnTextInput = ({
           aria-describedby={
             (helperText && `${identifier}-helper-text`) || undefined
           }
-          {...props}
+          {...propsToString}
         />
       ) : (
         <div className="vtmn-text-input_container">
@@ -129,7 +132,7 @@ export const VtmnTextInput = ({
             aria-describedby={
               (helperText && `${identifier}-helper-text`) || undefined
             }
-            {...props}
+            {...propsToString}
           />
           {icon && <VtmnIcon value={icon} size={20} onClick={onIconClick} />}
         </div>


### PR DESCRIPTION
## Context
<!--- Why is this change required? What problem does it solve? -->
We pass all the component props to the DOM as we receive it.
Some of them are in boolean type which causes a console warning.
(See the screenshots bellow)

<!--- If it fixes an opened issue, please link to the issue here. -->


## Changes description
<!--- Describe your changes in details. -->
We simply cast all the props as string before passing them to the DOM.


## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
<img width="1552" alt="Capture d’écran 2022-03-23 à 10 50 36" src="https://user-images.githubusercontent.com/6609866/159674300-7ee849e5-dd08-4467-a48a-528ac2b99a54.png">


