### PR TITLE
fix(@vtmn/svelte): switch js ref to svelte ref

### DIFF
--- a/packages/sources/svelte/src/components/forms/VtmnTextInput/VtmnTextInput.svelte
+++ b/packages/sources/svelte/src/components/forms/VtmnTextInput/VtmnTextInput.svelte
@@ -1,6 +1,6 @@
 <script>
   import { cn } from '../../../utils/classnames';
-  import { VtmnIcon } from '../../..';
+  import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
 
   /** @restProps { input | textarea } */
 

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
@@ -2,7 +2,7 @@
   import { cn } from '../../../utils/classnames';
   import { isFloat } from '../../../utils/math';
   import { VTMN_RATING_SIZE } from './enum';
-  import { VtmnIcon } from '../../..';
+  import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
 
   /**
    * @type {string} name used on interactive mode to name the inputs

--- a/packages/sources/svelte/src/components/indicators/VtmnTag/VtmnTag.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnTag/VtmnTag.svelte
@@ -1,7 +1,7 @@
 <script>
   import { cn } from '../../../utils/classnames';
   import { VTMN_TAG_VARIANT } from './enums';
-  import { VtmnIcon } from '../../..';
+  import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
 
   /**
    * The variant of the tag

--- a/packages/sources/svelte/src/components/navigation/VtmnTabsItem/VtmnTabsItem.svelte
+++ b/packages/sources/svelte/src/components/navigation/VtmnTabsItem/VtmnTabsItem.svelte
@@ -1,6 +1,6 @@
 <script>
-  import VtmnBadge from './../../indicators/VtmnBadge/VtmnBadge.svelte';
-  import VtmnIcon from './../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
+  import VtmnBadge from '../../indicators/VtmnBadge/VtmnBadge.svelte';
+  import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
   export let href = '#';
   export let badgeValue = undefined;
   export let icon = undefined;

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { VtmnButton } from '../../..';
+  import VtmnButton from '../../actions/VtmnButton/VtmnButton.svelte';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { cn } from '../../../utils/classnames';
   import { VTMN_ALERT_VARIANT } from './enums';

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -1,6 +1,6 @@
 <script>
   import { cn } from '../../../utils/classnames';
-  import { VtmnButton } from '../../../index';
+  import VtmnButton from '../../actions/VtmnButton/VtmnButton.svelte';
   import { createEventDispatcher } from 'svelte';
 
   const dispatch = createEventDispatcher();

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
@@ -1,6 +1,6 @@
 <script>
   import { cn } from '../../../utils/classnames';
-  import { VtmnButton } from '../../..';
+  import VtmnButton from '../../actions/VtmnButton/VtmnButton.svelte';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 
   /**

--- a/packages/sources/svelte/src/components/overlays/VtmnToast/VtmnToastItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnToast/VtmnToastItem.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { VtmnButton } from '../../..';
+  import VtmnButton from '../../actions/VtmnButton/VtmnButton.svelte';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { cn } from '../../../utils/classnames';
 

--- a/packages/sources/svelte/src/components/selection-controls/VtmnChip/VtmnChip.svelte
+++ b/packages/sources/svelte/src/components/selection-controls/VtmnChip/VtmnChip.svelte
@@ -1,5 +1,7 @@
 <script>
-  import { VtmnBadge, VtmnButton, VtmnIcon } from '../../..';
+  import VtmnBadge from '../../indicators/VtmnBadge/VtmnBadge.svelte';
+  import VtmnButton from '../../actions/VtmnButton/VtmnButton.svelte';
+  import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
   import { createEventDispatcher } from 'svelte';
   import { VTMN_CHIP_VARIANT, VTMN_CHIP_SIZE } from './enums';
   import { cn } from '../../../utils/classnames';


### PR DESCRIPTION
When we import the component with js, if we test this one which is import a vtmn module with other vtmn module (ex: my component -> vtmnRating -> vtmnButton), the component vtmnButton (on my example) is not a constructor.

So the solution is to set the relative path to the target svelte file.

![image](https://user-images.githubusercontent.com/2856778/160607566-e9a7cba8-dc7c-4bf3-ac93-a03690ad880c.png)
