### PR TITLE
feat(@vtmn/css-breadcrumb): add a11y aria-current

### DIFF
--- a/packages/showcases/css/stories/components/navigation/breadcrumb/examples/overview.html
+++ b/packages/showcases/css/stories/components/navigation/breadcrumb/examples/overview.html
@@ -1,15 +1,15 @@
 <div class="block">
-  <nav aria-label="Breadcrumb" class="vtmn-breadcrumb">
+  <nav aria-label="Breadcrumb 1" class="vtmn-breadcrumb">
     <ol>
       <li><a href="">Home</a></li>
       <li><a href="">Page 2</a></li>
-      <li aria-label="Current page title">Current</li>
+      <li aria-current="page">Current</li>
     </ol>
   </nav>
 </div>
 
 <div class="block">
-  <nav aria-label="Breadcrumb" class="vtmn-breadcrumb">
+  <nav aria-label="Breadcrumb 2" class="vtmn-breadcrumb">
     <ol>
       <li>
         <span class="vtmx-home-line" aria-hidden="true"></span
@@ -17,13 +17,13 @@
       </li>
       <li><a href="">New</a></li>
       <li><a href="">Children</a></li>
-      <li aria-label="Current page title">Tee-shirt</li>
+      <li aria-current="page">Tee-shirt</li>
     </ol>
   </nav>
 </div>
 
 <div class="block">
-  <nav aria-label="Breadcrumb" class="vtmn-breadcrumb">
+  <nav aria-label="Breadcrumb 3" class="vtmn-breadcrumb">
     <ol>
       <li>
         <span class="vtmx-home-line" aria-hidden="true"></span
@@ -41,7 +41,7 @@
         <span class="vtmx-user-line" aria-hidden="true"></span
         ><a href="">Children</a>
       </li>
-      <li aria-label="Current page title">
+      <li aria-current="page">
         <span class="vtmx-t-shirt-line" aria-hidden="true"></span>Tee-shirt
       </li>
     </ol>
@@ -49,14 +49,14 @@
 </div>
 
 <div class="block">
-  <nav aria-label="Breadcrumb" class="vtmn-breadcrumb">
+  <nav aria-label="Breadcrumb 4" class="vtmn-breadcrumb">
     <ol>
       <li>
         <span class="vtmx-home-line" aria-hidden="true"></span
         ><a href="">Home</a>
       </li>
       <li><button>...</button></li>
-      <li aria-label="Current page title">Tee-shirt</li>
+      <li aria-current="page">Tee-shirt</li>
     </ol>
   </nav>
 </div>

--- a/packages/sources/css/src/components/navigation/breadcrumb/src/index.css
+++ b/packages/sources/css/src/components/navigation/breadcrumb/src/index.css
@@ -18,7 +18,7 @@
 
 .vtmn-breadcrumb a {
   text-decoration: none;
-  line-height: 0;
+  line-height: 1;
   color: inherit;
   transition: var(--vtmn-transition_focus-visible);
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Replace the `aria-label` by `aria-current="page"` to show the current page of the breadcrumb
- `line-height` set to 1 instead of 0;

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Add a11y requirements for the breadcrumb

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

