### PR TITLE
fix(@vtmn/css): modal indicator overflow

### DIFF
--- a/packages/showcases/css/stories/components/overlays/modal/examples/demo.runscript.js
+++ b/packages/showcases/css/stories/components/overlays/modal/examples/demo.runscript.js
@@ -38,7 +38,6 @@ window.addEventListener('DOMContentLoaded', (event) => {
             exercitationem accusamus perferendis est aut repudiandae optio vel dicta
             reprehenderit ad, repellendus officiis cumque omnis labore in quia?
           </p>
-          <div class="vtmn-modal_content_body--overflow-indicator"></div>
         </div>
         <div class="vtmn-modal_content_actions">
           <button id="btn-close-modal-2" class="vtmn-btn vtmn-btn_variant--secondary">Got Back</button>

--- a/packages/showcases/css/stories/components/overlays/modal/examples/overview.html
+++ b/packages/showcases/css/stories/components/overlays/modal/examples/overview.html
@@ -4,6 +4,7 @@
       position: static;
       transform: translate(0, 0);
     }
+  }
 </style>
 
 <div class="block">

--- a/packages/showcases/css/stories/components/overlays/modal/examples/overview.html
+++ b/packages/showcases/css/stories/components/overlays/modal/examples/overview.html
@@ -64,7 +64,6 @@
           dicta reprehenderit ad, repellendus officiis cumque omnis labore in
           quia?
         </p>
-        <div class="vtmn-modal_content_body--overflow-indicator"></div>
       </div>
       <div class="vtmn-modal_content_actions">
         <button class="vtmn-btn vtmn-btn_variant--secondary">Got Back</button>

--- a/packages/sources/css/src/components/overlays/modal/src/index.css
+++ b/packages/sources/css/src/components/overlays/modal/src/index.css
@@ -76,6 +76,7 @@
 .vtmn-modal_content_body {
   margin: rem(16px) 0;
   overflow: auto;
+  position: relative;
 }
 
 .vtmn-modal_content_body--text {
@@ -88,25 +89,26 @@
 }
 
 .vtmn-modal_content_body--overflow-indicator {
-  position: absolute;
-  bottom: 5.5rem;
-  left: rem(32px);
-  right: rem(32px);
-  height: 4rem;
+  position: sticky;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   background: linear-gradient(
     180deg,
     hsl(
-      var(--vtmn-semantic-color_background-primary--h)
-        var(--vtmn-semantic-color_background-primary--s)
-        var(--vtmn-semantic-color_background-primary--l) / 0%
-    ),
+        var(--vtmn-semantic-color_background-primary--h)
+          var(--vtmn-semantic-color_background-primary--s)
+          var(--vtmn-semantic-color_background-primary--l) / 0%
+      )
+      80%,
     hsl(
-      var(--vtmn-semantic-color_background-primary--h)
-        var(--vtmn-semantic-color_background-primary--s)
-        var(--vtmn-semantic-color_background-primary--l) / 80%
-    )
+        var(--vtmn-semantic-color_background-primary--h)
+          var(--vtmn-semantic-color_background-primary--s)
+          var(--vtmn-semantic-color_background-primary--l) / 95%
+      )
+      100%
   );
-  overflow: auto;
   pointer-events: none;
 }
 

--- a/packages/sources/css/src/components/overlays/modal/src/index.css
+++ b/packages/sources/css/src/components/overlays/modal/src/index.css
@@ -76,7 +76,6 @@
 .vtmn-modal_content_body {
   margin: rem(16px) 0;
   overflow-y: auto;
-  position: relative;
 }
 
 .vtmn-modal_content_body--text {

--- a/packages/sources/css/src/components/overlays/modal/src/index.css
+++ b/packages/sources/css/src/components/overlays/modal/src/index.css
@@ -75,7 +75,7 @@
 
 .vtmn-modal_content_body {
   margin: rem(16px) 0;
-  overflow: auto;
+  overflow-y: auto;
   position: relative;
 }
 
@@ -86,30 +86,6 @@
   line-height: rem(24px);
   align-self: flex-start;
   text-align: left;
-}
-
-.vtmn-modal_content_body--overflow-indicator {
-  position: sticky;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: linear-gradient(
-    180deg,
-    hsl(
-        var(--vtmn-semantic-color_background-primary--h)
-          var(--vtmn-semantic-color_background-primary--s)
-          var(--vtmn-semantic-color_background-primary--l) / 0%
-      )
-      80%,
-    hsl(
-        var(--vtmn-semantic-color_background-primary--h)
-          var(--vtmn-semantic-color_background-primary--s)
-          var(--vtmn-semantic-color_background-primary--l) / 95%
-      )
-      100%
-  );
-  pointer-events: none;
 }
 
 .vtmn-modal_content_actions {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- The class `vtmn-modal_content_body--overflow-indicator` and its associated tag

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- The overflow indicator is buggy when there are no buttons in the modal, so it has been removed until a correct solution is found

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes, you can remove the `<div>` tag associated with the class `vtmn-modal_content_body--overflow-indicator`.
- It won't break your modal if you don't remove it
