### PR TITLE
fix(@vtmn/css): linear gradient full image card

### DIFF
--- a/packages/sources/css/src/components/structure/card/src/index.css
+++ b/packages/sources/css/src/components/structure/card/src/index.css
@@ -139,9 +139,8 @@
   > .vtmn-card_content:not(.vtmn-card_content--opaque) {
   background: linear-gradient(
     180deg,
-    color-mod(var(--vtmn-semantic-color_background-primary-reversed) alpha(0%))
-      20%,
-    var(--vtmn-semantic-color_background-primary-reversed) 100%
+    color-mod(var(--vtmn-semantic-color_background-primary-reversed) alpha(0%)),
+    var(--vtmn-semantic-color_background-primary-reversed)
   );
 }
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Gradient goes from 0% to 100% of the card height instead of 20% to 100%

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- The current linear gradient on the `card` component may cause accessibility problems.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

