### PR TITLE
feat(@vtmn/css): change border colors, add missing colors in color themes

### DIFF
--- a/packages/showcases/css/.storybook/preview-head.html
+++ b/packages/showcases/css/.storybook/preview-head.html
@@ -8,7 +8,7 @@
   .extended-toolbar {
     background-color: var(--vtmn-semantic-color_background-primary);
     padding: 1rem;
-    border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
+    border-bottom: 1px solid var(--vtmn-semantic-color_border-primary);
     width: 100%;
     z-index: 50;
     position: fixed;
@@ -76,10 +76,10 @@
     color: var(--vtmn-base-color_black);
   }
   .sbdocs-preview {
-    border-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-color: var(--vtmn-semantic-color_border-primary)!important;
   }
   .sbdocs-h2 {
-    border-bottom-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-bottom-color: var(--vtmn-semantic-color_border-primary)!important;
     font-family: var(--vtmn-typo_font-family)!important;
   }
   .sbdocs-h1, .sbdocs-h2 {
@@ -89,7 +89,7 @@
     font-weight: var(--vtmn-typo_font-weight--bold)!important;
   }
   .docblock-source {
-    border: 1px solid var(--vtmn-semantic-color_border-secondary)!important;
+    border: 1px solid var(--vtmn-semantic-color_border-primary)!important;
     background-color: var(--vtmn-semantic-color_background-secondary)!important;
   }
   .docblock-colorpalette * {

--- a/packages/showcases/icons/.storybook/preview-head.html
+++ b/packages/showcases/icons/.storybook/preview-head.html
@@ -34,7 +34,7 @@
   .extended-toolbar {
     background-color: var(--vtmn-semantic-color_background-primary);
     padding: 1rem;
-    border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
+    border-bottom: 1px solid var(--vtmn-semantic-color_border-primary);
     width: 100%;
     z-index: 50;
     position: fixed;
@@ -102,10 +102,10 @@
     color: var(--vtmn-base-color_black);
   }
   .sbdocs-preview {
-    border-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-color: var(--vtmn-semantic-color_border-primary)!important;
   }
   .sbdocs-h2 {
-    border-bottom-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-bottom-color: var(--vtmn-semantic-color_border-primary)!important;
     font-family: var(--vtmn-typo_font-family)!important;
   }
   .sbdocs-h1, .sbdocs-h2 {
@@ -115,7 +115,7 @@
     font-weight: var(--vtmn-typo_font-weight--bold)!important;
   }
   .docblock-source {
-    border: 1px solid var(--vtmn-semantic-color_border-secondary)!important;
+    border: 1px solid var(--vtmn-semantic-color_border-primary)!important;
     background-color: var(--vtmn-semantic-color_background-secondary)!important;
   }
   .docblock-colorpalette * {

--- a/packages/showcases/react/.storybook/preview-head.html
+++ b/packages/showcases/react/.storybook/preview-head.html
@@ -8,7 +8,7 @@
   .extended-toolbar {
     background-color: var(--vtmn-semantic-color_background-primary);
     padding: 1rem;
-    border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
+    border-bottom: 1px solid var(--vtmn-semantic-color_border-primary);
     width: 100%;
     z-index: 50;
     position: fixed;
@@ -102,10 +102,10 @@
     color: var(--vtmn-base-color_black);
   }
   .sbdocs-preview {
-    border-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-color: var(--vtmn-semantic-color_border-primary)!important;
   }
   .sbdocs-h2 {
-    border-bottom-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-bottom-color: var(--vtmn-semantic-color_border-primary)!important;
     font-family: var(--vtmn-typo_font-family)!important;
   }
   .sbdocs-h1, .sbdocs-h2 {
@@ -115,7 +115,7 @@
     font-weight: var(--vtmn-typo_font-weight--bold)!important;
   }
   .docblock-source {
-    border: 1px solid var(--vtmn-semantic-color_border-secondary)!important;
+    border: 1px solid var(--vtmn-semantic-color_border-primary)!important;
     background-color: var(--vtmn-semantic-color_background-secondary)!important;
   }
   .docblock-colorpalette * {

--- a/packages/showcases/svelte/.storybook/preview-head.html
+++ b/packages/showcases/svelte/.storybook/preview-head.html
@@ -8,7 +8,7 @@
   .extended-toolbar {
     background-color: var(--vtmn-semantic-color_background-primary);
     padding: 1rem;
-    border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
+    border-bottom: 1px solid var(--vtmn-semantic-color_border-primary);
     width: 100%;
     z-index: 50;
     position: fixed;
@@ -102,10 +102,10 @@
     color: var(--vtmn-base-color_black);
   }
   .sbdocs-preview {
-    border-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-color: var(--vtmn-semantic-color_border-primary)!important;
   }
   .sbdocs-h2 {
-    border-bottom-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-bottom-color: var(--vtmn-semantic-color_border-primary)!important;
     font-family: var(--vtmn-typo_font-family)!important;
   }
   .sbdocs-h1, .sbdocs-h2 {
@@ -115,7 +115,7 @@
     font-weight: var(--vtmn-typo_font-weight--bold)!important;
   }
   .docblock-source {
-    border: 1px solid var(--vtmn-semantic-color_border-secondary)!important;
+    border: 1px solid var(--vtmn-semantic-color_border-primary)!important;
     background-color: var(--vtmn-semantic-color_background-secondary)!important;
   }
   .docblock-colorpalette * {

--- a/packages/showcases/vue/.storybook/preview-head.html
+++ b/packages/showcases/vue/.storybook/preview-head.html
@@ -8,7 +8,7 @@
   .extended-toolbar {
     background-color: var(--vtmn-semantic-color_background-primary);
     padding: 1rem;
-    border-bottom: 1px solid var(--vtmn-semantic-color_border-secondary);
+    border-bottom: 1px solid var(--vtmn-semantic-color_border-primary);
     width: 100%;
     z-index: 50;
     position: fixed;
@@ -102,10 +102,10 @@
     color: var(--vtmn-base-color_black);
   }
   .sbdocs-preview {
-    border-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-color: var(--vtmn-semantic-color_border-primary)!important;
   }
   .sbdocs-h2 {
-    border-bottom-color: var(--vtmn-semantic-color_border-secondary)!important;
+    border-bottom-color: var(--vtmn-semantic-color_border-primary)!important;
     font-family: var(--vtmn-typo_font-family)!important;
   }
   .sbdocs-h1, .sbdocs-h2 {
@@ -115,7 +115,7 @@
     font-weight: var(--vtmn-typo_font-weight--bold)!important;
   }
   .docblock-source {
-    border: 1px solid var(--vtmn-semantic-color_border-secondary)!important;
+    border: 1px solid var(--vtmn-semantic-color_border-primary)!important;
     background-color: var(--vtmn-semantic-color_background-secondary)!important;
   }
   .docblock-colorpalette * {

--- a/packages/sources/css/presets/tailwind/theme.js
+++ b/packages/sources/css/presets/tailwind/theme.js
@@ -22,13 +22,14 @@ module.exports = {
     'background-brand-secondary':
       'var(--vtmn-semantic-color_background-brand-secondary)',
     'background-accent': 'var(--vtmn-semantic-color_background-accent)',
-    'background-discount': 'var(--vtmn-semantic-color_background-discount)',
+    'background-alert': 'var(--vtmn-semantic-color_background-alert)',
     'background-primary-reversed':
       'var(--vtmn-semantic-color_background-primary-reversed)',
     'background-brand-primary-reversed':
       'var(--vtmn-semantic-color_background-brand-primary-reversed)',
     'content-primary': 'var(--vtmn-semantic-color_content-primary)',
     'content-secondary': 'var(--vtmn-semantic-color_content-secondary)',
+    'content-tertiary': 'var(--vtmn-semantic-color_content-tertiary)',
     'content-action': 'var(--vtmn-semantic-color_content-action)',
     'content-active': 'var(--vtmn-semantic-color_content-active)',
     'content-inactive': 'var(--vtmn-semantic-color_content-inactive)',
@@ -36,12 +37,17 @@ module.exports = {
     'content-warning': 'var(--vtmn-semantic-color_content-warning)',
     'content-positive': 'var(--vtmn-semantic-color_content-positive)',
     'content-information': 'var(--vtmn-semantic-color_content-information)',
+    'content-accent': 'var(--vtmn-semantic-color_content-accent)',
+    'content-visited': 'var(--vtmn-semantic-color_content-visited)',
     'content-primary-reversed':
       'var(--vtmn-semantic-color_content-primary-reversed)',
     'content-action-reversed':
       'var(--vtmn-semantic-color_content-action-reversed)',
+    'content-visited-reversed':
+      'var(--vtmn-semantic-color_content-visited-reversed)',
     'border-primary': 'var(--vtmn-semantic-color_border-primary)',
     'border-secondary': 'var(--vtmn-semantic-color_border-secondary)',
+    'border-tertiary': 'var(--vtmn-semantic-color_border-tertiary)',
     'border-active': 'var(--vtmn-semantic-color_border-active)',
     'border-inactive': 'var(--vtmn-semantic-color_border-inactive)',
     'border-negative': 'var(--vtmn-semantic-color_border-negative)',
@@ -50,6 +56,14 @@ module.exports = {
     'border-information': 'var(--vtmn-semantic-color_border-information)',
     'border-primary-reversed':
       'var(--vtmn-semantic-color_border-primary-reversed)',
+    'decorative-gravel': 'var(--vtmn-semantic-color_decorative-gravel)',
+    'decorative-brick': 'var(--vtmn-semantic-color_decorative-brick)',
+    'decorative-saffron': 'var(--vtmn-semantic-color_decorative-saffron)',
+    'decorative-gold': 'var(--vtmn-semantic-color_decorative-gold)',
+    'decorative-jade': 'var(--vtmn-semantic-color_decorative-jade)',
+    'decorative-emerald': 'var(--vtmn-semantic-color_decorative-emerald)',
+    'decorative-cobalt': 'var(--vtmn-semantic-color_decorative-cobalt)',
+    'decorative-amethyst': 'var(--vtmn-semantic-color_decorative-amethyst)',
     'hover-primary': 'var(--vtmn-semantic-color_hover-primary)',
     'hover-primary-transparent':
       'var(--vtmn-semantic-color_hover-primary-transparent)',
@@ -64,8 +78,8 @@ module.exports = {
       'var(--vtmn-semantic-color_hover-primary-reversed-transparent)',
     'hover-secondary-reversed-transparent':
       'var(--vtmn-semantic-color_hover-secondary-reversed-transparent)',
-    'hover-brand-reversed-transparent':
-      'var(--vtmn-semantic-color_hover-brand-reversed-transparent)',
+    'hover-tertiary-reversed-transparent':
+      'var(--vtmn-semantic-color_hover-tertiary-reversed-transparent)',
     'active-primary': 'var(--vtmn-semantic-color_active-primary)',
     'active-primary-transparent':
       'var(--vtmn-semantic-color_active-primary-transparent)',
@@ -80,8 +94,11 @@ module.exports = {
       'var(--vtmn-semantic-color_active-primary-reversed-transparent)',
     'active-secondary-reversed-transparent':
       'var(--vtmn-semantic-color_active-secondary-reversed-transparent)',
+    'active-tertiary-reversed-transparent':
+      'var(--vtmn-semantic-color_active-tertiary-reversed-transparent)',
     'active-brand-reversed-transparent':
       'var(--vtmn-semantic-color_active-brand-reversed-transparent)',
+    shadow: 'var(--vtmn-semantic-color_shadow)',
     /* DEPRECATED legacy colors below (no longer maintained) */
     brand: { DEFAULT: 'var(--vtmn-color_brand)' },
     'brand-pro': { DEFAULT: 'var(--vtmn-color_brand-pro)' },

--- a/packages/sources/css/src/components/actions/button/src/index.css
+++ b/packages/sources/css/src/components/actions/button/src/index.css
@@ -85,27 +85,27 @@
   background-color: var(
     --vtmn-semantic-color_hover-tertiary-reversed-transparent
   );
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary);
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary);
 }
 
 .vtmn-btn_variant--primary-reversed:not(:disabled):active {
   background-color: var(
     --vtmn-semantic-color_active-brand-reversed-transparent
   );
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary);
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary);
 }
 
 .vtmn-btn_variant--primary-reversed:not(:disabled):focus-visible {
   outline: none;
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary),
-    0 0 0 rem(4px) var(--vtmn-semantic-color_border-primary),
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary),
+    0 0 0 rem(4px) var(--vtmn-semantic-color_border-secondary),
     0 0 0 rem(6px) var(--vtmn-semantic-color_border-primary-reversed);
 }
 
 /* Secondary button */
 .vtmn-btn_variant--secondary {
   background-color: var(--vtmn-semantic-color_background-primary);
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary);
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary);
   color: var(--vtmn-semantic-color_content-action);
   fill: var(--vtmn-semantic-color_content-action);
 }
@@ -120,7 +120,7 @@
 
 .vtmn-btn_variant--secondary:not(:disabled):focus-visible {
   outline: none;
-  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-secondary),
+  box-shadow: inset 0 0 0 rem(2px) var(--vtmn-semantic-color_border-primary),
     var(--vtmn-shadow_focus-visible);
 }
 
