### PR TITLE
feat(@vtmn/svelte): add `on:input` and `on:change` on `VtmnTextInput` component

### DIFF
--- a/packages/showcases/core/csf/components/forms/text-input.csf.js
+++ b/packages/showcases/core/csf/components/forms/text-input.csf.js
@@ -2,7 +2,7 @@ import vitamixIconsList from '@vtmn/icons/dist/vitamix/font/vitamix.json';
 
 export const parameters = {
   actions: {
-    handles: ['mouseenter', 'click', 'focusin', 'focusout'],
+    handles: ['mouseenter', 'click', 'focusin', 'focusout', 'input', 'change'],
   },
   design: {
     type: 'figma',

--- a/packages/sources/svelte/src/components/forms/VtmnTextInput/VtmnTextInput.svelte
+++ b/packages/sources/svelte/src/components/forms/VtmnTextInput/VtmnTextInput.svelte
@@ -84,6 +84,8 @@
 {#if multiline}
   <textarea
     bind:value
+    on:input
+    on:change
     class={componentClass}
     {id}
     {disabled}
@@ -94,6 +96,8 @@
   <div class="vtmn-text-input_container">
     <input
       bind:value
+      on:input
+      on:change
       class={componentClass}
       type="text"
       {id}

--- a/packages/sources/svelte/src/components/forms/VtmnTextInput/test/VtmnTextInput.spec.js
+++ b/packages/sources/svelte/src/components/forms/VtmnTextInput/test/VtmnTextInput.spec.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 
-import { render } from '@testing-library/svelte';
+import { render, fireEvent } from '@testing-library/svelte';
 import VtmnTextInput from '../VtmnTextInput.svelte';
 
 describe('VtmnTextInput', () => {
@@ -31,6 +31,18 @@ describe('VtmnTextInput', () => {
       );
       expect(getHelperText(container)).toBeUndefined();
       expect(getTextInput(container)).not.toHaveAttribute('disabled');
+    });
+
+    test('Should trigger event change when the input value changes', async () => {
+      const onChange = jest.fn((e) => e.target.value);
+      const nextValue = 'Unit test value changed';
+      const { container, component } = render(VtmnTextInput, { ...params });
+      component.$on('input', onChange);
+      await fireEvent.input(getTextInput(container), {
+        target: { value: nextValue },
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.results[0].value).toEqual(nextValue);
     });
 
     test('Should display the label if labelText are defined', () => {


### PR DESCRIPTION
## Changes description
Added on:input and on:change directives

## Context
With the previous implementation, the VtmnTextInput couln't handle a specific action whenever the value changes (on:input) like the native HTML input does.
For example, in my case I couldn't perform validations on the fly whenever the textfield changes

## Checklist
- Add on:input and on:change on theTextInput implementation to inherit the native HTML input behaviour
- Updated the TextInput's Component Story Format to handle these actions
- Added unit test to check if the on:input event is called once on every input change

## Does this introduce a breaking change?
No
