### PR TITLE
feat(@vtmn/css): use logical properties in btn spacings

### DIFF
--- a/packages/sources/css/src/components/actions/button/src/index.css
+++ b/packages/sources/css/src/components/actions/button/src/index.css
@@ -274,52 +274,52 @@
 
 .vtmn-btn--icon-left span[class^='vtmx-'],
 .vtmn-btn_size--medium.vtmn-btn--icon-left span[class^='vtmx-'] {
-  padding-right: rem(8px);
+  padding-inline-end: rem(8px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-left span[class^='vtmx-'] {
-  padding-right: rem(6px);
+  padding-inline-end: rem(6px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-right span[class^='vtmx-'] {
-  padding-left: rem(6px);
+  padding-inline-start: rem(6px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-left svg {
-  margin-right: rem(6px);
+  margin-inline-end: rem(6px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-right svg {
-  margin-left: rem(6px);
+  margin-inline-start: rem(6px);
 }
 
 .vtmn-btn--icon-right span[class^='vtmx-'],
 .vtmn-btn_size--medium.vtmn-btn--icon-right span[class^='vtmx-'] {
-  padding-left: rem(8px);
+  padding-inline-start: rem(8px);
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-left svg {
-  margin-right: rem(8px);
+  margin-inline-end: rem(8px);
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-right svg {
-  margin-left: rem(8px);
+  margin-inline-start: rem(8px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-left span[class^='vtmx-'] {
-  padding-right: rem(12px);
+  padding-inline-end: rem(12px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-right span[class^='vtmx-'] {
-  padding-left: rem(12px);
+  padding-inline-start: rem(12px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-left svg {
-  margin-right: rem(12px);
+  margin-inline-end: rem(12px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-right svg {
-  margin-left: rem(12px);
+  margin-inline-start: rem(12px);
 }
 
 /* Exceptions */


### PR DESCRIPTION
## Changes description
use logical properties in for button's icons padding and margin 

## Context
Spacing is wrong in a right to left reading context.

**Take this organism :**

<img width="643" alt="Capture d’écran 2022-04-14 à 11 50 52" src="https://user-images.githubusercontent.com/22882255/163360993-f4e164ba-3ad9-4751-8173-ee9d5bd37f27.png">

**In rtl direction it gives us this :** 

<img width="643" alt="Capture d’écran 2022-04-14 à 11 51 33" src="https://user-images.githubusercontent.com/22882255/163361109-6fe23606-0be8-4102-8285-962c733d00bb.png">

**This PR aims to correct icon spacing :** 

<img width="643" alt="Capture d’écran 2022-04-14 à 11 51 08" src="https://user-images.githubusercontent.com/22882255/163361185-d0fbebb9-96e1-4158-9c02-785217019b8f.png">



## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

