### PR TITLE
feat(@vtmn/css): remove some ratings showcase examples

### DIFF
--- a/packages/showcases/css/stories/components/indicators/rating/examples/overview.html
+++ b/packages/showcases/css/stories/components/indicators/rating/examples/overview.html
@@ -44,16 +44,6 @@
 </div>
 
 <div class="block">
-  <div class="vtmn-rating vtmn-rating_size--medium vtmn-rating_variant--brand">
-    <span class="vtmx-star-fill" role="presentation"></span>
-    <span class="vtmn-rating_comment--primary">
-      <span class="vtmn-sr-only">number of ratings</span>
-      112 ratings
-    </span>
-  </div>
-</div>
-
-<div class="block">
   <div class="vtmn-rating">
     <span class="vtmx-star-fill" role="presentation"></span>
     <span class="vtmn-rating_comment--primary">
@@ -68,6 +58,21 @@
 </div>
 
 <div class="block">
+  <div class="vtmn-rating vtmn-rating_size--small">
+    <span class="vtmn-sr-only">2 stars and a half out of 5</span>
+    <span class="vtmx-star-fill" role="presentation"></span>
+    <span class="vtmx-star-fill" role="presentation"></span>
+    <span class="vtmx-star-half-fill" role="presentation"></span>
+    <span class="vtmx-star-line" role="presentation"></span>
+    <span class="vtmx-star-line" role="presentation"></span>
+    <span class="vtmn-rating_comment--primary">
+      <span class="vtmn-sr-only">article rating</span>
+      2.6/5
+    </span>
+  </div>
+</div>
+
+<div class="block">
   <div class="vtmn-rating" aria-label="0 star out of 5">
     <span class="vtmx-star-fill" role="presentation"></span>
     <span class="vtmx-star-fill" role="presentation"></span>
@@ -76,7 +81,7 @@
     <span class="vtmx-star-half-fill" role="presentation"></span>
     <span class="vtmn-rating_comment--secondary">
       <span class="vtmn-sr-only">number of ratings</span>
-      (115)
+      115 ratings
     </span>
   </div>
 </div>
@@ -110,7 +115,7 @@
     <span class="vtmx-star-line" role="presentation"></span>
     <span class="vtmn-rating_comment--secondary">
       <span class="vtmn-sr-only">number of ratings</span>
-      (0)
+      1 rating
     </span>
   </div>
 </div>

--- a/packages/showcases/css/stories/components/indicators/rating/examples/read-only.html
+++ b/packages/showcases/css/stories/components/indicators/rating/examples/read-only.html
@@ -9,7 +9,7 @@
 </div>
 
 <div class="block">
-  <div class="vtmn-rating">
+  <div class="vtmn-rating vtmn-rating_variant--brand">
     <span class="vtmx-star-fill" role="presentation"></span>
     <span class="vtmn-rating_comment--primary">
       <span class="vtmn-sr-only">article rating</span>
@@ -18,16 +18,6 @@
     <span class="vtmn-rating_comment--secondary">
       <span class="vtmn-sr-only">number of ratings</span>
       (74)
-    </span>
-  </div>
-</div>
-
-<div class="block">
-  <div class="vtmn-rating vtmn-rating_size--medium vtmn-rating_variant--brand">
-    <span class="vtmx-star-fill" role="presentation"></span>
-    <span class="vtmn-rating_comment--primary">
-      <span class="vtmn-sr-only">number of ratings</span>
-      74 ratings
     </span>
   </div>
 </div>


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Removed some `rating` examples with only the number of ratings in parentheses.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Some ratings examples were not desired because they weren't precise.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No