@@ -202,7 +202,7 @@
 
 .vtmn-btn_variant--ghost-reversed:not(:disabled):focus-visible {
   outline: none;
-  box-shadow: 0 0 0 rem(4px) var(--vtmn-semantic-color_border-primary),
+  box-shadow: 0 0 0 rem(4px) var(--vtmn-semantic-color_border-secondary),
     0 0 0 rem(6px) var(--vtmn-semantic-color_border-primary-reversed);
 }
 

--- a/packages/sources/css/src/components/indicators/badge/src/index.css
+++ b/packages/sources/css/src/components/indicators/badge/src/index.css
@@ -15,7 +15,7 @@
   border-radius: var(--vtmn-radius_700);
   background-color: var(--vtmn-semantic-color_background-tertiary);
   color: var(--vtmn-semantic-color_content-primary);
-  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-secondary);
+  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-primary);
   padding-block: 0;
   padding-inline: rem(6px);
 }
@@ -24,7 +24,7 @@
 .vtmn-badge_variant--default {
   background-color: var(--vtmn-semantic-color_background-tertiary);
   color: var(--vtmn-semantic-color_content-primary);
-  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-secondary);
+  box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-primary);
 }
 
 .vtmn-badge_variant--brand {

--- a/packages/sources/css/src/components/structure/accordion/src/index.css
+++ b/packages/sources/css/src/components/structure/accordion/src/index.css
@@ -17,7 +17,7 @@
   color: var(--vtmn-semantic-color_content-primary);
   font-weight: var(--vtmn-typo_font-weight--normal);
   background-color: var(--vtmn-semantic-color_background-primary);
-  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-secondary);
+  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-primary);
   outline: 0;
 }
 
