### PR TITLE
fix(@vtmn/css): `height:auto` in the `<label>` of `VtmnDropdown` component

### DIFF
--- a/packages/sources/css/src/components/actions/dropdown/src/index.css
+++ b/packages/sources/css/src/components/actions/dropdown/src/index.css
@@ -124,6 +124,7 @@
   border-radius: rem(4px);
   display: inline-flex;
   position: relative;
+  height: auto;
 }
 
 .vtmn-dropdown_items > .vtmn-divider {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
We realized that there was a problem with the display of the dropdown on iOS (no problem on Android though).

<img src="https://user-images.githubusercontent.com/9600228/181048329-506da988-d55e-4b51-89af-b2e5958dd09a.jpeg" width="300" />

_Originally reported by @rtorond, thanks for this._

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
