### PR TITLE
fix(@vtmn/css): fix min-width and wrap behavior to correctly display the arrow

### DIFF
--- a/packages/sources/css/src/components/forms/select/src/index.css
+++ b/packages/sources/css/src/components/forms/select/src/index.css
@@ -31,6 +31,7 @@
   box-shadow: inset 0 0 0 rem(1px) var(--vtmn-semantic-color_border-inactive);
   border-radius: var(--vtmn-radius_100);
   block-size: rem(48px);
+  min-inline-size: 100%;
   inline-size: min-content;
   background-color: var(--vtmn-semantic-color_background-primary);
   cursor: pointer;
@@ -57,6 +58,7 @@
   line-height: var(--vtmn-typo_text-3-line-height);
   margin-block-start: rem(4px);
   display: inline-block;
+  white-space: normal;
 }
 
 .vtmn-select_container .vtmn-select_error-text::before {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Add a `min-inline-size` to 100% to keep the container flexible with the size of the label.
- The helper text is now wrapped if longer than the select container

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- The select container arrow could be misplaced if the helper text or the label was longer than the container.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No