### PR TITLE
fix(@vtmn/svelte): class on the `VtmnSearch`

### DIFF
--- a/packages/sources/svelte/src/components/navigation/VtmnSearch/VtmnSearch.svelte
+++ b/packages/sources/svelte/src/components/navigation/VtmnSearch/VtmnSearch.svelte
@@ -50,11 +50,13 @@
    */
   export let ariaLabels = {};
 
+  let className = undefined;
   /**
    * Custom classes to apply to the component.
+   *
    * @type {string}
    */
-  export let className = undefined;
+  export { className as class };
 
   const dispatch = createEventDispatcher();
 

--- a/packages/sources/svelte/src/components/navigation/VtmnSearch/test/VtmnSearch.spec.js
+++ b/packages/sources/svelte/src/components/navigation/VtmnSearch/test/VtmnSearch.spec.js
@@ -87,7 +87,7 @@ describe('<VtmnSearch />', () => {
   test('Can add custom css classes', () => {
     const { container } = render(VtmnSearch, {
       ...props,
-      className: 'test-class',
+      class: 'test-class',
     });
 
     expect(container.getElementsByClassName(`test-class`).length).toBe(1);


### PR DESCRIPTION
Fix an issue on the `VtmnSearch`.

Before : 
- `className` export should be set to pass class to the `VtmnSearch` component

Now : 
- `class` inject the component's class to the `VtmnSearch` component