### PR TITLE
fix(@vtmn/svelte): `VtmnSearch` hide clear button if no value

### DIFF
--- a/packages/showcases/svelte/stories/components/navigation/VtmnSearch/VtmnSearch.stories.svelte
+++ b/packages/showcases/svelte/stories/components/navigation/VtmnSearch/VtmnSearch.stories.svelte
@@ -10,7 +10,26 @@
 <Meta
   title="Components / Navigation / VtmnSearch"
   component={VtmnSearch}
-  {argTypes}
+  argTypes={{
+    ...argTypes,
+    ariaLabels: {
+      type: 'object',
+      description: 'Aria labels of the component.',
+      control: {
+        type: 'object',
+        properties: {
+          clearButton: {
+            type: 'string',
+            description: 'Aria label of the clear button.',
+          },
+          searchButton: {
+            type: 'string',
+            description: 'Aria label of the search button.',
+          },
+        },
+      },
+    },
+  }}
   {parameters}
 />
 

--- a/packages/sources/svelte/src/components/navigation/VtmnSearch/VtmnSearch.svelte
+++ b/packages/sources/svelte/src/components/navigation/VtmnSearch/VtmnSearch.svelte
@@ -33,6 +33,18 @@
   export let value;
 
   /**
+   * @typedef AriaLabels
+   * @type {object}
+   * @property {string} clearButton - Aria label of the clear button.
+   * @property {string} searchButton - Aria label of the search button.
+   */
+
+  /**
+   * @type {AriaLabels} Aria labels of the component.
+   */
+  export let ariaLabels = {};
+
+  /**
    * Custom classes to apply to the component.
    * @type {string}
    */
@@ -77,15 +89,17 @@
   />
 
   <div class="vtmn-search_buttons">
-    <VtmnButton
-      iconAlone="close-line"
-      variant="ghost"
-      {disabled}
-      {size}
-      on:click={resetInputValue}
-      aria-label="close"
-      aria-disabled={disabled}
-    />
+    {#if value}
+      <VtmnButton
+        iconAlone="close-line"
+        variant="ghost"
+        {disabled}
+        {size}
+        on:click={resetInputValue}
+        aria-label={ariaLabels.clearButton}
+        aria-disabled={disabled}
+      />
+    {/if}
 
     <VtmnButton
       iconAlone="search-line"
@@ -94,7 +108,7 @@
       {size}
       on:click={onSearch}
       type="submit"
-      aria-label="search"
+      aria-label={ariaLabels.searchButton}
     />
   </div>
 </div>

--- a/packages/sources/svelte/src/components/navigation/VtmnSearch/test/VtmnSearch.spec.js
+++ b/packages/sources/svelte/src/components/navigation/VtmnSearch/test/VtmnSearch.spec.js
@@ -3,7 +3,13 @@ import VtmnSearch from '../VtmnSearch.svelte';
 import { VTMN_SEARCH_VARIANT, VTMN_SEARCH_SIZE } from '../enums';
 
 describe('<VtmnSearch />', () => {
-  const props = { value: 'input value unit test' };
+  const props = {
+    value: 'input value unit test',
+    ariaLabels: {
+      clearButton: 'clear',
+      searchButton: 'search',
+    },
+  };
   test('Renders correctly', () => {
     const { container } = render(VtmnSearch, { ...props });
 
@@ -21,6 +27,26 @@ describe('<VtmnSearch />', () => {
         `vtmn-search_variant--${VTMN_SEARCH_VARIANT.PERSISTENT}`,
       ).length,
     ).toBe(1);
+  });
+
+  test('Should not display clear button', () => {
+    const { queryByLabelText } = render(VtmnSearch, {
+      value: '',
+      ariaLabels: {
+        clearButton: 'clear button',
+      },
+    });
+    expect(queryByLabelText('clear button')).toBeNull();
+  });
+
+  test('Should display clear button if value are defined', () => {
+    const { getByLabelText } = render(VtmnSearch, {
+      ...props,
+      ariaLabels: {
+        clearButton: 'clear button',
+      },
+    });
+    expect(getByLabelText('clear button')).toBeVisible();
   });
 
   test('Renders correctly on-content variant', () => {
@@ -72,10 +98,10 @@ describe('<VtmnSearch />', () => {
       ...props,
       value: 'test',
     });
-    const closeButton = getAllByLabelText('close')[0];
+    const clearButton = getAllByLabelText('clear')[0];
     const input = container.getElementsByTagName('input')[0];
 
-    await fireEvent.click(closeButton);
+    await fireEvent.click(clearButton);
 
     expect(input.value).toBe('');
   });


### PR DESCRIPTION
Enhancement on the `VtmnSearch`
- Add property `ariaLabels` to defined aria labels on component's elements
- Add condition in order to hide clear button if value are not defined