### PR TITLE
fix(@vtmn/react): aria prop typo in `VtmnDivider`

### DIFF
--- a/packages/sources/react/src/components/structure/VtmnDivider/VtmnDivider.tsx
+++ b/packages/sources/react/src/components/structure/VtmnDivider/VtmnDivider.tsx
@@ -43,7 +43,7 @@ export const VtmnDivider = ({
       {...props}
       role="separator"
       aria-orientation={orientation}
-      aria-labelledBy={labelId ? labelId : undefined}
+      aria-labelledby={labelId ? labelId : undefined}
     >
       {children ? (
         <span id={labelId ? labelId : undefined}>{children}</span>


### PR DESCRIPTION
## Changes description
changed `aria-labelledBy` with `aria-labelledby` in VtmnDivider

## Context
`aria-labelledBy` syntax is incorrect.

<img width="715" alt="image" src="https://user-images.githubusercontent.com/22882255/186720237-bac4f8d1-e6f8-4d3e-8f6e-c6762fa62332.png">


## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
- No