@@ -108,5 +108,5 @@
 }
 
 .vtmn-accordion_content:last-child {
-  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-secondary);
+  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-primary);
 }

--- a/packages/sources/css/src/components/structure/divider/src/index.css
+++ b/packages/sources/css/src/components/structure/divider/src/index.css
@@ -21,7 +21,7 @@
 .vtmn-divider_orientation--horizontal::after {
   content: '';
   block-size: rem(1px);
-  background-color: var(--vtmn-semantic-color_border-secondary);
+  background-color: var(--vtmn-semantic-color_border-primary);
   inline-size: 100%;
 }
 

--- a/packages/sources/css/src/components/structure/list/src/index.css
+++ b/packages/sources/css/src/components/structure/list/src/index.css
@@ -73,7 +73,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-secondary);
+  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-primary);
   white-space: nowrap;
   padding-block: var(--vtmn-spacing_3);
   padding-inline: rem(20px);
@@ -89,7 +89,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-secondary);
+  border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-primary);
   padding-block: var(--vtmn-spacing_3);
   padding-inline: var(--vtmn-spacing_4);
 }

--- a/packages/sources/css/src/design-tokens/src/shadows.css
+++ b/packages/sources/css/src/design-tokens/src/shadows.css
@@ -8,6 +8,6 @@
   --vtmn-shadow_400: rem(0) rem(48px) rem(48px) rem(0)
     var(--vtmn-semantic-color_shadow);
   --vtmn-shadow_focus-visible: 0 0 0 rem(4px)
