### PR TITLE
refactor(@vtmn/react): `VtmnAlert` component demo & `onClick` event

### DIFF
--- a/packages/showcases/react/stories/components/overlays/VtmnAlert/VtmnAlert.stories.tsx
+++ b/packages/showcases/react/stories/components/overlays/VtmnAlert/VtmnAlert.stories.tsx
@@ -38,3 +38,6 @@ const DemoTemplate: Story = (args) => {
 
 export const Overview = OverviewTemplate.bind({});
 Overview.args = {};
+
+export const Demo = DemoTemplate.bind({});
+Demo.args = {};

--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -24,7 +24,7 @@ export interface VtmnAlertProps
    * The alert callback close function
    * @type {function}
    */
-  onClose: () => void;
+  onClose?: (event: React.MouseEvent | undefined) => void;
 }
 
 export const VtmnAlert = ({
@@ -43,23 +43,25 @@ export const VtmnAlert = ({
         'show',
         className,
       )}
-      onClick={onClose}
     >
       <article className="vtmn-alert_content">
         <div className="vtmn-alert_content-title">
           {title}
-          <button
-            className={clsx(
-              'vtmn-btn',
-              'vtmn-btn_variant--ghost-reversed',
-              'vtmn-btn_size--small',
-              'vtmn-btn--icon-alone',
-              className,
-            )}
-            aria-label="Close alert"
-          >
-            <span className="vtmx-close-line" role="presentation"></span>
-          </button>
+          {onClose && (
+            <button
+              className={clsx(
+                'vtmn-btn',
+                'vtmn-btn_variant--ghost-reversed',
+                'vtmn-btn_size--small',
+                'vtmn-btn--icon-alone',
+                className,
+              )}
+              aria-label="Close alert"
+              onClick={onClose}
+            >
+              <span className="vtmx-close-line" role="presentation"></span>
+            </button>
+          )}
         </div>
         {message && (
           <span className="vtmn-alert_content-description">{message}</span>


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Activate `DemoTemplate` on Storybook for the VtmnAlert component.
Conditional display of close button in VtmnAlert component.
Set `onClick` prop to optional since it isn't given in VtmnAlert overview story.

## Context
<!--- Why is this change required? What problem does it solve? -->
The DemoTemplate wasn't used at all.
The close button was display even if no onClose callback where given.
The overview story wasn't giving the prop onClose therefore it needed to be optional.
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

The onClose is now executed on the button click, not the alert click
Otherwise, no real change here

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
No DemoTemplate, only OverviewTemplate, and also the close button wasn't working because no callback given (Before this PR):
https://streamable.com/75s799

After:
https://streamable.com/2ujq69


