### PR TITLE
feat(@vtmn/css): remove useless textInput line-height

### DIFF
--- a/packages/sources/css/src/components/forms/text-input/src/index.css
+++ b/packages/sources/css/src/components/forms/text-input/src/index.css
@@ -25,7 +25,6 @@
   display: block;
   font-weight: var(--vtmn-typo_font-weight--normal);
   font-size: var(--vtmn-typo_text-2-font-size);
-  line-height: 1;
   padding: rem(12px) rem(36px) rem(12px) rem(12px);
   color: var(--vtmn-semantic-color_content-primary);
   min-height: rem(48px);


### PR DESCRIPTION
## Changes description
remove forced line-height on `vtmn-text-input`

## Context
There's a useless `line-height: 1` declaration on `vtmn-text-input` (which targets `input` and `textarea` tags)

It has no effect on input tags beside selection visualization...

**With line-height :** 
<img width="352" alt="Capture d’écran 2022-04-03 à 10 22 05" src="https://user-images.githubusercontent.com/22882255/162446077-a0b3ad6c-9378-4d01-b3f0-6c9a01a63ab1.png">

**Without line-height :** 
<img width="352" alt="Capture d’écran 2022-04-03 à 10 22 14" src="https://user-images.githubusercontent.com/22882255/162446157-33c047cb-cced-440d-a901-14524733fa7d.png">

...but it shrinks the text of textarea : 

**With line-height :** 
<img width="655" alt="Capture d’écran 2022-04-01 à 11 03 30" src="https://user-images.githubusercontent.com/22882255/162446386-62ed8ea1-81fc-4b84-8fac-55294a65b6f6.png">

**Without line-height :** 
<img width="655" alt="Capture d’écran 2022-04-01 à 11 03 18" src="https://user-images.githubusercontent.com/22882255/162446425-e78851b4-9f90-4281-8df4-ed65c637112f.png">




## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

