### PR TITLE
feat(@vtmn/vue): add disabled attr to ```VtmnSelect``` options

### DIFF
--- a/packages/sources/vue/src/components/forms/VtmnSelect/VtmnSelect.vue
+++ b/packages/sources/vue/src/components/forms/VtmnSelect/VtmnSelect.vue
@@ -85,6 +85,7 @@ export default /*#__PURE__*/ defineComponent({
         :value="option.value"
         :key="index"
         :selected="option.value === modelValue"
+        :disabled="option.disabled"
       >
         {{ option.label }}
       </option>

--- a/packages/sources/vue/src/components/forms/VtmnSelect/types.ts
+++ b/packages/sources/vue/src/components/forms/VtmnSelect/types.ts
@@ -1,4 +1,5 @@
 export interface VtmnSelectOption {
   label: string | number | boolean | null;
   value: string | number | boolean | null;
+  disabled?: boolean;
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Add "disabled" attribute to options props. 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
We should be able to have disabled options inside our ```VtmnSelect``` component.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
The storybook story of the ```VtmnSelect``` component is still missing. Still trying to find a workaround to better use it with Vue 3 context and to be able to add props and reactivity.
