### PR TITLE
feat(@vtmn/css-quantity): no default border

### DIFF
--- a/packages/sources/css/src/components/selection-controls/quantity/src/index.css
+++ b/packages/sources/css/src/components/selection-controls/quantity/src/index.css
@@ -29,6 +29,7 @@
 
 .vtmn-quantity input[type='number'] {
   outline: 0;
+  border: 0;
   width: rem(60px);
   padding: 0 rem(2px);
   background-color: var(--vtmn-semantic-color_background-primary);


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add `border: 0` 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- In some browsers, the `quantity` input has a default border, it shouldn't have one.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
