### PR TITLE
fix(@vtmn/svelte): add unit param on `VtmnSkeleton`

### DIFF
--- a/packages/showcases/core/csf/components/structure/skeleton.csf.js
+++ b/packages/showcases/core/csf/components/structure/skeleton.csf.js
@@ -11,12 +11,20 @@ export const parameters = {
 export const argTypes = {
   width: {
     type: { name: 'number', required: false },
-    description: 'Width of the skeleton (in percentage).',
+    description: 'Width of the skeleton.',
     defaultValue: 100,
     control: {
-      type: 'range',
+      type: 'number',
       min: 0,
-      max: 100,
+    },
+  },
+  unit: {
+    type: { name: 'string', required: false },
+    description: 'Unit of the width.',
+    defaultValue: '%',
+    control: {
+      type: 'select',
+      options: ['%', 'em', 'rem', 'vw', 'ch', 'px'],
     },
   },
   shape: {

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -1,13 +1,23 @@
 <script>
   import { cn } from '../../../utils/classnames';
-  import { VTMN_SKELETON_SHAPE } from './enums';
+  import {
+    VTMN_SKELETON_SHAPE,
+    VTMN_SKELETON_UNIT,
+    VTMN_DEFAULT_WIDTH,
+  } from './enums';
   import { objectToStyle } from '../../../utils/style';
 
   /**
    * @type {number} width to apply to the skeleton (in percentage).
    * @defaultValue 100
    */
-  export let width = 100;
+  export let width = VTMN_DEFAULT_WIDTH;
+
+  /**
+   * @type {'%'|'rem'|'px'|'vw'|'ch'}
+   * @defaultValue %
+   */
+  export let unit = VTMN_SKELETON_UNIT.PERCENT;
 
   /**
    * @type {'line' | 'avatar' }  variant of the shape.
@@ -28,8 +38,14 @@
     className,
   );
 
+  $: computedWidth = width > 0 ? width : VTMN_DEFAULT_WIDTH;
+  $: computedUnit =
+    unit && Object.values(VTMN_SKELETON_UNIT).includes(unit)
+      ? unit
+      : VTMN_SKELETON_UNIT.PERCENT;
+
   $: componentStyle = objectToStyle({
-    '--skeleton-width': `${width}%`,
+    '--skeleton-width': `${computedWidth}${computedUnit}`,
   });
 </script>
 
@@ -38,6 +54,6 @@
 <style lang="css">
   @import '@vtmn/css-skeleton';
   .skeleton-width {
-    width: var(--skeleton-width, 0);
+    width: var(--skeleton-width, 100%);
   }
 </style>

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -2,8 +2,8 @@
   import { cn } from '../../../utils/classnames';
   import {
     VTMN_SKELETON_SHAPE,
-    VTMN_SKELETON_UNIT,
-    VTMN_DEFAULT_DEFAULT__WIDTH,
+    VTMN_SKELETON_DEFAULT_UNIT,
+    VTMN_SKELETON_DEFAULT_WIDTH,
   } from './enums';
   import { objectToStyle } from '../../../utils/style';
 
@@ -11,13 +11,13 @@
    * @type {number} Width applied on the skeleton.
    * @defaultValue 100
    */
-  export let width = VTMN_DEFAULT_DEFAULT__WIDTH;
+  export let width = VTMN_SKELETON_DEFAULT_WIDTH;
 
   /**
    * @type {'%'|'rem'|'em'|'px'|'vw'|'ch'} Unit applied on the width.
    * @defaultValue %
    */
-  export let unit = VTMN_SKELETON_UNIT.PERCENT;
+  export let unit = VTMN_SKELETON_DEFAULT_UNIT.PERCENT;
 
   /**
    * @type {'line' | 'avatar' } Variant of the shape.
@@ -44,10 +44,10 @@
   $: {
     if (
       width < 0 ||
-      (unit && !Object.values(VTMN_SKELETON_UNIT).includes(unit))
+      (unit && !Object.values(VTMN_SKELETON_DEFAULT_UNIT).includes(unit))
     ) {
       computedWidth = 100;
-      computedUnit = VTMN_SKELETON_UNIT.PERCENT;
+      computedUnit = VTMN_SKELETON_DEFAULT_UNIT.PERCENT;
       console.warn(
         '[VtmnSkeleton] property width or unit are wrong. Set to default value',
       );

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -43,11 +43,8 @@
   let computedWidth;
 
   $: {
-    if (
-      width < 0 ||
-      (unit && !Object.values(VTMN_SKELETON_UNIT).includes(unit))
-    ) {
-      computedWidth = 100;
+    if (width < 0 || !Object.values(VTMN_SKELETON_UNIT).includes(unit)) {
+      computedWidth = VTMN_SKELETON_DEFAULT_WIDTH;
       computedUnit = VTMN_SKELETON_DEFAULT_UNIT;
       console.warn(
         '[VtmnSkeleton] property width or unit are wrong. Set to default value',

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -8,19 +8,19 @@
   import { objectToStyle } from '../../../utils/style';
 
   /**
-   * @type {number} width to apply to the skeleton (in percentage).
+   * @type {number} Width applied on the skeleton.
    * @defaultValue 100
    */
   export let width = VTMN_DEFAULT_WIDTH;
 
   /**
-   * @type {'%'|'rem'|'px'|'vw'|'ch'}
+   * @type {'%'|'rem'|'px'|'vw'|'ch'} Unit applied on the width.
    * @defaultValue %
    */
   export let unit = VTMN_SKELETON_UNIT.PERCENT;
 
   /**
-   * @type {'line' | 'avatar' }  variant of the shape.
+   * @type {'line' | 'avatar' } Variant of the shape.
    * @defaultValue line
    */
   export let shape = VTMN_SKELETON_SHAPE.LINE;

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -14,7 +14,7 @@
   export let width = VTMN_DEFAULT_DEFAULT__WIDTH;
 
   /**
-   * @type {'%'|'rem'|'px'|'vw'|'ch'} Unit applied on the width.
+   * @type {'%'|'rem'|'em'|'px'|'vw'|'ch'} Unit applied on the width.
    * @defaultValue %
    */
   export let unit = VTMN_SKELETON_UNIT.PERCENT;
@@ -38,11 +38,24 @@
     className,
   );
 
-  $: computedWidth = width > 0 ? width : VTMN_DEFAULT_DEFAULT__WIDTH;
-  $: computedUnit =
-    unit && Object.values(VTMN_SKELETON_UNIT).includes(unit)
-      ? unit
-      : VTMN_SKELETON_UNIT.PERCENT;
+  let computedUnit;
+  let computedWidth;
+
+  $: {
+    if (
+      width < 0 ||
+      (unit && !Object.values(VTMN_SKELETON_UNIT).includes(unit))
+    ) {
+      computedWidth = 100;
+      computedUnit = VTMN_SKELETON_UNIT.PERCENT;
+      console.warn(
+        '[VtmnSkeleton] property width or unit are wrong. Set to default value',
+      );
+    } else {
+      computedWidth = width;
+      computedUnit = unit;
+    }
+  }
 
   $: componentStyle = objectToStyle({
     '--skeleton-width': `${computedWidth}${computedUnit}`,

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -2,6 +2,7 @@
   import { cn } from '../../../utils/classnames';
   import {
     VTMN_SKELETON_SHAPE,
+    VTMN_SKELETON_UNIT,
     VTMN_SKELETON_DEFAULT_UNIT,
     VTMN_SKELETON_DEFAULT_WIDTH,
   } from './enums';
@@ -17,7 +18,7 @@
    * @type {'%'|'rem'|'em'|'px'|'vw'|'ch'} Unit applied on the width.
    * @defaultValue %
    */
-  export let unit = VTMN_SKELETON_DEFAULT_UNIT.PERCENT;
+  export let unit = VTMN_SKELETON_DEFAULT_UNIT;
 
   /**
    * @type {'line' | 'avatar' } Variant of the shape.
@@ -44,10 +45,10 @@
   $: {
     if (
       width < 0 ||
-      (unit && !Object.values(VTMN_SKELETON_DEFAULT_UNIT).includes(unit))
+      (unit && !Object.values(VTMN_SKELETON_UNIT).includes(unit))
     ) {
       computedWidth = 100;
-      computedUnit = VTMN_SKELETON_DEFAULT_UNIT.PERCENT;
+      computedUnit = VTMN_SKELETON_DEFAULT_UNIT;
       console.warn(
         '[VtmnSkeleton] property width or unit are wrong. Set to default value',
       );

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -3,7 +3,7 @@
   import {
     VTMN_SKELETON_SHAPE,
     VTMN_SKELETON_UNIT,
-    VTMN_DEFAULT_WIDTH,
+    VTMN_DEFAULT_DEFAULT__WIDTH,
   } from './enums';
   import { objectToStyle } from '../../../utils/style';
 
@@ -11,7 +11,7 @@
    * @type {number} Width applied on the skeleton.
    * @defaultValue 100
    */
-  export let width = VTMN_DEFAULT_WIDTH;
+  export let width = VTMN_DEFAULT_DEFAULT__WIDTH;
 
   /**
    * @type {'%'|'rem'|'px'|'vw'|'ch'} Unit applied on the width.
@@ -38,7 +38,7 @@
     className,
   );
 
-  $: computedWidth = width > 0 ? width : VTMN_DEFAULT_WIDTH;
+  $: computedWidth = width > 0 ? width : VTMN_DEFAULT_DEFAULT__WIDTH;
   $: computedUnit =
     unit && Object.values(VTMN_SKELETON_UNIT).includes(unit)
       ? unit

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
@@ -15,4 +15,4 @@ export const VTMN_SKELETON_UNIT = {
   PX: 'px',
 };
 
-export const VTMN_DEFAULT_WIDTH = 100;
+export const VTMN_DEFAULT_DEFAULT__WIDTH = 100;

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
@@ -5,3 +5,14 @@ export const VTMN_SKELETON_SHAPE = {
   LINE: 'line',
   AVATAR: 'avatar',
 };
+
+export const VTMN_SKELETON_UNIT = {
+  EM: 'em',
+  REM: 'rem',
+  VW: 'vw',
+  CH: 'ch',
+  PERCENT: '%',
+  PX: 'px',
+};
+
+export const VTMN_DEFAULT_WIDTH = 100;

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
@@ -6,7 +6,7 @@ export const VTMN_SKELETON_SHAPE = {
   AVATAR: 'avatar',
 };
 
-export const VTMN_SKELETON_DEFAULT_UNIT = {
+export const VTMN_SKELETON_UNIT = {
   EM: 'em',
   REM: 'rem',
   VW: 'vw',
@@ -16,3 +16,4 @@ export const VTMN_SKELETON_DEFAULT_UNIT = {
 };
 
 export const VTMN_SKELETON_DEFAULT_WIDTH = 100;
+export const VTMN_SKELETON_DEFAULT_UNIT = VTMN_SKELETON_UNIT.PERCENT;

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
@@ -6,7 +6,7 @@ export const VTMN_SKELETON_SHAPE = {
   AVATAR: 'avatar',
 };
 
-export const VTMN_SKELETON_UNIT = {
+export const VTMN_SKELETON_DEFAULT_UNIT = {
   EM: 'em',
   REM: 'rem',
   VW: 'vw',
@@ -15,4 +15,4 @@ export const VTMN_SKELETON_UNIT = {
   PX: 'px',
 };
 
-export const VTMN_DEFAULT_DEFAULT__WIDTH = 100;
+export const VTMN_SKELETON_DEFAULT_WIDTH = 100;

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
@@ -50,7 +50,7 @@ describe('VtmnSkeleton', () => {
   });
 
   test('Should set the unit as % if unit not found', () => {
-    const { container } = render(VtmnSkeleton, { unit: 'toto' });
+    const { container } = render(VtmnSkeleton, { unit: 'foo' });
     expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
   });
 

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
@@ -43,4 +43,19 @@ describe('VtmnSkeleton', () => {
     const { container } = render(VtmnSkeleton, { 'data-nrt': 'test' });
     expect(getSkeleton(container)).toHaveAttribute('data-nrt', 'test');
   });
+
+  test('Should change the unit', () => {
+    const { container } = render(VtmnSkeleton, { unit: 'px' });
+    expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100px');
+  });
+
+  test('Should set the unit as % if unit not found', () => {
+    const { container } = render(VtmnSkeleton, { unit: 'toto' });
+    expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
+  });
+
+  test('Should set the width as 0 if width are negative', () => {
+    const { container } = render(VtmnSkeleton, { width: -1 });
+    expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
+  });
 });

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
@@ -50,12 +50,12 @@ describe('VtmnSkeleton', () => {
   });
 
   test('Should set the unit as % if unit not found', () => {
-    const { container } = render(VtmnSkeleton, { unit: 'foo' });
+    const { container } = render(VtmnSkeleton, { unit: 'foo', width: 50 });
     expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
   });
 
   test('Should set the width as 0 if width are negative', () => {
-    const { container } = render(VtmnSkeleton, { width: -1 });
+    const { container } = render(VtmnSkeleton, { width: -1, unit: 'px' });
     expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
   });
 });


### PR DESCRIPTION
Linked to https://github.com/Decathlon/vitamin-web/issues/1249

Add a new input `unit` on `VtmnSkeleton`
Rules applied : 
- Unit = `%` by default
- Width = `100` by default
- If unit are not `['%', 'em', 'rem', 'vw', 'ch', 'px']` -> unit = `%` (default value)
- If width are `< 0` -> width = `100` (default value)

<img width="1291" alt="image" src="https://user-images.githubusercontent.com/2856778/187488995-da6b7927-34ea-47ed-99fb-28c7a71cb843.png">