### PR TITLE
feat(@vtmn/react): add `onClear` prop on `VtmnSearch` component

### DIFF
--- a/packages/showcases/react/stories/components/navigation/VtmnSearch/VtmnSearch.stories.tsx
+++ b/packages/showcases/react/stories/components/navigation/VtmnSearch/VtmnSearch.stories.tsx
@@ -20,7 +20,7 @@ const Template: Story = (args) => {
 
   const onClear = () => {
     console.log('search field is cleared');
-  }
+  };
 
   return <VtmnSearch onSearch={onSearch} onClear={onClear} {...args} />;
 };

--- a/packages/showcases/react/stories/components/navigation/VtmnSearch/VtmnSearch.stories.tsx
+++ b/packages/showcases/react/stories/components/navigation/VtmnSearch/VtmnSearch.stories.tsx
@@ -18,7 +18,11 @@ const Template: Story = (args) => {
     console.log('search value is: ' + search);
   };
 
-  return <VtmnSearch onSearch={onSearch} {...args} />;
+  const onClear = () => {
+    console.log('search field is cleared');
+  }
+
+  return <VtmnSearch onSearch={onSearch} onClear={onClear} {...args} />;
 };
 
 export const Overview = Template.bind({});

--- a/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
@@ -47,13 +47,6 @@ export interface VtmnSearchProps
    * @default undefined
    */
   onSearch?: (search: string) => void;
-
-  /**
- * Called when user click on clear icon
- * @type {void}
- * @default undefined
- */
-  onClear?: () => void;
 }
 
 export const VtmnSearch = ({
@@ -64,7 +57,7 @@ export const VtmnSearch = ({
   value = undefined,
   className,
   onSearch,
-  onClear,
+
   ...props
 }: VtmnSearchProps) => {
   const [search, setSearch] = React.useState(value);
@@ -108,10 +101,7 @@ export const VtmnSearch = ({
             size={size}
             disabled={disabled}
             iconAlone="close-line"
-            onClick={() => {
-              setSearch('');
-              onClear && onClear();
-            }}
+            onClick={() => setSearch('')}
             aria-label="close"
             type="button"
           />

--- a/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
@@ -47,6 +47,13 @@ export interface VtmnSearchProps
    * @default undefined
    */
   onSearch?: (search: string) => void;
+
+  /**
+ * Called when user click on clear icon
+ * @type {void}
+ * @default undefined
+ */
+  onClear?: () => void;
 }
 
 export const VtmnSearch = ({
@@ -57,7 +64,7 @@ export const VtmnSearch = ({
   value = undefined,
   className,
   onSearch,
-
+  onClear,
   ...props
 }: VtmnSearchProps) => {
   const [search, setSearch] = React.useState(value);
@@ -101,7 +108,10 @@ export const VtmnSearch = ({
             size={size}
             disabled={disabled}
             iconAlone="close-line"
-            onClick={() => setSearch('')}
+            onClick={() => {
+              setSearch('');
+              onClear && onClear();
+            }}
             aria-label="close"
             type="button"
           />

--- a/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
@@ -49,10 +49,10 @@ export interface VtmnSearchProps
   onSearch?: (search: string) => void;
 
   /**
- * Called when user click on clear icon
- * @type {void}
- * @default undefined
- */
+   * Called when user click on clear icon
+   * @type {void}
+   * @default undefined
+   */
   onClear?: () => void;
 }
 


### PR DESCRIPTION
## Changes description
Allow user to call a function when clicking on clear icon

## Context
related to https://github.com/Decathlon/vitamin-web/issues/1197

## Checklist

 
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
- No

## Other information
Had some issues building the project so I couldn't fully test. But the changes are simple enough
![image](https://user-images.githubusercontent.com/48280545/176078869-b507a50b-6a63-4a37-8fac-97d9e75ff939.png)

