### PR TITLE
feat(@vtmn/react): adds boolean to disable `VtmnTooltip` when needed

### DIFF
--- a/packages/showcases/core/csf/components/overlays/tooltip.csf.js
+++ b/packages/showcases/core/csf/components/overlays/tooltip.csf.js
@@ -34,4 +34,11 @@ export const argTypes = {
     defaultValue: 'Tooltip text',
     control: { type: 'text' },
   },
+
+  isDisabled: {
+    type: { name: 'string', required: false },
+    description: 'Whether the tooltip is disabled',
+    defaultValue: false,
+    control: { type: 'boolean' },
+  },
 };

--- a/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
@@ -17,6 +17,12 @@ export interface VtmnTooltipProps
   tooltip: string;
 
   /**
+   * Whether the Tooltip is disabled
+   * @defaultValue false
+   */
+  isDisabled: boolean;
+
+  /**
    * The content to render inside the component.
    * @defaultValue undefined
    */
@@ -27,22 +33,29 @@ export const VtmnTooltip = ({
   children,
   position = 'top',
   tooltip,
+  isDisabled = false,
   className,
   ...props
 }: VtmnTooltipProps) => {
   return (
-    <div className="vtmn-flex">
-      <span
-        tabIndex={0}
-        role="tooltip"
-        className={`vtmn-tooltip ${className ?? className}`}
-        data-tooltip={tooltip}
-        data-position={position}
-        {...props}
-      >
-        {children}
-      </span>
-    </div>
+    <>
+      {isDisabled ? (
+        children
+      ) : (
+        <div className="vtmn-flex">
+          <span
+            tabIndex={0}
+            role="tooltip"
+            className={`vtmn-tooltip ${className ?? className}`}
+            data-tooltip={tooltip}
+            data-position={position}
+            {...props}
+          >
+            {children}
+          </span>
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Changes description
This PR adds a boolean isTooltipDisabled to the VtmnTooltip component to be able to disable or not the tooltip.
The boolean has a false value by default.

## Context
We needed this change in order to display or not the tooltip when a button is active or not.
https://github.com/Decathlon/vitamin-web/issues/1192

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
- No
