### PR TITLE
fix(@vtmn/svelte): move overlay id to uuid

### DIFF
--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
@@ -1,13 +1,9 @@
 import { writable } from 'svelte/store';
+import { uuid } from '../../../utils/math';
 
 class VtmnAlertStore {
   constructor() {
     this._alerts = writable([]);
-    this._id = 0;
-  }
-
-  get newId() {
-    return ++this._id;
   }
 
   send({ variant, title, description, withCloseButton, ...attributes }) {
@@ -19,7 +15,7 @@ class VtmnAlertStore {
         title,
         description,
         withCloseButton,
-        id: this.newId,
+        id: `vtmn-alert-${uuid()}`,
       },
     ]);
   }

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/vtmnSnackbarStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/vtmnSnackbarStore.js
@@ -1,17 +1,15 @@
 import { writable } from 'svelte/store';
+import { uuid } from '../../../utils/math';
 
 class VtmnSnackbarStore {
   constructor() {
     this._snackbar = writable([]);
-    this._id = 0;
-  }
-
-  get newId() {
-    return ++this._id;
   }
 
   send({ content, withCloseButton, action }) {
-    this._snackbar.set([{ content, withCloseButton, action, id: this.newId }]);
+    this._snackbar.set([
+      { content, withCloseButton, action, id: `vtmn-snackbar-${uuid()}` },
+    ]);
   }
 
   close() {

--- a/packages/sources/svelte/src/components/overlays/VtmnToast/vtmnToastStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnToast/vtmnToastStore.js
@@ -1,19 +1,15 @@
 import { writable } from 'svelte/store';
+import { uuid } from '../../../utils/math';
 
 class VtmnToastStore {
   constructor() {
     this._toasts = writable([]);
-    this._id = 0;
-  }
-
-  get newId() {
-    return ++this._id;
   }
 
   send({ content, withCloseButton, withIcon }) {
     this._toasts.update((state) => [
       ...state,
-      { content, withCloseButton, withIcon, id: this.newId },
+      { content, withCloseButton, withIcon, id: `vtmn-toast-${uuid()}` },
     ]);
   }
 

--- a/packages/sources/svelte/src/utils/math.js
+++ b/packages/sources/svelte/src/utils/math.js
@@ -5,3 +5,11 @@ export function isFloat(n) {
 export function isInteger(n) {
   return n === +n && n === (n | 0);
 }
+
+export function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
Before : 
- `VtmnOverlays` are generate id by increment a number.
This way wan provide duplicate id in the DOM.

After : 
- Generate uuid and prefix with the component name.
This way prevent all duplicate id in the DOM.