-      var(--vtmn-semantic-color_border-primary),
+      var(--vtmn-semantic-color_border-secondary),
     0 0 0 rem(6px) var(--vtmn-semantic-color_border-primary-reversed);
 }

--- a/packages/sources/css/src/design-tokens/src/themes/core-dark.css
+++ b/packages/sources/css/src/design-tokens/src/themes/core-dark.css
@@ -98,17 +98,17 @@
   --vtmn-semantic-color_content-visited-reversed--l: var(--vtmn-base-color_purple300--l);
   --vtmn-semantic-color_content-visited-reversed: hsl(var(--vtmn-semantic-color_content-visited-reversed--h), var(--vtmn-semantic-color_content-visited-reversed--s), var(--vtmn-semantic-color_content-visited-reversed--l));
   /* Border */
-  --vtmn-semantic-color_border-primary--h: var(--vtmn-base-color_grey800--h);
-  --vtmn-semantic-color_border-primary--s: var(--vtmn-base-color_grey800--s);
-  --vtmn-semantic-color_border-primary--l: var(--vtmn-base-color_grey800--l);
+  --vtmn-semantic-color_border-primary--h: var(--vtmn-base-color_grey700--h);
+  --vtmn-semantic-color_border-primary--s: var(--vtmn-base-color_grey700--s);
+  --vtmn-semantic-color_border-primary--l: var(--vtmn-base-color_grey700--l);
   --vtmn-semantic-color_border-primary: hsl(var(--vtmn-semantic-color_border-primary--h), var(--vtmn-semantic-color_border-primary--s), var(--vtmn-semantic-color_border-primary--l));
