### PR TITLE
feat(@vtmn/css): progressbar, add a11y requirements

### DIFF
--- a/packages/showcases/css/stories/components/indicators/progressbar/examples/circular.html
+++ b/packages/showcases/css/stories/components/indicators/progressbar/examples/circular.html
@@ -5,52 +5,9 @@
     aria-label="progress bar"
     aria-valuemin="0"
     aria-valuemax="100"
-    aria-valuenow="25"
-  >
-    <svg>
-      <circle
-        class="vtmn-progressbar_indicator"
-        stroke-dashoffset="calc(200px - (200px * 25) / 100)"
-        cx="50%"
-        cy="50%"
-        r="32"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container vtmn-progressbar_variant--circular"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="40"
-  >
-    <svg>
-      <circle class="vtmn-progressbar_track" cx="50%" cy="50%" r="64" />
-      <circle
-        class="vtmn-progressbar_indicator"
-        stroke-dashoffset="calc(400px - (400px * 40) / 100)"
-        cx="50%"
-        cy="50%"
-        r="64"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container vtmn-progressbar_variant--circular vtmn-progressbar_size--small"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
     aria-valuenow="50"
   >
-    <span class="vtmn-progressbar_label" data-value="50"></span>
+    <span class="vtmn-progressbar_label">50%</span>
     <svg>
       <circle
         class="vtmn-progressbar_indicator"
@@ -72,7 +29,7 @@
     aria-valuemax="100"
     aria-valuenow="60"
   >
-    <span class="vtmn-progressbar_label" data-value="60"></span>
+    <span class="vtmn-progressbar_label">60%</span>
     <svg>
       <circle class="vtmn-progressbar_track" cx="50%" cy="50%" r="64" />
       <circle
@@ -175,11 +132,7 @@
     aria-valuemax="100"
     aria-valuenow="0"
   >
-    <span
-      id="vtmn-progressbar-label-2"
-      class="vtmn-progressbar_label"
-      data-value="0"
-    ></span>
+    <span id="vtmn-progressbar-label-2" class="vtmn-progressbar_label">0%</span>
     <svg>
       <circle class="vtmn-progressbar_track" cx="50%" cy="50%" r="64" />
       <circle
@@ -204,11 +157,7 @@
     aria-valuemax="100"
     aria-valuenow="50"
   >
-    <span
-      id="vtmn-progressbar-label-3"
-      class="vtmn-progressbar_label"
-      data-value="0"
-    ></span>
+    <span id="vtmn-progressbar-label-3" class="vtmn-progressbar_label">0%</span>
     <svg>
       <circle
         id="vtmn-progressbar-3"

--- a/packages/showcases/css/stories/components/indicators/progressbar/examples/circular.runscript.js
+++ b/packages/showcases/css/stories/components/indicators/progressbar/examples/circular.runscript.js
@@ -6,25 +6,26 @@ function initCircularProgressbarShowcase() {
     let label = document.getElementById(`vtmn-progressbar-label-${i}`);
     let progress = document.getElementById(`vtmn-progressbar-${i}`);
 
-    let type = 'circular';
-
-    resetProgress(container, progress, label, type);
-    launchProgress(container, progress, label, type);
+    resetProgress(container, progress, label);
+    launchProgress(container, progress, label);
   }
 
