### PR TITLE
fix(@vtmn/css): change borders `quantity` component

### DIFF
--- a/packages/sources/css/src/components/selection-controls/quantity/src/index.css
+++ b/packages/sources/css/src/components/selection-controls/quantity/src/index.css
@@ -34,7 +34,7 @@
   padding-inline: rem(2px);
   border: 0;
   background-color: var(--vtmn-semantic-color_background-primary);
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary);
+  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-inactive);
   text-align: center;
   z-index: 1;
   appearance: textfield;
@@ -47,7 +47,7 @@
 }
 
 .vtmn-quantity input[type='number']:not(:disabled, :focus):hover {
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary),
+  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-inactive),
     0 0 0 rem(3px) var(--vtmn-semantic-color_hover-primary);
 }
 
@@ -81,6 +81,7 @@
 .vtmn-quantity .vtmn-btn {
   min-inline-size: rem(48px);
   min-block-size: rem(48px);
+  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-inactive);
 }
 
 .vtmn-quantity .vtmn-btn:focus-visible {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- `quantity` default borders (input + buttons) is similar to the `text-input`'s.
- Change from `rem(2px) var(--vtmn-semantic-color_border-secondary)` to `rem(1px) var(--vtmn-semantic-color_border-inactive)` 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- The `text-input` and the `quantity` component weren't very similar so it causes a lack of homogeneity.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