-  --vtmn-semantic-color_border-secondary--h: var(--vtmn-base-color_grey700--h);
-  --vtmn-semantic-color_border-secondary--s: var(--vtmn-base-color_grey700--s);
-  --vtmn-semantic-color_border-secondary--l: var(--vtmn-base-color_grey700--l);
+  --vtmn-semantic-color_border-secondary--h: var(--vtmn-base-color_black--h);
+  --vtmn-semantic-color_border-secondary--s: var(--vtmn-base-color_black--s);
+  --vtmn-semantic-color_border-secondary--l: var(--vtmn-base-color_black--l);
   --vtmn-semantic-color_border-secondary: hsl(var(--vtmn-semantic-color_border-secondary--h), var(--vtmn-semantic-color_border-secondary--s), var(--vtmn-semantic-color_border-secondary--l));
-  --vtmn-semantic-color_border-tertiary--h: var(--vtmn-base-color_black--h);
-  --vtmn-semantic-color_border-tertiary--s: var(--vtmn-base-color_black--s);
-  --vtmn-semantic-color_border-tertiary--l: var(--vtmn-base-color_black--l);
+  --vtmn-semantic-color_border-tertiary--h: var(--vtmn-base-color_grey800--h);
+  --vtmn-semantic-color_border-tertiary--s: var(--vtmn-base-color_grey800--s);
+  --vtmn-semantic-color_border-tertiary--l: var(--vtmn-base-color_grey800--l);
   --vtmn-semantic-color_border-tertiary: hsl(var(--vtmn-semantic-color_border-tertiary--h), var(--vtmn-semantic-color_border-tertiary--s), var(--vtmn-semantic-color_border-tertiary--l));
   --vtmn-semantic-color_border-active--h: var(--vtmn-base-color_blue300--h);
   --vtmn-semantic-color_border-active--s: var(--vtmn-base-color_blue300--s);

