### PR TITLE
fix(@vtmn/svelte): `VtmnModal` add flex auto + remove overflow indicator

### DIFF
--- a/packages/sources/css/src/components/overlays/modal/src/index.css
+++ b/packages/sources/css/src/components/overlays/modal/src/index.css
@@ -52,6 +52,7 @@
   font-weight: var(--vtmn-typo_font-weight--bold);
   font-size: rem(26px);
   line-height: rem(32px);
+  flex: auto;
 }
 
 .vtmn-modal_content_title .vtmn-btn {
@@ -75,12 +76,12 @@
 }
 
 .vtmn-modal_content_body--text {
-  padding-bottom: rem(30px);
   font-weight: var(--vtmn-typo_font-weight--normal);
   font-size: var(--vtmn-typo_text-3-font-size);
   line-height: rem(24px);
   align-self: flex-start;
   text-align: left;
+  flex: auto;
 }
 
 .vtmn-modal_content_actions {

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -67,9 +67,6 @@
             <slot name="description" />
           </p>
         {/if}
-        {#if $$slots.actions}
-          <div class="vtmn-modal_content_body--overflow-indicator" />
-        {/if}
       </div>
       {#if $$slots.actions}
         <div class="vtmn-modal_content_actions">

--- a/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/test/VtmnModal.spec.js
@@ -123,21 +123,9 @@ describe('VtmnModal', () => {
         });
         expect(getContentActions(container)).toBeUndefined();
       });
-      test("Should not have a class 'vtmn-modal_content_body--overflow-indicator'", () => {
-        const { container } = render(VtmnModalWithoutActions, {
-          open: true,
-        });
-        expect(getOverFlow(container)).toBeUndefined();
-      });
     });
 
     describe('With slot description and actions', () => {
-      test("Should have a class 'vtmn-modal_content_body--overflow-indicator'", () => {
-        const { container } = render(VtmnModalWithActions, {
-          open: true,
-        });
-        expect(getOverFlow(container)).toBeVisible();
-      });
       test('Should have a slot actions', () => {
         const { container } = render(VtmnModalWithActions, {
           open: true,


### PR DESCRIPTION
Add some changes on the component : 
- Remove the `vtmn-modal_content_body--overflow-indicator` on svelte (PR https://github.com/Decathlon/vitamin-web/pull/1068)
- Add `flex: auto` on title to make the title take all the remaining width.
- Add `flex: auto` on description to make the description content fill all the page. This fix will set the action div always on the bottom of the modal.
- Remove `padding-bottom` not necessary since `vtmn-modal_content_body--overflow-indicator` are removed