### PR TITLE
fix(@vtmn/svelte): rework `VtmnRating` component

### DIFF
--- a/packages/showcases/core/csf/components/indicators/rating.csf.js
+++ b/packages/showcases/core/csf/components/indicators/rating.csf.js
@@ -48,14 +48,25 @@ export const argTypes = {
   },
   compact: {
     type: { name: 'number', required: false },
-    description: 'How many stars to display.',
+    description: 'Display compact mode (only if readonly is true).',
     defaultValue: false,
     control: { type: 'boolean' },
   },
-  rating: {
+  value: {
     type: { name: 'boolean', required: false },
-    description: 'How many stars are filled.',
+    description: 'Rating value.',
     defaultValue: 0,
     control: { type: 'range', min: 0, max: 5, step: 0.25 },
+  },
+  comments: {
+    type: { name: 'number', required: false },
+    description: 'Review number.',
+    control: { type: 'number', min: 0, step: 1 },
+  },
+  showValue: {
+    type: { name: 'boolean', required: false },
+    description: 'Display the rating value.',
+    defaultValue: false,
+    control: { type: 'boolean' },
   },
 };

--- a/packages/showcases/core/csf/components/indicators/rating.csf.js
+++ b/packages/showcases/core/csf/components/indicators/rating.csf.js
@@ -11,7 +11,7 @@ export const parameters = {
 export const argTypes = {
   name: {
     type: { name: 'string', required: false },
-    description: 'Name used on the input radio',
+    description: 'Name used on the input radio.',
     defaultValue: 'rating',
     control: {
       type: 'text',
@@ -19,7 +19,7 @@ export const argTypes = {
   },
   emphasis: {
     type: { name: 'boolean', required: false },
-    description: 'The variant of the rating. Only if readonly is true',
+    description: 'The variant of the rating. Only if readonly is true.',
     defaultValue: false,
     control: {
       type: 'boolean',
@@ -48,7 +48,7 @@ export const argTypes = {
   },
   compact: {
     type: { name: 'number', required: false },
-    description: 'Display compact mode, only if readonly is true.',
+    description: 'Display compact mode. Only if readonly is true.',
     defaultValue: false,
     control: { type: 'boolean' },
   },
@@ -61,12 +61,12 @@ export const argTypes = {
   comments: {
     type: { name: 'string', required: false },
     description:
-      'Comments displayed after the rating. Only if readonly is true',
+      'Comments displayed after the rating. Only if readonly is true.',
     control: { type: 'text' },
   },
   showValue: {
     type: { name: 'boolean', required: false },
-    description: 'Display the rating value. Only if readonly is true',
+    description: 'Display the rating value. Only if readonly is true.',
     defaultValue: false,
     control: { type: 'boolean' },
   },

--- a/packages/showcases/core/csf/components/indicators/rating.csf.js
+++ b/packages/showcases/core/csf/components/indicators/rating.csf.js
@@ -19,7 +19,7 @@ export const argTypes = {
   },
   emphasis: {
     type: { name: 'boolean', required: false },
-    description: 'The variant of the rating.',
+    description: 'The variant of the rating. Only if readonly is true',
     defaultValue: false,
     control: {
       type: 'boolean',
@@ -48,7 +48,7 @@ export const argTypes = {
   },
   compact: {
     type: { name: 'number', required: false },
-    description: 'Display compact mode (only if readonly is true).',
+    description: 'Display compact mode, only if readonly is true.',
     defaultValue: false,
     control: { type: 'boolean' },
   },
@@ -59,13 +59,14 @@ export const argTypes = {
     control: { type: 'range', min: 0, max: 5, step: 0.25 },
   },
   comments: {
-    type: { name: 'number', required: false },
-    description: 'Review number.',
-    control: { type: 'number', min: 0, step: 1 },
+    type: { name: 'string', required: false },
+    description:
+      'Comments displayed after the rating. Only if readonly is true',
+    control: { type: 'text' },
   },
   showValue: {
     type: { name: 'boolean', required: false },
-    description: 'Display the rating value.',
+    description: 'Display the rating value. Only if readonly is true',
     defaultValue: false,
     control: { type: 'boolean' },
   },

--- a/packages/showcases/svelte/stories/components/indicators/VtmnRating/VtmnRating.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnRating/VtmnRating.stories.svelte
@@ -26,60 +26,70 @@
     name="story-interfactive-1"
     emphasis
     size="medium"
-    rating={0}
+    value={0}
   />
   <VtmnRating
     class="rating-stories"
     name="story-interfactive-2"
     emphasis
     size="small"
-    rating={0}
+    value={0}
   />
   <VtmnRating
     class="rating-stories"
     name="story-interfactive-3"
     emphasis
     disabled
-    rating={0}
+    value={0}
   />
 </Story>
 
 <Story name="Read Only with text">
-  <VtmnRating class="rating-stories" readonly compact rating={1}>
-    <span slot="primary">4.1/5</span>
-  </VtmnRating>
-  <VtmnRating class="rating-stories" readonly compact rating={0.1}>
-    <span slot="primary">1/5</span>
-  </VtmnRating>
-  <VtmnRating class="rating-stories" size="small" readonly compact rating={1}>
-    <span slot="primary">2.9/5</span>
-    <span slot="secondary">(74)</span>
-  </VtmnRating>
-  <VtmnRating class="rating-stories" emphasis readonly compact rating={1}>
-    <span slot="primary">74 ratings</span>
-  </VtmnRating>
-  <VtmnRating class="rating-stories" emphasis readonly rating={2.3}>
-    <span slot="primary">2.3/5</span>
-    <span slot="secondary">(74)</span>
-  </VtmnRating>
+  <VtmnRating class="rating-stories" readonly compact value={4.1} showValue />
+  <VtmnRating class="rating-stories" readonly compact value={1} showValue />
+  <VtmnRating
+    class="rating-stories"
+    size="small"
+    readonly
+    compact
+    value={2.9}
+    comments={74}
+    showValue
+  />
+  <VtmnRating
+    class="rating-stories"
+    emphasis
+    readonly
+    compact
+    value={5}
+    comments={74}
+  />
+  <VtmnRating
+    class="rating-stories"
+    emphasis
+    readonly
+    value={2.3}
+    showValue
+    comments={74}
+  />
 </Story>
 
 <Story name="Read only">
   <div class="rating-story-align">
     <div>
-      <VtmnRating class="rating-stories" readonly size="small" rating={0} />
-      <VtmnRating class="rating-stories" readonly size="small" rating={0.5} />
-      <VtmnRating class="rating-stories" readonly size="small" rating={1} />
-      <VtmnRating class="rating-stories" readonly size="small" rating={1.5} />
-      <VtmnRating class="rating-stories" readonly size="small" rating={2} />
-      <VtmnRating class="rating-stories" readonly size="small" rating={2.5} />
+      <VtmnRating class="rating-stories" readonly size="small" value={0} />
+      <VtmnRating class="rating-stories" readonly size="small" value={0.5} />
+      <VtmnRating class="rating-stories" readonly size="small" value={1} />
+      <VtmnRating class="rating-stories" readonly size="small" value={1.5} />
+      <VtmnRating class="rating-stories" readonly size="small" value={2} />
+      <VtmnRating class="rating-stories" readonly size="small" value={2.5} />
     </div>
     <div>
-      <VtmnRating class="rating-stories" readonly emphasis rating={3} />
-      <VtmnRating class="rating-stories" readonly emphasis rating={3.5} />
-      <VtmnRating class="rating-stories" readonly emphasis rating={4} />
-      <VtmnRating class="rating-stories" readonly emphasis rating={4.5} />
-      <VtmnRating class="rating-stories" readonly emphasis rating={5} />
+      <VtmnRating class="rating-stories" readonly emphasis value={3} />
+      <VtmnRating class="rating-stories" readonly emphasis value={3.5} />
+      <VtmnRating class="rating-stories" readonly emphasis value={4} />
+      <VtmnRating class="rating-stories" readonly emphasis value={4.5} />
+      <VtmnRating class="rating-stories" readonly emphasis value={5} />
     </div>
   </div>
 </Story>

--- a/packages/showcases/svelte/stories/components/indicators/VtmnRating/VtmnRating.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnRating/VtmnRating.stories.svelte
@@ -53,7 +53,7 @@
     readonly
     compact
     value={2.9}
-    comments={74}
+    comments="(74)"
     showValue
   />
   <VtmnRating
@@ -62,7 +62,7 @@
     readonly
     compact
     value={5}
-    comments={74}
+    comments="(74)"
   />
   <VtmnRating
     class="rating-stories"
@@ -70,7 +70,7 @@
     readonly
     value={2.3}
     showValue
-    comments={74}
+    comments="(74)"
   />
 </Story>
 

--- a/packages/showcases/svelte/stories/components/indicators/VtmnRating/VtmnRating.stories.svelte
+++ b/packages/showcases/svelte/stories/components/indicators/VtmnRating/VtmnRating.stories.svelte
@@ -44,7 +44,7 @@
   />
 </Story>
 
-<Story name="Read Only with text">
+<Story name="Read only with comments">
   <VtmnRating class="rating-stories" readonly compact value={4.1} showValue />
   <VtmnRating class="rating-stories" readonly compact value={1} showValue />
   <VtmnRating

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
@@ -11,7 +11,7 @@
   export let name;
 
   /**
-   * @type {boolean} use the emphasis mode
+   * @type {boolean} use the emphasis mode. Only if readonly is true.
    * @default false
    */
   export let emphasis = false;
@@ -35,7 +35,7 @@
   export let readonly = false;
 
   /**
-   * @type {boolean} enable the compact mode, only for readonly
+   * @type {boolean} enable the compact mode. Only if readonly is true.
    * @default false
    */
   export let compact = false;
@@ -47,13 +47,13 @@
   export let value;
 
   /**
-   * @type {boolean} display the rating value
+   * @type {boolean} display the rating value. Only if readonly is true.
    * default false
    */
   export let showValue = false;
 
   /**
-   * @type {number} Review number
+   * @type {number} Comments displayed after the rating. Only if readonly is true.
    */
   export let comments = undefined;
 
@@ -125,12 +125,12 @@
         {value}/5
       </span>
     {/if}
-    {#if typeof comments === 'number'}
+    {#if comments}
       <span
         class="vtmn-rating_comment--secondary"
         aria-label="number of ratings"
       >
-        ({comments})
+        {comments}
       </span>
     {/if}
   {/if}

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
@@ -6,38 +6,56 @@
 
   /**
    * @type {string} name used on interactive mode to name the inputs
+   * @required
    */
   export let name;
 
   /**
    * @type {boolean} use the emphasis mode
+   * @default false
    */
   export let emphasis = false;
 
   /**
    * @type {boolean} size of the component
+   * @default medium
    */
   export let size = VTMN_RATING_SIZE.MEDIUM;
 
   /**
    * @type {boolean} disable the component
+   * @default false
    */
   export let disabled = false;
 
   /**
    * @type {boolean} is readonly component
+   * @default false
    */
   export let readonly = false;
 
   /**
-   * @type {boolean} enable the compact mode
+   * @type {boolean} enable the compact mode, only for readonly
+   * @default false
    */
   export let compact = false;
 
   /**
    * @type {number} rating to display on the component
+   * @requires
    */
-  export let rating = 0;
+  export let value;
+
+  /**
+   * @type {boolean} display the rating value
+   * default false
+   */
+  export let showValue = false;
+
+  /**
+   * @type {number} Review number
+   */
+  export let comments = undefined;
 
   let className = undefined;
   /**
@@ -54,13 +72,16 @@
   $: starsCnt = compact && readonly ? 1 : 5;
 
   const computeRatingFill = (currentRatingStar) => {
-    if (currentRatingStar <= rating) {
+    if (starsCnt === 1) {
+      return value === 0 ? 'line' : 'fill';
+    }
+    if (currentRatingStar <= value) {
       return 'fill';
     }
     if (
-      rating < currentRatingStar &&
-      isFloat(rating) &&
-      Math.ceil(rating) === currentRatingStar
+      value < currentRatingStar &&
+      isFloat(value) &&
+      Math.ceil(value) === currentRatingStar
     ) {
       return 'half-fill';
     }
@@ -68,50 +89,48 @@
   };
 </script>
 
-<div
-  class={componentClass}
-  aria-disabled={disabled}
-  aria-label={$$restProps['aria-label']}
->
+<div class={componentClass} aria-disabled={disabled} {...$$restProps}>
   {#if !readonly}
     <div
       class="vtmn-rating--interactive"
       aria-label="Rate the article"
       role="radiogroup"
-      data-rating={rating}
+      data-rating={value}
     >
-      {#each Array(starsCnt) as _, i}
+      {#each Array(starsCnt) as _, index}
+        {@const position = index + 1}
         <input
           type="radio"
-          bind:group={rating}
+          bind:group={value}
           {name}
-          value={i + 1}
-          id={`${name}-${i + 1}`}
-          aria-label={`${i + 1} star out of 5`}
+          value={position}
+          id={`${name}-${position}`}
+          aria-label={`${position} star out of 5`}
           {disabled}
         />
-        <label for={`${name}-${i + 1}`} />
+        <label for={`${name}-${position}`} />
       {/each}
     </div>
   {/if}
   {#if readonly}
-    {#each Array(starsCnt) as _, i}
+    {#each Array(starsCnt) as _, index}
+      {@const position = index + 1}
       <VtmnIcon
-        value={`star-${computeRatingFill(i + 1)}`}
+        value={`star-${computeRatingFill(position)}`}
         role="presentation"
       />
     {/each}
-    {#if $$slots.primary}
+    {#if showValue}
       <span class="vtmn-rating_comment--primary" aria-label="article rating">
-        <slot name="primary" />
+        {value}/5
       </span>
     {/if}
-    {#if $$slots.secondary}
+    {#if typeof comments === 'number'}
       <span
         class="vtmn-rating_comment--secondary"
         aria-label="number of ratings"
       >
-        <slot name="secondary" />
+        ({comments})
       </span>
     {/if}
   {/if}

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 
 import { fireEvent, render } from '@testing-library/svelte';
 import VtmnRating from '../VtmnRating.svelte';
-import VtmnRatingWithSlots from './VtmnRatingWithSlots.svelte';
 
 describe('VtmnRating', () => {
   const getRating = (container) =>
@@ -18,14 +17,9 @@ describe('VtmnRating', () => {
   const getRadioInputs = (container) =>
     container.querySelectorAll('input[type="radio"]');
 
-  const getPrimarySlot = (container) =>
-    container.querySelector('[slot="primary"]');
-  const getSecondarySlot = (container) =>
-    container.querySelector('[slot="secondary"]');
-
   describe('Default', () => {
     test("Should have by default class 'vtmn-rating' + class 'vtmn-rating_size--medium' and not 'vtmn-rating_variant--brand' + aria-disabled", () => {
-      const { container } = render(VtmnRating, { name: 'rating' });
+      const { container } = render(VtmnRating, { name: 'rating', value: 2 });
       expect(getRating(container)).toHaveClass('vtmn-rating');
       expect(getRating(container)).toHaveClass('vtmn-rating_size--medium');
       expect(getRating(container)).not.toHaveClass(
@@ -37,6 +31,7 @@ describe('VtmnRating', () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         size: 'medium',
+        value: 2,
       });
       expect(getRating(container)).toHaveClass('vtmn-rating_size--medium');
     });
@@ -44,6 +39,7 @@ describe('VtmnRating', () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         size: 'small',
+        value: 2,
       });
       expect(getRating(container)).toHaveClass('vtmn-rating_size--small');
     });
@@ -51,6 +47,7 @@ describe('VtmnRating', () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         emphasis: false,
+        value: 2,
       });
       expect(getRating(container)).not.toHaveClass(
         'vtmn-rating_variant--brand',
@@ -60,6 +57,7 @@ describe('VtmnRating', () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         emphasis: true,
+        value: 2,
       });
       expect(getRating(container)).toHaveClass('vtmn-rating_variant--brand');
     });
@@ -67,6 +65,7 @@ describe('VtmnRating', () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         class: 'unit-test',
+        value: 2,
       });
       expect(getRating(container)).toHaveClass('unit-test');
     });
@@ -74,110 +73,89 @@ describe('VtmnRating', () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         disabled: true,
+        value: 2,
       });
       expect(getRating(container)).toHaveAttribute('aria-disabled', 'true');
     });
     test("Should not have a primary slot and class 'vtmn-rating_comment--primary'", () => {
-      const { container } = render(VtmnRating, { name: 'rating' });
+      const { container } = render(VtmnRating, { name: 'rating', value: 2 });
       expect(getCommentPrimary(container)).toBeUndefined();
-      expect(getPrimarySlot(container)).toBeNull();
     });
     test("Should not have a secondary slot and class 'vtmn-rating_comment--secondary'", () => {
-      const { container } = render(VtmnRating, { name: 'rating' });
+      const { container } = render(VtmnRating, { name: 'rating', value: 2 });
       expect(getCommentSecondary(container)).toBeUndefined();
-      expect(getSecondarySlot(container)).toBeNull();
     });
   });
 
   describe('readonly', () => {
     test("Should not have 'vtmn-rating--interactive' if readonly = true", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
+        value: 2,
       });
       expect(getInteractive(container)).toBeUndefined();
     });
-    test("Should display primary slot and class 'vtmn-rating_comment--primary' if slot primary are set", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+    test("Should display primary slot and class 'vtmn-rating_comment--primary' if value and showValue are set", () => {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
+        value: 2,
+        showValue: true,
       });
       expect(getCommentPrimary(container)).toBeVisible();
-      expect(getPrimarySlot(container)).toBeVisible();
     });
-    test("Should display secondary slot and class 'vtmn-rating_comment--secondary' if slot secondary are set", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+    test("Should display secondary slot and class 'vtmn-rating_comment--secondary' if comments are set", () => {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
+        value: 2,
+        comments: 46,
       });
       expect(getCommentSecondary(container)).toBeVisible();
-      expect(getSecondarySlot(container)).toBeVisible();
     });
 
     test("Should have 1 span role 'presentation' if compact is true", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: true,
+        value: 2,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(1);
       expect(spans[0]).toBeVisible();
     });
     test("Should have 1 span with class 'vtmx-star-line' if rating = 0 and compact mode", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: true,
-        rating: 0,
+        value: 0,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(1);
       expect(spans[0]).toBeVisible();
       expect(spans[0]).toHaveClass('vtmx-star-line');
     });
-    test("Should have 1 span with class 'vtmx-star-half-fill' if rating = 0.1 and compact mode", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+    test("Should have 1 span with class 'vtmx-star-fill' if rating > 0 and compact mode", () => {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: true,
-        rating: 0.1,
-      });
-      const spans = getReadonlyPresentations(container);
-      expect(spans.length).toEqual(1);
-      expect(spans[0]).toBeVisible();
-      expect(spans[0]).toHaveClass('vtmx-star-half-fill');
-    });
-    test("Should have 1 span with class 'vtmx-star-half-fill' if rating = 0.9 and compact mode", () => {
-      const { container } = render(VtmnRatingWithSlots, {
-        name: 'rating',
-        readonly: true,
-        compact: true,
-        rating: 0.9,
-      });
-      const spans = getReadonlyPresentations(container);
-      expect(spans.length).toEqual(1);
-      expect(spans[0]).toBeVisible();
-      expect(spans[0]).toHaveClass('vtmx-star-half-fill');
-    });
-    test("Should have 1 span with class 'vtmx-star-fill' if rating = 1 and compact mode", () => {
-      const { container } = render(VtmnRatingWithSlots, {
-        name: 'rating',
-        readonly: true,
-        compact: true,
-        rating: 1,
+        value: 0.1,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(1);
       expect(spans[0]).toBeVisible();
       expect(spans[0]).toHaveClass('vtmx-star-fill');
     });
-
     test("Should have 5 span with class 'vtmx-star-line' and compact = false by default", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
+        value: 0,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);
@@ -187,11 +165,11 @@ describe('VtmnRating', () => {
       }
     });
     test("Should have 5 span with class 'vtmx-star-line' if rating = 0 and compact = false", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
-        rating: 0,
+        value: 0,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);
@@ -201,11 +179,11 @@ describe('VtmnRating', () => {
       }
     });
     test("Should have 2 span with class 'vtmx-star-fill' and 3 span with class 'vtmx-star-line' if rating = 2 and compact = false", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
-        rating: 2,
+        value: 2,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);
@@ -219,11 +197,11 @@ describe('VtmnRating', () => {
       expect(spans[4]).toHaveClass('vtmx-star-line');
     });
     test("Should have 2 span with class 'vtmx-star-fill' and 1 with class 'vtmx-star-half-fill' and 2 span with class 'vtmx-star-line' if rating = 2.1 and compact = false", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
-        rating: 2.1,
+        value: 2.1,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);
@@ -237,11 +215,11 @@ describe('VtmnRating', () => {
       expect(spans[4]).toHaveClass('vtmx-star-line');
     });
     test("Should have 2 span with class 'vtmx-star-fill' and 1 with class 'vtmx-star-half-fill' and 2 span with class 'vtmx-star-line' if rating = 2.9 and compact = false", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
-        rating: 2.9,
+        value: 2.9,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);
@@ -255,11 +233,11 @@ describe('VtmnRating', () => {
       expect(spans[4]).toHaveClass('vtmx-star-line');
     });
     test("Should have 5 span with class 'vtmx-star-fill' if rating = 5 and compact = false", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
-        rating: 5,
+        value: 5,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);
@@ -272,16 +250,18 @@ describe('VtmnRating', () => {
 
   describe('Interactive', () => {
     test("Should not have 'vtmn-rating--interactive' if readonly = false", () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
+        value: 2,
       });
       expect(getInteractive(container)).toBeVisible();
     });
     test('Should have 5 input type radio if readonly = false', () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
+        value: 2,
       });
       const inputs = getRadioInputs(container);
       expect(inputs.length).toEqual(5);
@@ -290,10 +270,11 @@ describe('VtmnRating', () => {
       }
     });
     test('Should have 5 input type radio if readonly = false and compact = true', () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
         compact: true,
+        value: 2,
       });
       const inputs = getRadioInputs(container);
       expect(inputs.length).toEqual(5);
@@ -302,10 +283,11 @@ describe('VtmnRating', () => {
       }
     });
     test('Should have 5 input type radio disabled if readonly = false and disabled = true', () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
         disabled: true,
+        value: 2,
       });
       const inputs = getRadioInputs(container);
       expect(inputs.length).toEqual(5);
@@ -315,10 +297,11 @@ describe('VtmnRating', () => {
       }
     });
     test('Should have 5 input type radio with name if readonly = false and name are set', () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
         disabled: true,
+        value: 2,
       });
       const inputs = getRadioInputs(container);
       expect(inputs.length).toEqual(5);
@@ -328,25 +311,26 @@ describe('VtmnRating', () => {
       }
     });
     test('Should not have a slot primary if slot are defined', () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
+        value: 2,
       });
       expect(getCommentPrimary(container)).toBeUndefined();
-      expect(getPrimarySlot(container)).toBeNull();
     });
     test('Should not have a slot secondary if slot are defined', () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
+        value: 2,
       });
       expect(getCommentPrimary(container)).toBeUndefined();
-      expect(getPrimarySlot(container)).toBeNull();
     });
     test('Should radio inputs reactive to rating variable', async () => {
-      const { container } = render(VtmnRatingWithSlots, {
+      const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: false,
+        value: 0,
       });
 
       expect(getInteractive(container)).toHaveAttribute('data-rating', '0');

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRatingWithSlots.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRatingWithSlots.svelte
@@ -1,8 +1,0 @@
-<script>
-  import VtmnRating from '../VtmnRating.svelte';
-</script>
-
-<VtmnRating {...$$restProps}>
-  <span slot="primary">2.9/5</span>
-  <span slot="secondary">(74)</span>
-</VtmnRating>


### PR DESCRIPTION
Some changes:  
- Remove slots
- `rating` property move to `value`
- slot secondary are moved to `comments` property
- add `showValue` property to display the value string
- rework the storybook
- adapt unit-tests
- New rule for compact rating, if value > 0 fill the star, if value = 0 line