--- a/packages/sources/css/src/design-tokens/src/themes/core-light.css
+++ b/packages/sources/css/src/design-tokens/src/themes/core-light.css
@@ -98,17 +98,17 @@
   --vtmn-semantic-color_content-visited-reversed--l: var(--vtmn-base-color_purple200--l);
   --vtmn-semantic-color_content-visited-reversed: hsl(var(--vtmn-semantic-color_content-visited-reversed--h), var(--vtmn-semantic-color_content-visited-reversed--s), var(--vtmn-semantic-color_content-visited-reversed--l));
   /* Border */
-  --vtmn-semantic-color_border-primary--h: var(--vtmn-base-color_white--h);
-  --vtmn-semantic-color_border-primary--s: var(--vtmn-base-color_white--s);
-  --vtmn-semantic-color_border-primary--l: var(--vtmn-base-color_white--l);
+  --vtmn-semantic-color_border-primary--h: var(--vtmn-base-color_grey200--h);
+  --vtmn-semantic-color_border-primary--s: var(--vtmn-base-color_grey200--s);
+  --vtmn-semantic-color_border-primary--l: var(--vtmn-base-color_grey200--l);
   --vtmn-semantic-color_border-primary: hsl(var(--vtmn-semantic-color_border-primary--h), var(--vtmn-semantic-color_border-primary--s), var(--vtmn-semantic-color_border-primary--l));
-  --vtmn-semantic-color_border-secondary--h: var(--vtmn-base-color_grey200--h);
-  --vtmn-semantic-color_border-secondary--s: var(--vtmn-base-color_grey200--s);
-  --vtmn-semantic-color_border-secondary--l: var(--vtmn-base-color_grey200--l);
+  --vtmn-semantic-color_border-secondary--h: var(--vtmn-base-color_grey100--h);
+  --vtmn-semantic-color_border-secondary--s: var(--vtmn-base-color_grey100--s);
+  --vtmn-semantic-color_border-secondary--l: var(--vtmn-base-color_grey100--l);
   --vtmn-semantic-color_border-secondary: hsl(var(--vtmn-semantic-color_border-secondary--h), var(--vtmn-semantic-color_border-secondary--s), var(--vtmn-semantic-color_border-secondary--l));
-  --vtmn-semantic-color_border-tertiary--h: var(--vtmn-base-color_grey100--h);
-  --vtmn-semantic-color_border-tertiary--s: var(--vtmn-base-color_grey100--s);
-  --vtmn-semantic-color_border-tertiary--l: var(--vtmn-base-color_grey100--l);
+  --vtmn-semantic-color_border-tertiary--h: var(--vtmn-base-color_white--h);
+  --vtmn-semantic-color_border-tertiary--s: var(--vtmn-base-color_white--s);
+  --vtmn-semantic-color_border-tertiary--l: var(--vtmn-base-color_white--l);
   --vtmn-semantic-color_border-tertiary: hsl(var(--vtmn-semantic-color_border-tertiary--h), var(--vtmn-semantic-color_border-tertiary--s), var(--vtmn-semantic-color_border-tertiary--l));
   --vtmn-semantic-color_border-active--h: var(--vtmn-base-color_blue400--h);
   --vtmn-semantic-color_border-active--s: var(--vtmn-base-color_blue400--s);

