### PR TITLE
fix(@vtmn/css): color class for rating interactive

### DIFF
--- a/packages/showcases/css/stories/components/indicators/rating/examples/overview.html
+++ b/packages/showcases/css/stories/components/indicators/rating/examples/overview.html
@@ -1,7 +1,7 @@
 <div class="block">
-  <div class="vtmn-rating vtmn-rating_size--brand">
+  <div class="vtmn-rating">
     <div
-      class="vtmn-rating--interactive vtmn-rating_variant--primary"
+      class="vtmn-rating--interactive"
       aria-label="Rate the article"
       role="radiogroup"
     >

--- a/packages/showcases/css/stories/components/indicators/rating/examples/overview.html
+++ b/packages/showcases/css/stories/components/indicators/rating/examples/overview.html
@@ -1,7 +1,7 @@
 <div class="block">
-  <div class="vtmn-rating">
+  <div class="vtmn-rating vtmn-rating_size--brand">
     <div
-      class="vtmn-rating--interactive"
+      class="vtmn-rating--interactive vtmn-rating_variant--primary"
       aria-label="Rate the article"
       role="radiogroup"
     >

--- a/packages/sources/css/src/components/indicators/rating/src/index.css
+++ b/packages/sources/css/src/components/indicators/rating/src/index.css
@@ -23,9 +23,25 @@
   block-size: rem(32px);
   inline-size: calc(rem(40px) * 5);
   min-inline-size: calc(rem(40px) * 5);
-  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='%23007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
   background-size: rem(40px) rem(32px);
   outline: 0;
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--primary {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--primary-reversed {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#FFFFFF' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--brand {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--brand-reversed {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#3D9ACC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
 }
 
 .vtmn-rating--interactive:focus-visible {
@@ -68,7 +84,35 @@
 
 .vtmn-rating--interactive input:checked + label,
 .vtmn-rating--interactive input:focus + label {
-  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='%23007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--primary input:checked + label,
+.vtmn-rating--interactive.vtmn-rating_variant--primary input:focus + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--primary-reversed
+  input:checked
+  + label,
+.vtmn-rating--interactive.vtmn-rating_variant--primary-reversed
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#FFFFFF' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--brand input:checked + label,
+.vtmn-rating--interactive.vtmn-rating_variant--brand input:focus + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating--interactive.vtmn-rating_variant--brand-reversed
+  input:checked
+  + label,
+.vtmn-rating--interactive.vtmn-rating_variant---brand-reversed
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#3D9ACC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
 }
 
 .vtmn-rating--interactive input {
@@ -146,8 +190,28 @@
   block-size: rem(16px);
   inline-size: calc(rem(20px) * 5);
   min-inline-size: calc(rem(20px) * 5);
-  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='%23007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
   background-size: rem(20px) rem(16px);
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary-reversed {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#FFFFFF' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand-reversed {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#3D9ACC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
 }
 
 .vtmn-rating_size--small > .vtmn-rating--interactive label {
@@ -176,7 +240,51 @@
 
 .vtmn-rating_size--small > .vtmn-rating--interactive input:checked + label,
 .vtmn-rating_size--small > .vtmn-rating--interactive input:focus + label {
-  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='%23007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary
+  input:checked
+  + label,
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary-reversed
+  input:checked
+  + label,
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary-reversed
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#FFFFFF' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand
+  input:checked
+  + label,
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand-reversed
+  input:checked
+  + label,
+.vtmn-rating_size--small
+  > .vtmn-rating--interactive.vtmn-rating_variant---brand-reversed
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='16' height='16' viewBox='0 0 16 16' fill='#3D9ACC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
 }
 
 /* Medium */
@@ -196,8 +304,28 @@
   block-size: rem(32px);
   inline-size: calc(rem(40px) * 5);
   min-inline-size: calc(rem(40px) * 5);
-  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='%23007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
   background-size: rem(40px) rem(32px);
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary-reversed {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#FFFFFF' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand-reversed {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#3D9ACC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M3.298 14.805 8 12.173l4.702 2.632-1.05-5.285 3.957-3.659-5.352-.634L8 .333 5.743 5.227.39 5.86l3.958 3.66-1.05 5.285zm7.533-2.575L8 10.645 5.169 12.23 5.8 9.048 3.42 6.845l3.222-.382L8 3.517l1.359 2.946 3.222.382-2.382 2.203.632 3.182z'/></svg>");
 }
 
 .vtmn-rating_size--medium > .vtmn-rating--interactive label {
@@ -226,5 +354,49 @@
 
 .vtmn-rating_size--medium > .vtmn-rating--interactive input:checked + label,
 .vtmn-rating_size--medium > .vtmn-rating--interactive input:focus + label {
-  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='%23007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary
+  input:checked
+  + label,
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#001018' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary-reversed
+  input:checked
+  + label,
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--primary-reversed
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#FFFFFF' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand
+  input:checked
+  + label,
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#007DBC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
+}
+
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant--brand-reversed
+  input:checked
+  + label,
+.vtmn-rating_size--medium
+  > .vtmn-rating--interactive.vtmn-rating_variant---brand-reversed
+  input:focus
+  + label {
+  background-image: url("data:image/svg+xml;charset=utf-8, <svg width='32' height='32' viewBox='0 0 16 16' fill='#3D9ACC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='m8 12.173-4.702 2.632 1.05-5.285L.391 5.861l5.352-.634L8 .333l2.257 4.894 5.352.634-3.957 3.659 1.05 5.285L8 12.173z'/></svg>");
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add 4 variant colors for the interactive `rating` : `primary`, `primary-reversed`, `brand` and `brand-reversed` available with their respecting classes : `vtmn-rating_variant--primary`, `vtmn-rating_variant--primary-reversed`, `vtmn-rating_variant--brand` an `vtmn-rating_variant--brand-reversed`

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- The interactive `rating` is built differently than the reading-only `rating`. Unfortunately, with this implementation it can't automatically switch color according to the color theme. We have created 4 classes to apply to the interactive `rating` to bypass this and to avoid breaking change on the component.
- This PR close #1176 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
