### PR TITLE
fix(@vtmn/react): `VtmnSearch` 'enter' key inside form tag do not clear input

### DIFF
--- a/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
@@ -85,6 +85,7 @@ export const VtmnSearch = ({
             iconAlone="close-line"
             onClick={() => setSearch('')}
             aria-label="close"
+            type="button"
           />
         )}
 


### PR DESCRIPTION
## Changes description
Button type added on the "clear" button to be able to press enter to submit when the `VtmnSearch` component is used inside a `form` tag.

## Context
When `VtmnSearch` is used inside a `form` tag, press "enter" key empty the input and the submit event is not triggered.
It seems like the "clear" button "catch" the enter event and act like it's clicked.

It can be reproduced in the following codesandbox:
https://codesandbox.io/s/vtmnsearch-submit-issue-fsi0f8?file=/src/App.js

Adding a type on the "clear" button fix the issue.

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
No