--- a/packages/sources/css/src/design-tokens/src/themes/default.css
+++ b/packages/sources/css/src/design-tokens/src/themes/default.css
@@ -98,17 +98,17 @@
   --vtmn-semantic-color_content-visited-reversed--l: var(--vtmn-base-color_purple200--l);
   --vtmn-semantic-color_content-visited-reversed: hsl(var(--vtmn-semantic-color_content-visited-reversed--h), var(--vtmn-semantic-color_content-visited-reversed--s), var(--vtmn-semantic-color_content-visited-reversed--l));
   /* Border */
-  --vtmn-semantic-color_border-primary--h: var(--vtmn-base-color_white--h);
-  --vtmn-semantic-color_border-primary--s: var(--vtmn-base-color_white--s);
-  --vtmn-semantic-color_border-primary--l: var(--vtmn-base-color_white--l);
+  --vtmn-semantic-color_border-primary--h: var(--vtmn-base-color_grey200--h);
+  --vtmn-semantic-color_border-primary--s: var(--vtmn-base-color_grey200--s);
+  --vtmn-semantic-color_border-primary--l: var(--vtmn-base-color_grey200--l);
   --vtmn-semantic-color_border-primary: hsl(var(--vtmn-semantic-color_border-primary--h), var(--vtmn-semantic-color_border-primary--s), var(--vtmn-semantic-color_border-primary--l));
-  --vtmn-semantic-color_border-secondary--h: var(--vtmn-base-color_grey200--h);
-  --vtmn-semantic-color_border-secondary--s: var(--vtmn-base-color_grey200--s);
-  --vtmn-semantic-color_border-secondary--l: var(--vtmn-base-color_grey200--l);
+  --vtmn-semantic-color_border-secondary--h: var(--vtmn-base-color_grey100--h);
+  --vtmn-semantic-color_border-secondary--s: var(--vtmn-base-color_grey100--s);
+  --vtmn-semantic-color_border-secondary--l: var(--vtmn-base-color_grey100--l);
   --vtmn-semantic-color_border-secondary: hsl(var(--vtmn-semantic-color_border-secondary--h), var(--vtmn-semantic-color_border-secondary--s), var(--vtmn-semantic-color_border-secondary--l));
-  --vtmn-semantic-color_border-tertiary--h: var(--vtmn-base-color_grey100--h);
-  --vtmn-semantic-color_border-tertiary--s: var(--vtmn-base-color_grey100--s);
-  --vtmn-semantic-color_border-tertiary--l: var(--vtmn-base-color_grey100--l);
+  --vtmn-semantic-color_border-tertiary--h: var(--vtmn-base-color_white--h);
+  --vtmn-semantic-color_border-tertiary--s: var(--vtmn-base-color_white--s);
+  --vtmn-semantic-color_border-tertiary--l: var(--vtmn-base-color_white--l);
   --vtmn-semantic-color_border-tertiary: hsl(var(--vtmn-semantic-color_border-tertiary--h), var(--vtmn-semantic-color_border-tertiary--s), var(--vtmn-semantic-color_border-tertiary--l));
   --vtmn-semantic-color_border-active--h: var(--vtmn-base-color_blue400--h);
   --vtmn-semantic-color_border-active--s: var(--vtmn-base-color_blue400--s);


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
```
☀️ Core Theme - Light Mode

Today we’ve got: 

borderPrimary == white
borderSecondary == grey200
borderTertiary == grey100

What we want:

borderPrimary == grey200
borderSecondary == grey100
borderTertiary == white

--

🌙 Core Theme - Dark Mode

Today we’ve got: 

borderPrimary == grey800
borderSecondary == grey700
borderTertiary == black

What we want:

borderPrimary == grey700
borderSecondary == black
borderTertiary == grey800
```

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Some semantics were not logic in their shade order
- Close #1191 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
