### PR TITLE
fix(@vtmn/svelte): `VtmnDivider` component `labelId` & default `<slot></slot>`

### DIFF
--- a/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from 'svelte';
   import { cn } from '../../../utils/classnames';
   import { uuid } from '../../../utils/math';
 
@@ -21,7 +20,7 @@
   /**
    * @type {string} Id of the label
    */
-  export let labelId = undefined;
+  export let labelId = uuid();
 
   let className = undefined;
 
@@ -29,12 +28,6 @@
    * @type {string} Custom classes to apply to the component.
    */
   export { className as class };
-
-  onMount(async () => {
-    if (labelId === undefined) {
-      labelId = uuid();
-    }
-  });
 
   $: componentClass = cn(
     'vtmn-divider',
@@ -51,7 +44,7 @@
   aria-labelledby={labelId}
   {...$$restProps}
 >
-  {#if $$restProps['slot'] !== undefined && $$restProps['slot'] !== ''}
+  {#if $$restProps['slot']}
     <span id={labelId}>
       <slot />
     </span>

--- a/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
@@ -1,5 +1,7 @@
 <script>
+  import { onMount } from 'svelte';
   import { cn } from '../../../utils/classnames';
+  import { uuid } from '../../../utils/math';
 
   import {
     VTMN_DIVIDER_ORIENTATION,
@@ -28,6 +30,12 @@
    */
   export { className as class };
 
+  onMount(async () => {
+    if (labelId === undefined) {
+      labelId = uuid();
+    }
+  });
+
   $: componentClass = cn(
     'vtmn-divider',
     `vtmn-divider_orientation--${orientation}`,
@@ -43,7 +51,7 @@
   aria-labelledby={labelId}
   {...$$restProps}
 >
-  {#if $$restProps['slot'] !== ''}
+  {#if $$restProps['slot'] !== undefined && $$restProps['slot'] !== ''}
     <span id={labelId}>
       <slot />
     </span>

--- a/packages/sources/svelte/src/components/structure/VtmnDivider/test/VtmnDivider.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnDivider/test/VtmnDivider.spec.js
@@ -33,12 +33,16 @@ describe('VtmnDivider', () => {
     );
   });
   test('Should display text position', () => {
-    const { getByText } = render(VtmnDivider, { textPosition: 'end' });
+    const { getByText } = render(VtmnDivider, {
+      textPosition: 'end',
+      slot: 'unit test divider',
+    });
     expect(getByText('unit test divider')).toBeVisible();
   });
   test('Should be accessible', () => {
     const { container } = render(VtmnDivider, {
       labelId: 'idForTest',
+      slot: 'unit test divider',
     });
     expect(getDivider(container)).toHaveAttribute(
       'aria-labelledby',


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
This PR fixes two problems on `VtmnDivider` Svelte component.
1. Divider has an empty span on several showcases like this one in `VtmnTabs` _(thanks Christophe Drag for reporting me this)_: https://decathlon.github.io/vitamin-web/@vtmn/showcase-svelte/?path=/story/components-navigation-vtmntabs--overview
<img width="779" alt="CleanShot 2022-07-26 at 21 49 31@2x" src="https://user-images.githubusercontent.com/9600228/181099439-f4eaf80d-43af-4571-8562-53a887420b14.png">
2. There is warning when `yarn test` for the `VtmnDivider` component because `labelId` is undefined. That's why I propose to use the `uuid()` function to generate a unique identifier if not present (for a11y purposes).

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No