### PR TITLE
fix(@vtmn/svelte): custom class should be apply on the `VtmnModal` content

### DIFF
--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -17,7 +17,7 @@
    */
   export { className as class };
 
-  $: componentClass = cn('vtmn-modal', className);
+  $: componentClass = cn('vtmn-modal_content', className);
 
   const handleClose = () => {
     dispatch('close', { open });
@@ -31,7 +31,7 @@
     }
   </style>
   <div
-    class={componentClass}
+    class="vtmn-modal"
     role="dialog"
     aria-modal="true"
     aria-labelledby={$$restProps['aria-labelledby']}
@@ -42,7 +42,7 @@
       class="vtmn-modal_background-overlay"
       on:click={handleClose}
     />
-    <div class="vtmn-modal_content">
+    <div class={componentClass}>
       <div class="vtmn-modal_content_title">
         {#if $$slots.title}
           <span id="vtmn-modal-title" class="vtmn-modal_content_title--text"

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
@@ -28,6 +28,8 @@ describe('VtmnModal', () => {
     container.getElementsByClassName(
       'vtmn-modal_content_body--overflow-indicator',
     )[0];
+  const getModalContent = (container) =>
+    container.getElementsByClassName('vtmn-modal_content')[0];
   const getContentActions = (container) =>
     container.getElementsByClassName('vtmn-modal_content_actions')[0];
   const getContentDescription = (container) =>
@@ -51,12 +53,12 @@ describe('VtmnModal', () => {
       });
       expect(getModal(container)).toBeVisible();
     });
-    test('Should pass custom class to modal', () => {
+    test('Should pass custom class to modal content', () => {
       const { container } = render(VtmnModal, {
         open: true,
         class: 'unit-test',
       });
-      expect(getModal(container)).toHaveClass('unit-test');
+      expect(getModalContent(container)).toHaveClass('unit-test');
     });
     test('Should trigger close if user click on overlay', async () => {
       const { container, component } = render(VtmnModal, {


### PR DESCRIPTION
When we use the `VtmnModal` and want to apply custom style on it, the style are applied on the main container `vtmn-modal` and not the content of the modal `vtmn-modal_content`.

The first level only contains the overlay and the content.

In fact, if we want to apply a custom height to the modal for example : 

Without the fix
```
<style>
.variant-full-screen {
  .vtmn-modal-content {
    height: 100vh;
  }
}
</style>

<VtmnModal class="modal-full-screen" />
```

With the fix 
```
<VtmnModal class="vtmn-h-screen" />
```