-  function launchProgress(container, progress, label, type) {
+  function launchProgress(container, progress, label) {
     setInterval(() => {
       let random = getRandom(1, 15);
-      let currentLabelValue = Number(label.getAttribute('data-value'));
+      let textLabel = label.textContent;
+      let currentLabelValue = Number(
+        textLabel.substring(0, textLabel.length - 1),
+      );
       let newValue = Number(currentLabelValue + random);
       if (newValue >= 100) {
         newValue = 100;
-        addProgress(container, progress, label, type, newValue);
+        addProgress(container, progress, label, newValue);
         setTimeout(() => {
-          resetProgress(container, progress, label, type);
+          resetProgress(container, progress, label);
         }, 2000);
       } else {
-        addProgress(container, progress, label, type, newValue);
+        addProgress(container, progress, label, newValue);
       }
     }, 1000);
   }
@@ -33,17 +34,10 @@ function initCircularProgressbarShowcase() {
     return Math.ceil(Math.random() * (max - min) + min);
   }
 
-  function addProgress(container, progress, label, type, value) {
-    label.setAttribute('data-value', `${value}`);
+  function addProgress(container, progress, label, value) {
+    label.textContent = `${value}%`;
     container.setAttribute('aria-valuenow', `${value}`);
-    switch (type) {
-      case 'linear':
-        progress.style.transform = `translateX(calc(-100% + ${value}%))`;
-        break;
-      case 'circular':
-        setCircularProgress(container, progress, value);
-        break;
-    }
+    setCircularProgress(container, progress, value);
   }
 
   function setCircularProgress(container, progress, value) {
@@ -60,17 +54,10 @@ function initCircularProgressbarShowcase() {
     }
   }
 
-  function resetProgress(container, progress, label, type) {
-    label.setAttribute('data-value', '0');
+  function resetProgress(container, progress, label) {
+    label.textContent = '0%';
     container.setAttribute('aria-valuenow', '0');
-    switch (type) {
-      case 'linear':
-        progress.style.transform = `translateX(-105%)`;
-        break;
-      case 'circular':
-        setCircularProgress(container, progress, 0);
-        break;
-    }
+    setCircularProgress(container, progress, 0);
   }
 
   window.removeEventListener(

--- a/packages/showcases/css/stories/components/indicators/progressbar/examples/linear.html
+++ b/packages/showcases/css/stories/components/indicators/progressbar/examples/linear.html
@@ -7,33 +7,15 @@
     aria-valuemax="100"
     aria-valuenow="60"
   >
-    <span class="vtmn-progressbar_label" data-value="60">Loading</span>
+    <div class="vtmn-progressbar_label">
+      <span>Loading</span>
+      <span>60%</span>
+    </div>
     <svg>
       <line
         class="vtmn-progressbar_indicator"
         x1="0"
         x2="60%"
-        y1="50%"
-        y2="50%"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container vtmn-progressbar_size--small"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="40"
-  >
-    <svg>
-      <line
-        class="vtmn-progressbar_indicator"
-        x1="0"
-        x2="40%"
         y1="50%"
         y2="50%"
       />
@@ -68,33 +50,15 @@
     aria-valuemax="100"
     aria-valuenow="25"
   >
-    <span class="vtmn-progressbar_label" data-value="25">Loading</span>
+    <div class="vtmn-progressbar_label">
+      <span>Loading</span>
+      <span>25%</span>
+    </div>
     <svg>
       <line
         class="vtmn-progressbar_indicator"
         x1="0"
         x2="25%"
-        y1="50%"
-        y2="50%"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container vtmn-progressbar_size--medium"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="90"
-  >
-    <svg>
-      <line
-        class="vtmn-progressbar_indicator"
-        x1="0"
-        x2="90%"
         y1="50%"
         y2="50%"
       />
@@ -129,33 +93,15 @@
     aria-valuemax="100"
     aria-valuenow="35"
   >
-    <span class="vtmn-progressbar_label" data-value="35">Loading</span>
+    <div class="vtmn-progressbar_label">
+      <span>Loading</span>
+      <span>35%</span>
+    </div>
     <svg>
       <line
         class="vtmn-progressbar_indicator"
         x1="0"
         x2="35%"
-        y1="50%"
-        y2="50%"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container vtmn-progressbar_size--large"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="65"
-  >
-    <svg>
-      <line
-        class="vtmn-progressbar_indicator"
-        x1="0"
-        x2="65%"
         y1="50%"
         y2="50%"
       />
@@ -191,12 +137,10 @@
     aria-valuemax="100"
     aria-valuenow="0"
   >
-    <span
-      id="vtmn-progressbar-label-1"
-      class="vtmn-progressbar_label"
-      data-value="0"
-      >Loading</span
-    >
+    <div class="vtmn-progressbar_label">
+      <span>Loading</span>
+      <span id="vtmn-progressbar-label-1">0%</span>
+    </div>
     <svg>
       <line
         id="vtmn-progressbar-1"

--- a/packages/showcases/css/stories/components/indicators/progressbar/examples/linear.runscript.js
+++ b/packages/showcases/css/stories/components/indicators/progressbar/examples/linear.runscript.js
@@ -5,26 +5,26 @@ function initLinearProgressbarShowcase() {
   let label = document.getElementById('vtmn-progressbar-label-1');
   let progress = document.getElementById(`vtmn-progressbar-1`);
 
-  console.log('label', label);
+  resetProgress(container, progress, label);
+  launchProgress(container, progress, label);
 
-  let type = 'linear';
-
-  resetProgress(container, progress, label, type);
-  launchProgress(container, progress, label, type);
-
-  function launchProgress(container, progress, label, type) {
+  function launchProgress(container, progress, label) {
     setInterval(() => {
       let random = getRandom(1, 15);
-      let currentLabelValue = label.textContent;
+      let textLabel = label.textContent;
+      let currentLabelValue = Number(
+        textLabel.substring(0, textLabel.length - 1),
+      );
+
       let newValue = Number(currentLabelValue + random);
       if (newValue >= 100) {
         newValue = 100;
-        addProgress(container, progress, label, type, newValue);
+        addProgress(container, progress, label, newValue);
         setTimeout(() => {
-          resetProgress(container, progress, label, type);
+          resetProgress(container, progress, label);
         }, 2000);
       } else {
-        addProgress(container, progress, label, type, newValue);
+        addProgress(container, progress, label, newValue);
       }
     }, 1000);
   }
@@ -33,30 +33,16 @@ function initLinearProgressbarShowcase() {
     return Math.ceil(Math.random() * (max - min) + min);
   }
 
-  function addProgress(container, progress, label, type, value) {
-    label.textContent = String(value);
+  function addProgress(container, progress, label, value) {
+    label.textContent = `${value}%`;
     container.setAttribute('aria-valuenow', `${value}`);
-    switch (type) {
-      case 'linear':
-        progress.style.transform = `translateX(calc(-100% + ${value}%))`;
-        break;
-      case 'circular':
-        setCircularProgress(container, progress, value);
-        break;
-    }
+    progress.style.transform = `translateX(calc(-100% + ${value}%))`;
   }
 
-  function resetProgress(container, progress, label, type) {
+  function resetProgress(container, progress, label) {
     label.textContent = '0%';
     container.setAttribute('aria-valuenow', '0');
-    switch (type) {
-      case 'linear':
-        progress.style.transform = `translateX(-105%)`;
-        break;
-      case 'circular':
-        setCircularProgress(container, progress, 0);
-        break;
-    }
+    progress.style.transform = `translateX(-105%)`;
   }
 
   window.removeEventListener('DOMContentLoaded', initLinearProgressbarShowcase);

--- a/packages/showcases/css/stories/components/indicators/progressbar/examples/linear.runscript.js
+++ b/packages/showcases/css/stories/components/indicators/progressbar/examples/linear.runscript.js
@@ -2,8 +2,10 @@ window.addEventListener('DOMContentLoaded', initLinearProgressbarShowcase);
 
 function initLinearProgressbarShowcase() {
   let container = document.getElementById(`vtmn-progressbar-container-1`);
-  let label = document.getElementById(`vtmn-progressbar-label-1`);
+  let label = document.getElementById('vtmn-progressbar-label-1');
   let progress = document.getElementById(`vtmn-progressbar-1`);
+
+  console.log('label', label);
 
   let type = 'linear';
 
@@ -13,7 +15,7 @@ function initLinearProgressbarShowcase() {
   function launchProgress(container, progress, label, type) {
     setInterval(() => {
       let random = getRandom(1, 15);
-      let currentLabelValue = Number(label.getAttribute('data-value'));
+      let currentLabelValue = label.textContent;
       let newValue = Number(currentLabelValue + random);
       if (newValue >= 100) {
         newValue = 100;
@@ -32,7 +34,7 @@ function initLinearProgressbarShowcase() {
   }
 
   function addProgress(container, progress, label, type, value) {
-    label.setAttribute('data-value', `${value}`);
+    label.textContent = String(value);
     container.setAttribute('aria-valuenow', `${value}`);
     switch (type) {
       case 'linear':
@@ -45,7 +47,7 @@ function initLinearProgressbarShowcase() {
   }
 
   function resetProgress(container, progress, label, type) {
-    label.setAttribute('data-value', '0');
+    label.textContent = '0%';
     container.setAttribute('aria-valuenow', '0');
     switch (type) {
       case 'linear':

--- a/packages/showcases/css/stories/components/indicators/progressbar/examples/overview.html
+++ b/packages/showcases/css/stories/components/indicators/progressbar/examples/overview.html
@@ -7,33 +7,15 @@
     aria-valuemax="100"
     aria-valuenow="60"
   >
-    <span class="vtmn-progressbar_label" data-value="60">Loading</span>
+    <div class="vtmn-progressbar_label">
+      <span>Loading</span>
+      <span>60%</span>
+    </div>
     <svg>
       <line
         class="vtmn-progressbar_indicator"
         x1="0"
         x2="60%"
-        y1="50%"
-        y2="50%"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="40"
-  >
-    <svg>
-      <line
-        class="vtmn-progressbar_indicator"
-        x1="0"
-        x2="40%"
         y1="50%"
         y2="50%"
       />
@@ -50,35 +32,8 @@
     aria-valuemax="100"
     aria-valuenow="65"
   >
-    <span class="vtmn-progressbar_label" data-value="65"></span>
+    <span class="vtmn-progressbar_label">65%</span>
     <svg>
-      <circle
-        class="vtmn-progressbar_indicator"
-        stroke-dashoffset="calc(400px - (400px * 65) / 100)"
-        cx="50%"
-        cy="50%"
-        r="64"
-      />
-    </svg>
-  </div>
-</div>
-
-<div class="block">
-  <div
-    class="vtmn-progressbar_container vtmn-progressbar_variant--circular"
-    role="progressbar"
-    aria-label="progress bar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="80"
-  >
-    <img
-      class="vtmn-progressbar_image"
-      src="https://storage.googleapis.com/dkt-design-cdn/images/landscape-placeholder.jpg"
-      alt="Black and white grid"
-    />
-    <svg>
-      <circle class="vtmn-progressbar_track" cx="50%" cy="50%" r="64" />
       <circle
         class="vtmn-progressbar_indicator"
         stroke-dashoffset="calc(400px - (400px * 65) / 100)"

--- a/packages/sources/css/src/components/indicators/progressbar/src/index.css
+++ b/packages/sources/css/src/components/indicators/progressbar/src/index.css
@@ -24,13 +24,6 @@
   width: 100%;
 }
 
-.vtmn-progressbar_label::after {
-  width: fit-content;
-  content: attr(data-value) '%';
-  position: absolute;
-  right: 0;
-}
-
 .vtmn-progressbar_indicator {
   width: 100%;
   height: 100%;
@@ -40,6 +33,14 @@
   transition: all 200ms;
 }
 
+.vtmn-progressbar_container:not(.vtmn-progressbar_variant--circular)
+  .vtmn-progressbar_label {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
 /* Circle */
 .vtmn-progressbar_variant--circular.vtmn-progressbar_container {
   width: rem(136px);
@@ -47,17 +48,23 @@
 }
 
 .vtmn-progressbar_variant--circular .vtmn-progressbar_label {
-  width: 100%;
-  height: 100%;
-}
-
-.vtmn-progressbar_variant--circular .vtmn-progressbar_label::after {
+  width: fit-content;
+  position: absolute;
+  right: 0;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   font-size: var(--vtmn-typo_title-3-font-size);
   font-weight: var(--vtmn-typo_font-weight--bold);
 }
+
+/* .vtmn-progressbar_variant--circular .vtmn-progressbar_label::after {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: var(--vtmn-typo_title-3-font-size);
+  font-weight: var(--vtmn-typo_font-weight--bold);
+} */
 
 .vtmn-progressbar_variant--circular .vtmn-progressbar_image {
   max-width: rem(112px);
@@ -101,7 +108,7 @@
 }
 
 .vtmn-progressbar_size--small.vtmn-progressbar_variant--circular
-  .vtmn-progressbar_label::after {
+  .vtmn-progressbar_label {
   font-size: var(--vtmn-typo_text-1-font-size);
   font-weight: var(--vtmn-typo_font-weight--normal);
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Remove `progressbar` without progression label
- The `%` is part of the HTML and is not added by the CSS anymore
- Refactor the demo in consequence

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Some progressbar showcases didn't pass the a11y requirements. We need to enhance them to become accessible.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes, you need to add the `%` in the progressbar bar.
- The `:after` selector is not used anymore.
- Linear progressbar uses two `span`s to display the progression indicator.
