### PR TITLE
refactor(@vtmn/react): omit `helperText` prop in `VtmnSelect`

### DIFF
--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -5,7 +5,7 @@ import '@vtmn/css-select/dist/index-with-vars.css';
 export interface VtmnSelectProps extends React.ComponentPropsWithRef<'select'> {
   error?: boolean;
   errorText?: string;
-  helperText?: string;
+  helperText?: string; // this props is not used.
   id: string;
   labelText?: string;
   options: React.ComponentPropsWithoutRef<'option'>[];
@@ -24,6 +24,7 @@ export const VtmnSelect = ({
 }: VtmnSelectProps) => {
   const errorTextId = `error-text-${id}`;
   const hasErrorText = error && errorText;
+  const { helperText, ...rest } = props;
 
   return (
     <div className="vtmn-select_container">
@@ -34,7 +35,7 @@ export const VtmnSelect = ({
           'vtmn-select--error': error,
         })}
         aria-describedby={hasErrorText ? errorTextId : undefined}
-        {...props}
+        {...rest}
       >
         {options.map((option) => option)}
       </select>

--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -5,7 +5,6 @@ import '@vtmn/css-select/dist/index-with-vars.css';
 export interface VtmnSelectProps extends React.ComponentPropsWithRef<'select'> {
   error?: boolean;
   errorText?: string;
-  helperText?: string; // this props is not used.
   id: string;
   labelText?: string;
   options: React.ComponentPropsWithoutRef<'option'>[];
@@ -24,7 +23,6 @@ export const VtmnSelect = ({
 }: VtmnSelectProps) => {
   const errorTextId = `error-text-${id}`;
   const hasErrorText = error && errorText;
-  const { helperText, ...rest } = props;
 
   return (
     <div className="vtmn-select_container">
@@ -35,7 +33,7 @@ export const VtmnSelect = ({
           'vtmn-select--error': error,
         })}
         aria-describedby={hasErrorText ? errorTextId : undefined}
-        {...rest}
+        {...props}
       >
         {options.map((option) => option)}
       </select>


### PR DESCRIPTION
## Changes description
Omit helperText props in VtmnSelect component

## Context
<!--- Why is this change required? What problem does it solve? -->
The props interface indicates that the component VtmnSelect could use a helperText props
But in reality, it is not used and as in other components, every props are passed to the DOM
In the case where VtmnSelect consumers pass a helperText, this was causing a DOM error (see screenshot)
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
![Capture d’écran 2022-03-28 à 14 35 20](https://user-images.githubusercontent.com/6609866/160399023-7dd364a9-5635-473e-91cb-54f57eeff86f.png)
