### PR TITLE
fix(@vtmn/svelte): fix display label

### DIFF
--- a/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnDivider/VtmnDivider.svelte
@@ -44,7 +44,7 @@
   aria-labelledby={labelId}
   {...$$restProps}
 >
-  {#if $$restProps['slot']}
+  {#if $$slots.default}
     <span id={labelId}>
       <slot />
     </span>


### PR DESCRIPTION
Current : 
![image](https://user-images.githubusercontent.com/2856778/185361848-29f85924-9723-4ab6-b0c5-c277bc08a2f4.png)

Expected : 
![image](https://user-images.githubusercontent.com/2856778/185361924-3c551c97-4ae2-41b1-97d5-d358e33dc337.png)

No breaking changes.
We check if the default slot are defined 