### PR TITLE
fix(@vtmn/svelte): prevent body scroll on mobile for `VtmnModal`

### DIFF
--- a/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnModal/VtmnModal.svelte
@@ -32,9 +32,11 @@
 <svelte:head>
   {#if open}
     // eslint-disable-next-line
-    <style type="text/css">
+    <style lang="css">
       body {
         overflow: hidden;
+        touch-action: none;
+        -ms-touch-action: none;
       }
     </style>
   {/if}


### PR DESCRIPTION
When `VtmnModal` are open, we apply a `overflow: hidden` on the body.
In fact, this solution works pretty well on desktop, but on mobile devices the touch are always enable and in some cases, the user can scroll over the body in the background.

To prevent this effect, we apply a `touch-action:none` on the body when the modal are open.