### PR TITLE
feat(@vtmn-react): cast props to string in every components

### DIFF
--- a/packages/sources/react/src/components/actions/VtmnButton/VtmnButton.tsx
+++ b/packages/sources/react/src/components/actions/VtmnButton/VtmnButton.tsx
@@ -3,6 +3,7 @@ import '@vtmn/css-button/dist/index-with-vars.css';
 import { VtmnButtonVariant, VtmnButtonSize } from './types';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnButtonProps
   extends React.ComponentPropsWithoutRef<'button'> {
@@ -67,7 +68,7 @@ export const VtmnButton = React.forwardRef<HTMLButtonElement, VtmnButtonProps>(
         } ${!iconAlone && iconLeft ? 'vtmn-btn--icon-left' : ''} ${
           !iconAlone && iconRight ? 'vtmn-btn--icon-right' : ''
         } ${iconAlone ? 'vtmn-btn--icon-alone' : ''}`}
-        {...props}
+        {...objectValuesToString(props)}
       >
         {!iconAlone && iconLeft && (
           <VtmnIcon

--- a/packages/sources/react/src/components/actions/VtmnLink/VtmnLink.tsx
+++ b/packages/sources/react/src/components/actions/VtmnLink/VtmnLink.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import '@vtmn/css-link/dist/index-with-vars.css';
 import clsx from 'clsx';
 import { VtmnLinkSize } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnLinkProps extends React.ComponentPropsWithoutRef<'a'> {
   /**
@@ -48,7 +49,7 @@ export const VtmnLink = ({
         { 'vtmn-link--icon-along': standalone && iconAlong },
         className,
       )}
-      {...props}
+      {...objectValuesToString(props)}
     >
       {children}
     </a>

--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import '@vtmn/css-select/dist/index-with-vars.css';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnSelectProps extends React.ComponentPropsWithRef<'select'> {
   error?: boolean;
@@ -34,7 +35,7 @@ export const VtmnSelect = ({
           'vtmn-select--error': error,
         })}
         aria-describedby={hasErrorText ? errorTextId : undefined}
-        {...props}
+        {...objectValuesToString(props)}
       >
         {options.map((option) => option)}
       </select>

--- a/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
@@ -3,6 +3,7 @@ import '@vtmn/css-text-input/dist/index-with-vars.css';
 import clsx from 'clsx';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
+import { objectValuesToString } from '../../../utils/object';
 
 type VtmnTextInputAdditionalProps = {
   /**
@@ -90,9 +91,6 @@ export const VtmnTextInput = ({
   onIconClick,
   ...props
 }: VtmnTextInputProps) => {
-  const propsToString = Object.keys(props).map((propKey) =>
-    props[propKey].toString(),
-  );
   return (
     <>
       {labelText && (
@@ -113,7 +111,7 @@ export const VtmnTextInput = ({
           aria-describedby={
             (helperText && `${identifier}-helper-text`) || undefined
           }
-          {...propsToString}
+          {...objectValuesToString(props)}
         />
       ) : (
         <div className="vtmn-text-input_container">
@@ -132,7 +130,7 @@ export const VtmnTextInput = ({
             aria-describedby={
               (helperText && `${identifier}-helper-text`) || undefined
             }
-            {...propsToString}
+            {...objectValuesToString(props)}
           />
           {icon && <VtmnIcon value={icon} size={20} onClick={onIconClick} />}
         </div>

--- a/packages/sources/react/src/components/indicators/VtmnBadge/VtmnBadge.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnBadge/VtmnBadge.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-badge/dist/index-with-vars.css';
 import { VtmnBadgeVariant } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnBadgeProps extends React.ComponentPropsWithoutRef<'span'> {
   /**
@@ -27,7 +28,7 @@ export const VtmnBadge = ({
       className={`vtmn-badge vtmn-badge_variant--${variant}  ${
         className ? className : ''
       }`}
-      {...props}
+      {...objectValuesToString(props)}
     >
       {value && value > 99 ? '99+' : value || ''}
     </span>

--- a/packages/sources/react/src/components/indicators/VtmnLoader/VtmnLoader.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnLoader/VtmnLoader.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-loader/dist/index-with-vars.css';
 import { VtmnLoaderSize } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnLoaderProps extends React.ComponentPropsWithoutRef<'div'> {
   /**
@@ -18,7 +19,7 @@ export const VtmnLoader = ({
   return (
     <div
       className={`vtmn-loader vtmn-loader_size--${size} ${className}`}
-      {...props}
+      {...objectValuesToString(props)}
     ></div>
   );
 };

--- a/packages/sources/react/src/components/indicators/VtmnPrice/VtmnPrice.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnPrice/VtmnPrice.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-price/dist/index-with-vars.css';
 import { VtmnPriceVariant, VtmnPriceSize } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnPriceProps extends React.ComponentPropsWithoutRef<'span'> {
   /**
@@ -33,7 +34,7 @@ export const VtmnPrice = React.forwardRef<HTMLButtonElement, VtmnPriceProps>(
         className={`vtmn-price vtmn-price_variant--${variant} vtmn-price_size--${size} ${
           className ? className : ''
         }`}
-        {...props}
+        {...objectValuesToString(props)}
       >
         {children}
       </span>

--- a/packages/sources/react/src/components/indicators/VtmnProgressbar/VtmnProgressbar.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnProgressbar/VtmnProgressbar.tsx
@@ -6,6 +6,7 @@ import {
   VtmnProgressbarSize,
   VtmnProgressbarStatus,
 } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnProgressbarProps
   extends React.ComponentPropsWithoutRef<'div'> {
@@ -85,7 +86,7 @@ export const VtmnProgressbar = ({
       aria-label="progress bar"
       aria-valuemin={0}
       aria-valuemax={100}
-      {...props}
+      {...objectValuesToString(props)}
     >
       {/**
        * Linear Progress Bar

--- a/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
@@ -3,6 +3,7 @@ import '@vtmn/css-button/dist/index-with-vars.css';
 import clsx from 'clsx';
 import { VtmnSearchVariant, VtmnSearchSize } from './types';
 import { VtmnButton } from '../../actions/VtmnButton/VtmnButton';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnSearchProps
   extends Omit<React.ComponentPropsWithoutRef<'input'>, 'size'> {
@@ -68,7 +69,7 @@ export const VtmnSearch = ({
         value={search}
         disabled={disabled}
         type="search"
-        {...props}
+        {...objectValuesToString(props)}
         onChange={(event) => {
           // Overwrite previously defined onChange then call it back once search is set
           setSearch(event.target.value);

--- a/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-tooltip/dist/index-with-vars.css';
 import { VtmnTooltipPosition } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnTooltipProps
   extends React.ComponentPropsWithoutRef<'span'> {
@@ -38,7 +39,7 @@ export const VtmnTooltip = ({
         className={`vtmn-tooltip ${className ?? className}`}
         data-tooltip={tooltip}
         data-position={position}
-        {...props}
+        {...objectValuesToString(props)}
       >
         {children}
       </span>

--- a/packages/sources/react/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import '@vtmn/css-checkbox/dist/index-with-vars.css';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnCheckboxProps
   extends React.ComponentPropsWithoutRef<'input'> {
@@ -46,7 +47,7 @@ export const VtmnCheckbox = ({
         id={identifier}
         checked={checked}
         disabled={disabled}
-        {...props}
+        {...objectValuesToString(props)}
       />
       <label htmlFor={identifier}>{labelText}</label>
     </div>

--- a/packages/sources/react/src/components/selection-controls/VtmnChip/VtmnChip.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnChip/VtmnChip.tsx
@@ -6,6 +6,7 @@ import { VtmnChipSize, VtmnChipVariant } from './types';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon/VtmnIcon';
 import { VtmnButton } from '../../actions/VtmnButton/VtmnButton';
 import { VtmnBadge } from '../../indicators/VtmnBadge/VtmnBadge';
+import { objectValuesToString } from '../../../utils/object';
 export interface VtmnChipProps extends React.ComponentPropsWithoutRef<'div'> {
   /**
    * Called when clicking the chip
@@ -86,7 +87,7 @@ export const VtmnChip = ({
         className,
       )}
       onClick={onClick}
-      {...props}
+      {...objectValuesToString(props)}
     >
       {icon && (
         <VtmnIcon variant={selected ? 'reversed' : 'default'} value={icon} />

--- a/packages/sources/react/src/components/selection-controls/VtmnRadioButton/VtmnRadioButton.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnRadioButton/VtmnRadioButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import '@vtmn/css-radio-button/dist/index-with-vars.css';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnRadioButtonProps
   extends React.ComponentPropsWithoutRef<'input'> {
@@ -46,7 +47,7 @@ export const VtmnRadioButton = ({
         id={identifier}
         checked={checked}
         disabled={disabled}
-        {...props}
+        {...objectValuesToString(props)}
       />
       <label htmlFor={identifier}>{labelText}</label>
     </div>

--- a/packages/sources/react/src/components/selection-controls/VtmnToggle/VtmnToggle.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnToggle/VtmnToggle.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import '@vtmn/css-toggle/dist/index-with-vars.css';
 import clsx from 'clsx';
 import { VtmnToggleSize } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnToggleProps
   extends Omit<React.ComponentPropsWithoutRef<'input'>, 'size'> {
@@ -58,7 +59,7 @@ export const VtmnToggle = ({
           id={identifier}
           checked={checked}
           disabled={disabled}
-          {...props}
+          {...objectValuesToString(props)}
         />
         <span aria-hidden="true"></span>
       </div>

--- a/packages/sources/react/src/components/structure/VtmnDivider/VtmnDivider.tsx
+++ b/packages/sources/react/src/components/structure/VtmnDivider/VtmnDivider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import '@vtmn/css-divider/dist/index-with-vars.css';
 import { VtmnDividerOrientation, VtmnDividerTextPosition } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnDividerProps
   extends React.ComponentPropsWithoutRef<'div'> {
@@ -33,7 +34,7 @@ export const VtmnDivider = ({
         `vtmn-divider_orientation--${orientation}`,
         className,
       )}
-      {...props}
+      {...objectValuesToString(props)}
       role="separator"
       aria-orientation={orientation}
     >

--- a/packages/sources/react/src/guidelines/iconography/VtmnIcon/VtmnIcon.tsx
+++ b/packages/sources/react/src/guidelines/iconography/VtmnIcon/VtmnIcon.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import { VtmnIconColor, VtmnIconSize, VtmnIconVariant } from './types';
+import { objectValuesToString } from '../../../utils/object';
 
 export interface VtmnIconProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -74,7 +75,7 @@ export const VtmnIcon: React.FC<VtmnIconProps> = ({
         color: getIconColor(),
         ...style,
       }}
-      {...props}
+      {...objectValuesToString(props)}
     ></span>
   );
 };

--- a/packages/sources/react/src/utils/object.ts
+++ b/packages/sources/react/src/utils/object.ts
@@ -1,0 +1,2 @@
+export const objectValuesToString = (object: object) =>
+  Object.keys(object).map((key) => object[key].toString());


### PR DESCRIPTION
## Changes description
We cast props to string when passing them in the DOM of every components.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
This will fix errors like in this [PR](https://github.com/Decathlon/vitamin-web/pull/1063) for every components.
And it was something asked by @lauthieb (https://github.com/Decathlon/vitamin-web/pull/1063#discussion_r833090919)


## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Comments

I did a bit of a testing to check if everything was working fine, it seems like it is, but more testing would be welcome

PS: also, imports are really ugly (`../../../`) could be replaced by absolute path or aliases but i saw that you where doing that in some components, so in order not to break anything, I did choose to let it like that