### PR TITLE
feat(@vtmn/svelte): add main into package

### DIFF
--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -106,6 +106,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
+  "main": "src/index.js",
   "svelte": "src/index.js",
   "babel": {
     "presets": [


### PR DESCRIPTION
Link to #1071

With jest, if we import the `@vtmn/svelte` into a test, he can't find the `index.js` from `./src`.
So we need to specify the main into `package.json`

![image](https://user-images.githubusercontent.com/2856778/160436157-96940dff-c6e9-46a0-9b38-0ef8b8f6a4aa.png)