### PR TITLE
feat(@vtmn/css): fix bug loop dropdown

### DIFF
--- a/packages/showcases/css/stories/components/actions/dropdown/examples/demo.html
+++ b/packages/showcases/css/stories/components/actions/dropdown/examples/demo.html
@@ -12,7 +12,7 @@
         role="group"
         aria-labelledby="dropdown-demo-label"
       >
-        <span id="block-focus-trap-start" tabindex="0"></span>
+        <span id="block-focus-trap-start" tabindex="-1"></span>
 
         <input type="checkbox" name="dropdown-demo" id="dropdown-demo-opt-1" />
         <label for="dropdown-demo-opt-1">

--- a/packages/showcases/css/stories/components/actions/dropdown/examples/demo.runscript.js
+++ b/packages/showcases/css/stories/components/actions/dropdown/examples/demo.runscript.js
@@ -11,11 +11,19 @@ window.addEventListener('DOMContentLoaded', () => {
     firstItem.focus();
   });
 
+  groupItem.addEventListener('focusout', () => {
+    firstFocusTrap.setAttribute('tabindex', '-1');
+  });
+
   groupItem.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
       document.querySelector('#dropdown-details').open = false;
       document.querySelector('#dropdown-details > summary').focus();
     }
+  });
+
+  firstItem.addEventListener('focus', () => {
+    firstFocusTrap.setAttribute('tabindex', '0');
   });
 
   firstFocusTrap.addEventListener('focus', () => {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Set the `tabindex` of the group item to 0 only when inside the dropdown to prevent going to the last item.
- Set the `tabindex` of the group Item to -1 when not focusing the group item.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- In some browsers, the focus is redirected to the last item when focusing on the first element of the dropdown.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
