### PR TITLE
feat(@vtmn/react): use of `VtmnButton` in overlays

### DIFF
--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import '@vtmn/css-alert/dist/index-with-vars.css';
 import { VtmnAlertVariant } from './types';
 import clsx from 'clsx';
+import { VtmnButton } from '../../actions/VtmnButton';
 
 export interface VtmnAlertProps
   extends React.ComponentPropsWithoutRef<'dialog'> {
@@ -48,19 +49,13 @@ export const VtmnAlert = ({
         <div className="vtmn-alert_content-title">
           {title}
           {onClose && (
-            <button
-              className={clsx(
-                'vtmn-btn',
-                'vtmn-btn_variant--ghost-reversed',
-                'vtmn-btn_size--small',
-                'vtmn-btn--icon-alone',
-                className,
-              )}
-              aria-label="Close alert"
+            <VtmnButton
+              size="small"
+              variant="ghost-reversed"
+              iconAlone="close-line"
+              aria-label="Close toast"
               onClick={onClose}
-            >
-              <span className="vtmx-close-line" role="presentation"></span>
-            </button>
+            ></VtmnButton>
           )}
         </div>
         {message && (

--- a/packages/sources/react/src/components/overlays/VtmnToast/VtmnToast.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnToast/VtmnToast.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-alert/dist/index-with-vars.css';
 import clsx from 'clsx';
+import { VtmnButton } from '../../actions/VtmnButton';
 
 export interface VtmnToastProps
   extends React.ComponentPropsWithoutRef<'dialog'> {
@@ -46,19 +47,13 @@ export const VtmnToast = ({
     >
       <div className="vtmn-toast_content">{content}</div>
       {onClose && withCloseButton && (
-        <button
-          className={clsx(
-            'vtmn-btn',
-            'vtmn-btn_variant--ghost-reversed',
-            'vtmn-btn_size--small',
-            'vtmn-btn--icon-alone',
-            className,
-          )}
+        <VtmnButton
+          size="small"
+          variant="ghost-reversed"
+          iconAlone="close-line"
           aria-label="Close toast"
           onClick={onClose}
-        >
-          <span className="vtmx-close-line" role="presentation"></span>
-        </button>
+        ></VtmnButton>
       )}
     </div>
   );


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Use `VtmnButton` instead of custom `button` for appropriate overlay components

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
