### PR TITLE
fix(@vtmn/svelte): add correct types for `VtmnPopover` component

### DIFF
--- a/packages/sources/svelte/src/components/overlays/VtmnPopover/VtmnPopover.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnPopover/VtmnPopover.svelte
@@ -8,7 +8,7 @@
    */
   export let id;
 
-  /** @type {VTMN_POPOVER_POSITION} */
+  /** @type {'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'} */
   export let position = VTMN_POPOVER_POSITION.TOP;
 
   let className = undefined;


### PR DESCRIPTION
## Changes description
Svelte popover component had not correct type for the position attribute. I changed it for the correct one.

## Context
We use this component in OneShop project

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
No
