### PR TITLE
fix(@vtmn/svelte): add export inputRef into the component `VtmnSearch`

### DIFF
--- a/packages/sources/svelte/src/components/navigation/VtmnSearch/VtmnSearch.svelte
+++ b/packages/sources/svelte/src/components/navigation/VtmnSearch/VtmnSearch.svelte
@@ -33,6 +33,12 @@
   export let value;
 
   /**
+   * Reference of the search input
+   * @type {HTMLElement}
+   */
+  export let inputRef;
+
+  /**
    * @typedef AriaLabels
    * @type {object}
    * @property {string} clearButton - Aria label of the clear button.
@@ -73,6 +79,7 @@
 <div class={componentClass} role="search">
   <input
     type="search"
+    bind:this={inputRef}
     {...$$restProps}
     on:click
     on:input


### PR DESCRIPTION
This PR aimed to add an attribute `inputRef` only for svelte.

With this props, we can get the reference of the input from the parent. For example : 

```html
<script>
  let vtmnButtonRef;

  onMount(() => {
    vtmnButtonRef.focus();
  });
</script>

<VtmnSearch bind:inputRef={vtmnButtonRef} />
```