### PR TITLE
feat(@vtmn/css, @vtmn/svelte): add ARIA a11y feature

### DIFF
--- a/packages/showcases/css/stories/components/navigation/navbar/examples/overview.html
+++ b/packages/showcases/css/stories/components/navigation/navbar/examples/overview.html
@@ -71,7 +71,10 @@
 <div class="block">
   <nav class="vtmn-navbar" aria-label="Navbar with icons">
     <div class="vtmn-navbar_left-navigation">
-      <button class="vtmn-btn vtmn-btn--icon-alone vtmn-btn_variant--ghost">
+      <button
+        class="vtmn-btn vtmn-btn--icon-alone vtmn-btn_variant--ghost"
+        aria-expanded="false"
+      >
         <span class="vtmn-sr-only">Menu</span>
         <span class="vtmx-menu-line" aria-hidden="true"></span>
       </button>
@@ -133,7 +136,10 @@
 <div class="block">
   <nav class="vtmn-navbar" aria-label="Navbar with buttons">
     <div class="vtmn-navbar_left-navigation">
-      <button class="vtmn-btn vtmn-btn--icon-alone vtmn-btn_variant--ghost">
+      <button
+        class="vtmn-btn vtmn-btn--icon-alone vtmn-btn_variant--ghost"
+        aria-expanded="false"
+      >
         <span class="vtmn-sr-only">Menu</span>
         <span class="vtmx-menu-line" aria-hidden="true"></span>
       </button>

--- a/packages/showcases/svelte/stories/components/navigation/VtmnNavbar/VtmnNavbar.stories.svelte
+++ b/packages/showcases/svelte/stories/components/navigation/VtmnNavbar/VtmnNavbar.stories.svelte
@@ -50,7 +50,11 @@
   <div style="width: 800px; display: flex; justify-content: center">
     <VtmnNavbar {...args}>
       <svelte:fragment slot="left-nav">
-        <VtmnButton iconAlone="menu-line" variant="ghost" />
+        <VtmnButton
+          iconAlone="menu-line"
+          variant="ghost"
+          aria-expanded="false"
+        />
       </svelte:fragment>
 
       <svelte:fragment slot="logo">
@@ -98,7 +102,11 @@
   <div style="width: 800px; display: flex; justify-content: center">
     <VtmnNavbar {...args}>
       <svelte:fragment slot="left-nav">
-        <VtmnButton iconAlone="menu-line" variant="ghost" />
+        <VtmnButton
+          iconAlone="menu-line"
+          variant="ghost"
+          aria-expanded="false"
+        />
       </svelte:fragment>
 
       <svelte:fragment slot="logo">


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add `aria-expanded` on the menu button of the `navbar` (svelte and css)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- The `navbar` needs some improvements to match a11y standards

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No breaking changes, but you should use the new `aria-expanded` attribute 
