### PR TITLE
fix(@vtmn/react): utils method and button component

### DIFF
--- a/packages/sources/react/src/components/actions/VtmnButton/VtmnButton.tsx
+++ b/packages/sources/react/src/components/actions/VtmnButton/VtmnButton.tsx
@@ -56,6 +56,7 @@ export const VtmnButton = React.forwardRef<HTMLButtonElement, VtmnButtonProps>(
       iconAlone,
       children,
       className,
+      disabled = false,
       ...props
     },
     ref,
@@ -68,6 +69,7 @@ export const VtmnButton = React.forwardRef<HTMLButtonElement, VtmnButtonProps>(
         } ${!iconAlone && iconLeft ? 'vtmn-btn--icon-left' : ''} ${
           !iconAlone && iconRight ? 'vtmn-btn--icon-right' : ''
         } ${iconAlone ? 'vtmn-btn--icon-alone' : ''}`}
+        disabled={disabled}
         {...objectValuesToString(props)}
       >
         {!iconAlone && iconLeft && (

--- a/packages/sources/react/src/utils/object.ts
+++ b/packages/sources/react/src/utils/object.ts
@@ -1,2 +1,18 @@
-export const objectValuesToString = (object: object) =>
-  Object.keys(object).map((key) => object[key].toString());
+export const isObject = (object: object) => {
+  return (
+    typeof object === 'object' && !Array.isArray(object) && object !== null
+  );
+};
+
+export const objectValuesToString = (object: object) => {
+  if (!isObject(object)) {
+    return {};
+  }
+
+  return JSON.parse(JSON.stringify(object), (_key, value) => {
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      return value.toString();
+    }
+    return value;
+  });
+};


### PR DESCRIPTION
## Changes description
It fixes some bug and handles more cases like empty and null inputs.
Also, it casts to string only booleans and numbers because objects and arrays doesn't need to be casted.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
The method wasn't working properly when passing more props to components.
Causing errors/warnings when using @vtmn/react components

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Comments

Testing in Storybook only was a terrible mistake as it doesn't include our use-case, maybe writing test suite for methods like that would be a good start.