### PR TITLE
fix(@vtmn/css): edit `button` icon sizes, increase icon sizes for `icon-alone` variant, a11y 

### DIFF
--- a/packages/sources/css/src/components/actions/button/src/index.css
+++ b/packages/sources/css/src/components/actions/button/src/index.css
@@ -317,7 +317,7 @@
 
 .vtmn-btn_size--large.vtmn-btn--icon-right span[class^='vtmx-'] {
   padding-inline-start: rem(12px);
-  rem(24px)
+  font-size: rem(24px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-left svg {

--- a/packages/sources/css/src/components/actions/button/src/index.css
+++ b/packages/sources/css/src/components/actions/button/src/index.css
@@ -239,7 +239,7 @@
 }
 
 .vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_text-2-font-size);
+  font-size: var(--vtmn-typo_title-5-font-size);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-alone {
@@ -249,7 +249,7 @@
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_text-3-font-size);
+  font-size: var(--vtmn-typo_text-2-font-size);
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-alone {
@@ -259,7 +259,7 @@
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_text-2-font-size);
+  font-size: var(--vtmn-typo_title-5-font-size);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-alone {
@@ -269,7 +269,7 @@
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_title-5-font-size);
+  font-size: var(--vtmn-typo_title-4-font-size);
 }
 
 .vtmn-btn--icon-left span[class^='vtmx-'],

--- a/packages/sources/css/src/components/actions/button/src/index.css
+++ b/packages/sources/css/src/components/actions/button/src/index.css
@@ -13,10 +13,10 @@
   justify-content: center;
   align-items: center;
   position: relative;
-  height: rem(48px);
+  block-size: rem(48px);
   border: 0;
   line-height: 1;
-  width: max-content;
+  inline-size: max-content;
   padding: rem(14px) rem(24px);
   font-family: var(--vtmn-typo_font-family);
   font-weight: var(--vtmn-typo_font-weight--bold);
@@ -209,80 +209,83 @@
 .vtmn-btn_size--small {
   font-size: rem(14px);
   padding: rem(8px) rem(16px);
-  height: rem(32px);
+  block-size: rem(32px);
   letter-spacing: rem(0.24px);
 }
 
 .vtmn-btn_size--medium {
   font-size: rem(16px);
   padding: rem(14px) rem(24px);
-  height: rem(48px);
+  block-size: rem(48px);
   letter-spacing: rem(0.27px);
 }
 
 .vtmn-btn_size--large {
   font-size: rem(20px);
   padding: rem(20px) rem(40px);
-  height: rem(64px);
+  block-size: rem(64px);
   letter-spacing: rem(0.34px);
 }
 
 .vtmn-btn_size--stretched {
-  width: 100%;
+  inline-size: 100%;
 }
 
 /* Button icons  */
 .vtmn-btn--icon-alone {
-  width: rem(48px);
-  height: rem(48px);
+  inline-size: rem(48px);
+  block-size: rem(48px);
   padding: rem(14px);
 }
 
 .vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_title-5-font-size);
+  font-size: rem(24px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-alone {
-  width: rem(32px);
-  height: rem(32px);
+  inline-size: rem(32px);
+  block-size: rem(32px);
   padding: rem(8px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_text-2-font-size);
+  font-size: rem(20px);
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-alone {
-  width: rem(48px);
-  height: rem(48px);
+  inline-size: rem(48px);
+  block-size: rem(48px);
   padding: rem(14px);
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_title-5-font-size);
+  font-size: rem(24px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-alone {
-  width: rem(64px);
-  height: rem(64px);
+  inline-size: rem(64px);
+  block-size: rem(64px);
   padding: rem(20px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-alone span[class^='vtmx-'] {
-  font-size: var(--vtmn-typo_title-4-font-size);
+  font-size: rem(32px);
 }
 
 .vtmn-btn--icon-left span[class^='vtmx-'],
 .vtmn-btn_size--medium.vtmn-btn--icon-left span[class^='vtmx-'] {
   padding-inline-end: rem(8px);
+  font-size: rem(20px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-left span[class^='vtmx-'] {
   padding-inline-end: rem(6px);
+  font-size: rem(16px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-right span[class^='vtmx-'] {
   padding-inline-start: rem(6px);
+  font-size: rem(16px);
 }
 
 .vtmn-btn_size--small.vtmn-btn--icon-left svg {
@@ -296,6 +299,7 @@
 .vtmn-btn--icon-right span[class^='vtmx-'],
 .vtmn-btn_size--medium.vtmn-btn--icon-right span[class^='vtmx-'] {
   padding-inline-start: rem(8px);
+  font-size: rem(20px);
 }
 
 .vtmn-btn_size--medium.vtmn-btn--icon-left svg {
@@ -308,10 +312,12 @@
 
 .vtmn-btn_size--large.vtmn-btn--icon-left span[class^='vtmx-'] {
   padding-inline-end: rem(12px);
+  font-size: rem(24px);
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-right span[class^='vtmx-'] {
   padding-inline-start: rem(12px);
+  rem(24px)
 }
 
 .vtmn-btn_size--large.vtmn-btn--icon-left svg {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

For icon-left / icon-right vairants :

- Small button icon goes from `--vtmn-typo_text-3-font-size` to `16px`
- Medium (default) button icon goes from `--vtmn-typo_text-2-font-size` to `20px`
- Small button icon goes from `--vtmn-typo_title-5-font-size` to `24px`

For icon-alone vairants :

- Small button icon goes from `--vtmn-typo_text-3-font-size` to `20px`
- Medium (default) button icon goes from `--vtmn-typo_text-2-font-size` to `24px`
- Small button icon goes from `--vtmn-typo_title-5-font-size` to `32px`

Accessibility:

- `width` turned into `inline-size`
- `height` turned into `block-size` 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Icon in `buttons` were smaller than in the design library.
- Add a11y on the css sizes

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
