### PR TITLE
fix(@vtmn/svelte): prevent flickering `VtmnDivider`

### DIFF
--- a/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
@@ -25,7 +25,7 @@
   $: componentClass = cn(
     'vtmn-divider',
     `vtmn-divider_orientation--${orientation}`,
-    `vtmn-divider_text-position--${textPosition}`,
+    $$slots.default && `vtmn-divider_text-position--${textPosition}`,
     className,
   );
 </script>


### PR DESCRIPTION
When we use the `VtmnDivider` inside an application, when we don't apply a slot, a empty line are display at start for a second.

Don't apply the class if no default slot are defined prevent this side effect.