### PR TITLE
fix(@vtmn/css): move flex auto to body

### DIFF
--- a/packages/sources/css/src/components/overlays/modal/src/index.css
+++ b/packages/sources/css/src/components/overlays/modal/src/index.css
@@ -73,6 +73,7 @@
 .vtmn-modal_content_body {
   margin: rem(16px) 0;
   overflow-y: auto;
+  flex: auto;
 }
 
 .vtmn-modal_content_body--text {
@@ -81,7 +82,6 @@
   line-height: rem(24px);
   align-self: flex-start;
   text-align: left;
-  flex: auto;
 }
 
 .vtmn-modal_content_actions {


### PR DESCRIPTION
Refer to https://github.com/Decathlon/vitamin-web/pull/1143

`flex: auto` must be set on the class `.vtmn-modal_content_body` and not `.vtmn-modal_content_body--text`

![image](https://user-images.githubusercontent.com/2856778/167139382-e65ed4b6-0fd2-4f73-b77a-801bca257762.png)
![image](https://user-images.githubusercontent.com/2856778/167139433-e8ca9d4c-0769-47c3-a030-bdc2cd9ff457.png)
