### PR TITLE
fix(@vtmn/css, @vtmn/svelte, @vtmn/react, @vtmn/vue): popover position & a11y (#1259)

### DIFF
--- a/packages/showcases/css/stories/components/overlays/popover/examples/overview.html
+++ b/packages/showcases/css/stories/components/overlays/popover/examples/overview.html
@@ -15,16 +15,15 @@
   <div
     class="vtmn-popover"
     data-position="top-right"
-    aria-labelledby="my-popover--title-1"
-    aria-describedby="my-popover-description-1"
-    tabindex="0"
+    aria-labelledby="my-popover-label-1"
+    aria-describedby="my-popover-1"
   >
-    <a class="vtmn-link vtmn-link_size--small">Top-Right</a>
-    <div role="tooltip">
-      <span id="my-popover--title-1" class="vtmn-popover_title"
+    <button class="vtmn-btn vtmn-btn_size--small">Top-Right</button>
+    <div id="my-popover-1" role="dialog">
+      <span id="my-popover-label-1" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-1" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -41,16 +40,15 @@
   <div
     class="vtmn-popover"
     data-position="top"
-    aria-labelledby="my-popover--title-2"
-    aria-describedby="my-popover-description-2"
-    tabindex="0"
+    aria-labelledby="my-popover-label-2"
+    aria-describedby="my-popover-2"
   >
     <button class="vtmn-btn vtmn-btn_size--small">Top</button>
-    <div id="my-popover-2" role="tooltip">
-      <span id="my-popover--title-2" class="vtmn-popover_title"
+    <div id="my-popover-2" role="dialog">
+      <span id="my-popover-label-2" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-2" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -67,16 +65,15 @@
   <div
     class="vtmn-popover"
     data-position="top-left"
-    aria-labelledby="my-popover--title-3"
-    aria-describedby="my-popover-description-3"
-    tabindex="0"
+    aria-labelledby="my-popover-label-3"
+    aria-describedby="my-popover-3"
   >
-    <a class="vtmn-link vtmn-link_size--large">Top-Left</a>
-    <div id="my-popover-3" role="tooltip">
-      <span id="my-popover--title-3" class="vtmn-popover_title"
+    <button class="vtmn-btn vtmn-btn_size--small">Top-left</button>
+    <div id="my-popover-3" role="dialog">
+      <span id="my-popover-label-3" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-3" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -107,16 +104,15 @@
   <div
     class="vtmn-popover"
     data-position="right"
-    aria-labelledby="my-popover--title-4"
-    aria-describedby="my-popover-description-4"
-    tabindex="0"
+    aria-labelledby="my-popover-label-4"
+    aria-describedby="my-popover-4"
   >
     <button class="vtmn-btn vtmn-btn_size--medium">Right</button>
-    <div id="my-popover-4" role="tooltip">
-      <span id="my-popover--title-4" class="vtmn-popover_title"
+    <div id="my-popover-4" role="dialog">
+      <span id="my-popover-label-4" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-4" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -133,16 +129,15 @@
   <div
     class="vtmn-popover"
     data-position="left"
-    aria-labelledby="my-popover--title-5"
-    aria-describedby="my-popover-description-5"
-    tabindex="0"
+    aria-labelledby="my-popover-label-5"
+    aria-describedby="my-popover-5"
   >
     <button class="vtmn-btn vtmn-btn_size--medium">Left</button>
-    <div id="my-popover-5" role="tooltip">
-      <span id="my-popover--title-5" class="vtmn-popover_title"
+    <div id="my-popover-5" role="dialog">
+      <span id="my-popover-label-5" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-5" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -173,16 +168,15 @@
   <div
     class="vtmn-popover"
     data-position="bottom-right"
-    aria-labelledby="my-popover--title-6"
-    aria-describedby="my-popover-description-6"
-    tabindex="0"
+    aria-labelledby="my-popover-label-6"
+    aria-describedby="my-popover-6"
   >
-    <a class="vtmn-link vtmn-link_size--large">Bottom-Right</a>
-    <div id="my-popover-6" role="tooltip">
-      <span id="my-popover--title-6" class="vtmn-popover_title"
+    <button class="vtmn-btn vtmn-btn_size--small">Bottom-Right</button>
+    <div id="my-popover-6" role="dialog">
+      <span id="my-popover-label-6" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-6" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -199,17 +193,16 @@
   <div
     class="vtmn-popover"
     data-position="bottom"
-    aria-labelledby="my-popover--title-7"
-    aria-describedby="my-popover-description-7"
-    tabindex="0"
+    aria-labelledby="my-popover-label-7"
+    aria-describedby="my-popover-7"
   >
     <button class="vtmn-btn vtmn-btn_size--large">Bottom</button>
 
-    <div id="my-popover-7" role="tooltip">
-      <span id="my-popover--title-7" class="vtmn-popover_title"
+    <div id="my-popover-7" role="dialog">
+      <span id="my-popover-label-7" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-7" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover
@@ -226,16 +219,15 @@
   <div
     class="vtmn-popover"
     data-position="bottom-left"
-    aria-labelledby="my-popover--title-8"
-    aria-describedby="my-popover-description-8"
-    tabindex="0"
+    aria-labelledby="my-popover-label-8"
+    aria-describedby="my-popover-8"
   >
-    <a class="vtmn-link vtmn-link_size--small">Bottom-Left</a>
-    <div id="my-popover-8" role="tooltip">
-      <span id="my-popover--title-8" class="vtmn-popover_title"
+    <button class="vtmn-btn vtmn-btn_size--small">Bottom-Left</button>
+    <div id="my-popover-8" role="dialog">
+      <span id="my-popover-label-8" class="vtmn-popover_title" role="heading"
         >This is the title of the popover</span
       >
-      <span id="my-popover-description-8" class="vtmn-popover_text">
+      <span class="vtmn-popover_text">
         A popover can appear when users click or focus an element to provide his
         description in details, and often also with a link or button inside.
         Popovers will automatically close when clicking outside the popover

--- a/packages/showcases/svelte/stories/components/overlays/VtmnPopover/VtmnPopover.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnPopover/VtmnPopover.stories.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
-  import { VtmnPopover, VtmnLink } from '@vtmn/svelte';
+  import { VtmnPopover, VtmnButton } from '@vtmn/svelte';
   import {
     parameters,
     argTypes,
@@ -18,7 +18,7 @@
   <VtmnPopover position={args.position} id={args.id}>
     <svelte:fragment slot="title">{args.title}</svelte:fragment>
     <svelte:fragment slot="body">{args.body}</svelte:fragment>
-    <VtmnLink>Popover on the {args.position}</VtmnLink>
+    <VtmnButton>Popover on the {args.position}</VtmnButton>
   </VtmnPopover>
 </Template>
 

--- a/packages/sources/css/src/components/overlays/popover/src/index.css
+++ b/packages/sources/css/src/components/overlays/popover/src/index.css
@@ -13,7 +13,7 @@
   outline: 0;
 }
 
-.vtmn-popover > [role='tooltip'] > .vtmn-popover_title {
+.vtmn-popover > [role='dialog'] > .vtmn-popover_title {
   margin-block: rem(4px);
   margin-inline: 0;
   font-family: var(--vtmn-typo_font-family);
@@ -23,7 +23,7 @@
   align-self: flex-start;
 }
 
-.vtmn-popover > [role='tooltip'] > .vtmn-popover_text {
+.vtmn-popover > [role='dialog'] > .vtmn-popover_text {
   margin-block: rem(8px);
   margin-inline: 0;
   font-family: var(--vtmn-typo_font-family);
@@ -34,13 +34,13 @@
   text-align: left;
 }
 
-.vtmn-popover > [role='tooltip'] > button {
+.vtmn-popover > [role='dialog'] > button {
   margin: 0;
   align-self: flex-end;
 }
 
 /* ALL POPOVER */
-.vtmn-popover > [role='tooltip'] {
+.vtmn-popover > [role='dialog'] {
   min-inline-size: rem(250px);
   inline-size: auto;
   box-shadow: var(--vtmn-shadow_200);
@@ -55,7 +55,7 @@
   cursor: default;
 }
 
-.vtmn-popover > [role='tooltip']::after {
+.vtmn-popover > [role='dialog']::after {
   border-radius: 0;
   content: ' ';
   block-size: 0;
@@ -64,7 +64,7 @@
   box-shadow: none;
 }
 
-.vtmn-popover:focus-within > [role='tooltip'] {
+.vtmn-popover:focus-within > [role='dialog'] {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -77,13 +77,13 @@
 }
 
 /* POSITION: TOP */
-.vtmn-popover[data-position^='top'] > [role='tooltip'] {
-  bottom: 100%;
+.vtmn-popover[data-position^='top'] > [role='dialog'] {
+  bottom: calc(100% + 1.5em);
   left: 50%;
-  transform: translate(-50%, -1.5em);
+  transform: translateX(-50%);
 }
 
-.vtmn-popover[data-position^='top'] > [role='tooltip']::after {
+.vtmn-popover[data-position^='top'] > [role='dialog']::after {
   border-left: solid transparent 0.6em;
   border-right: solid transparent 0.6em;
   border-top: solid var(--vtmn-semantic-color_background-primary-reversed)
@@ -94,50 +94,31 @@
 }
 
 /* POSITION: TOP-LEFT */
-.vtmn-popover[data-position='top-left'] > [role='tooltip']::after {
+.vtmn-popover[data-position='top-left'] > [role='dialog']::after {
   left: 90%;
 }
 
-.vtmn-popover[data-position='top-left'] > [role='tooltip'] {
-  transform: translate(-90%, -1.5em);
+.vtmn-popover[data-position='top-left'] > [role='dialog'] {
+  transform: translateX(-90%);
 }
 
 /* POSITION: TOP-RIGHT */
-.vtmn-popover[data-position='top-right'] > [role='tooltip']::after {
+.vtmn-popover[data-position='top-right'] > [role='dialog']::after {
   left: 10%;
 }
 
-.vtmn-popover[data-position='top-right'] > [role='tooltip'] {
-  transform: translate(-10%, -1.5em);
+.vtmn-popover[data-position='top-right'] > [role='dialog'] {
+  transform: translateX(-10%);
 }
 
 /* POSITION: BOTTOM */
-.vtmn-popover[data-position^='bottom'] > [role='tooltip'] {
-  bottom: 100%;
+.vtmn-popover[data-position^='bottom'] > [role='dialog'] {
+  top: calc(100% + 1.5em);
   left: 50%;
-  transform: translate(-50%, 100%);
+  transform: translateX(-50%);
 }
 
-.vtmn-popover[data-position^='bottom']
-  > .vtmn-btn_size--small
-  + [role='tooltip'] {
-  bottom: -40%;
-}
-
-.vtmn-popover[data-position^='bottom']
-  > .vtmn-btn_size--medium
-  + [role='tooltip'],
-.vtmn-popover[data-position^='bottom'] > .vtmn-btn + [role='tooltip'] {
-  bottom: -40%;
-}
-
-.vtmn-popover[data-position^='bottom']
-  > .vtmn-btn_size--large
-  + [role='tooltip'] {
-  bottom: -20%;
-}
-
-.vtmn-popover[data-position^='bottom'] > [role='tooltip']::after {
+.vtmn-popover[data-position^='bottom'] > [role='dialog']::after {
   border-left: solid transparent 0.6em;
   border-right: solid transparent 0.6em;
   border-bottom: solid var(--vtmn-semantic-color_background-primary-reversed)
@@ -148,81 +129,53 @@
 }
 
 /* POSITION: BOTTOM-LEFT */
-.vtmn-popover[data-position='bottom-left'] > [role='tooltip']::after {
+.vtmn-popover[data-position='bottom-left'] > [role='dialog']::after {
   left: 90%;
 }
 
-.vtmn-popover[data-position='bottom-left'] > [role='tooltip'] {
-  transform: translate(-90%, 120%);
+.vtmn-popover[data-position='bottom-left'] > [role='dialog'] {
+  transform: translateX(-90%);
 }
 
 /* POSITION: BOTTOM-RIGHT */
-.vtmn-popover[data-position='bottom-right'] > [role='tooltip']::after {
+.vtmn-popover[data-position='bottom-right'] > [role='dialog']::after {
   left: 10%;
 }
 
-.vtmn-popover[data-position='bottom-right'] > [role='tooltip'] {
-  transform: translate(-10%, 120%);
+.vtmn-popover[data-position='bottom-right'] > [role='dialog'] {
+  transform: translateX(-10%);
 }
 
 /* POSITION: LEFT */
-.vtmn-popover[data-position='left'] > [role='tooltip'] {
-  transform: translate(-100%, -50%);
+.vtmn-popover[data-position='left'] > [role='dialog'] {
+  top: 50%;
   left: -1.5em;
+  transform: translate(-100%, -50%);
 }
 
-.vtmn-popover[data-position='left'] > .vtmn-btn_size--small + [role='tooltip'] {
-  transform: translate(-100%, -52%);
-}
-
-.vtmn-popover[data-position='left']
-  > .vtmn-btn_size--medium
-  + [role='tooltip'] {
-  transform: translate(-100%, -55%);
-}
-
-.vtmn-popover[data-position='left'] > .vtmn-btn_size--large + [role='tooltip'] {
-  transform: translate(-100%, -58%);
-}
-
-.vtmn-popover[data-position='left'] > [role='tooltip']::after {
+.vtmn-popover[data-position='left'] > [role='dialog']::after {
   border-top: solid transparent 0.6em;
   border-bottom: solid transparent 0.6em;
   border-left: solid var(--vtmn-semantic-color_background-primary-reversed)
     0.65em;
   right: -0.6em;
-  bottom: 50%;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 /* POSITION: RIGHT */
-.vtmn-popover[data-position='right'] > [role='tooltip'] {
-  transform: translate(100%, -50%);
+.vtmn-popover[data-position='right'] > [role='dialog'] {
+  top: 50%;
   right: -1.5em;
+  transform: translate(100%, -50%);
 }
 
-.vtmn-popover[data-position='right']
-  > .vtmn-btn_size--small
-  + [role='tooltip'] {
-  transform: translate(100%, -52%);
-}
-
-.vtmn-popover[data-position='right']
-  > .vtmn-btn_size--medium
-  + [role='tooltip'] {
-  transform: translate(100%, -55%);
-}
-
-.vtmn-popover[data-position='right']
-  > .vtmn-btn_size--large
-  + [role='tooltip'] {
-  transform: translate(100%, -58%);
-}
-
-.vtmn-popover[data-position='right'] > [role='tooltip']::after {
+.vtmn-popover[data-position='right'] > [role='dialog']::after {
   border-top: solid transparent 0.6em;
   border-bottom: solid transparent 0.6em;
   border-right: solid var(--vtmn-semantic-color_background-primary-reversed)
     0.65em;
   left: -0.6em;
-  bottom: 50%;
+  top: 50%;
+  transform: translateY(-50%);
 }

--- a/packages/sources/react/src/components/overlays/VtmnPopover/VtmnPopover.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnPopover/VtmnPopover.tsx
@@ -40,13 +40,19 @@ export const VtmnPopover = ({
       className="vtmn-popover"
       data-position={position}
       aria-describedby={identifier}
-      tabIndex={0}
+      aria-labelledby={`${identifier}-title`}
       {...props}
     >
       {children}
 
-      <div id={identifier} role="tooltip">
-        <p className="vtmn-popover_title">{title}</p>
+      <div id={identifier} role="dialog">
+        <p
+          className="vtmn-popover_title"
+          id={`${identifier}-title`}
+          role="heading"
+        >
+          {title}
+        </p>
         <p className="vtmn-popover_text">{body}</p>
       </div>
     </div>

--- a/packages/sources/svelte/src/components/overlays/VtmnPopover/VtmnPopover.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnPopover/VtmnPopover.svelte
@@ -24,13 +24,15 @@
   class={componentClass}
   data-position={position}
   aria-describedby={id}
-  tabindex="0"
+  aria-labelledby={`${id}-title`}
   {...$$restProps}
 >
   <slot />
 
-  <div {id} role="tooltip">
-    <p class="vtmn-popover_title"><slot name="title" /></p>
+  <div {id} role="dialog">
+    <p class="vtmn-popover_title" id={`${id}-title`} role="heading">
+      <slot name="title" />
+    </p>
     <p class="vtmn-popover_text"><slot name="body" /></p>
   </div>
 </div>

--- a/packages/sources/svelte/src/components/overlays/VtmnPopover/test/VtmnPopover.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnPopover/test/VtmnPopover.spec.js
@@ -16,7 +16,6 @@ describe('VtmnPopover', () => {
       'aria-describedby',
       'unit-test-id',
     );
-    expect(getPopover(container)).toHaveAttribute('tabindex', '0');
     expect(getByRole('tooltip')).toHaveAttribute('id', 'unit-test-id');
   });
   test('Should apply the position', () => {

--- a/packages/sources/svelte/src/components/overlays/VtmnPopover/test/VtmnPopover.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnPopover/test/VtmnPopover.spec.js
@@ -16,7 +16,7 @@ describe('VtmnPopover', () => {
       'aria-describedby',
       'unit-test-id',
     );
-    expect(getByRole('tooltip')).toHaveAttribute('id', 'unit-test-id');
+    expect(getByRole('dialog')).toHaveAttribute('id', 'unit-test-id');
   });
   test('Should apply the position', () => {
     const { container } = render(VtmnPopover, {

--- a/packages/sources/vue/src/components/overlays/VtmnPopover/VtmnPopover.vue
+++ b/packages/sources/vue/src/components/overlays/VtmnPopover/VtmnPopover.vue
@@ -41,13 +41,16 @@ export default /*#__PURE__*/ defineComponent({
     class="vtmn-popover"
     :data-position="position"
     :aria-describedby="id"
+    :aria-labelledby="id + '-title'"
     tabindex="0"
     v-bind="$attrs"
   >
     <slot />
 
-    <div :id="id" role="tooltip">
-      <p class="vtmn-popover_title">{{ title }}</p>
+    <div :id="id" role="dialog">
+      <p :id="id + '-title'" class="vtmn-popover_title" role="heading">
+        {{ title }}
+      </p>
       <p class="vtmn-popover_text">{{ body }}</p>
     </div>
   </div>


### PR DESCRIPTION

## Changes description
<!--- Describe your changes in details. -->
- CSS: clean up popover positioning
- A11y: remove unnecessary attributes, add missing attributes, update values
- Integration: update React / Vue / Svelte components accordingly

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
- An [issue (#1259)](https://github.com/Decathlon/vitamin-web/issues/1259) has been opened on a weird positioning of the popover in some context.
- The component css had indeed curious positioning values such as absolute positioning dependent on its size (should not), magic number (52%, 40%, ...) and unwanted dependency to other component (VtmnButton).
- The component accessibility attributes was partly inaccurate: was defined as "tooltip" instead of "dialog" (since it is focusable), sometimes triggerred by anchor link in some showcases, missing id and aria attributes, etc.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

