### PR TITLE
feat(@vtmn/css, @vtmn/svelte, @vtmn/react, @vtmn/vue): tabindex for the popover

### DIFF
--- a/packages/showcases/css/stories/components/overlays/popover/examples/overview.html
+++ b/packages/showcases/css/stories/components/overlays/popover/examples/overview.html
@@ -17,6 +17,7 @@
     data-position="top-right"
     aria-labelledby="my-popover-label-1"
     aria-describedby="my-popover-1"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--small">Top-Right</button>
     <div id="my-popover-1" role="dialog">
@@ -42,6 +43,7 @@
     data-position="top"
     aria-labelledby="my-popover-label-2"
     aria-describedby="my-popover-2"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--small">Top</button>
     <div id="my-popover-2" role="dialog">
@@ -67,6 +69,7 @@
     data-position="top-left"
     aria-labelledby="my-popover-label-3"
     aria-describedby="my-popover-3"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--small">Top-left</button>
     <div id="my-popover-3" role="dialog">
@@ -106,6 +109,7 @@
     data-position="right"
     aria-labelledby="my-popover-label-4"
     aria-describedby="my-popover-4"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--medium">Right</button>
     <div id="my-popover-4" role="dialog">
@@ -131,6 +135,7 @@
     data-position="left"
     aria-labelledby="my-popover-label-5"
     aria-describedby="my-popover-5"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--medium">Left</button>
     <div id="my-popover-5" role="dialog">
@@ -170,6 +175,7 @@
     data-position="bottom-right"
     aria-labelledby="my-popover-label-6"
     aria-describedby="my-popover-6"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--small">Bottom-Right</button>
     <div id="my-popover-6" role="dialog">
@@ -195,6 +201,7 @@
     data-position="bottom"
     aria-labelledby="my-popover-label-7"
     aria-describedby="my-popover-7"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--large">Bottom</button>
 
@@ -221,6 +228,7 @@
     data-position="bottom-left"
     aria-labelledby="my-popover-label-8"
     aria-describedby="my-popover-8"
+    tabindex="0"
   >
     <button class="vtmn-btn vtmn-btn_size--small">Bottom-Left</button>
     <div id="my-popover-8" role="dialog">

--- a/packages/showcases/react/stories/components/overlays/VtmnPopover/VtmnPopover.stories.tsx
+++ b/packages/showcases/react/stories/components/overlays/VtmnPopover/VtmnPopover.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VtmnPopover, VtmnLink } from '@vtmn/react';
+import { VtmnPopover, VtmnButton } from '@vtmn/react';
 import { Meta, Story } from '@storybook/react';
 import {
   argTypes,
@@ -15,7 +15,7 @@ export default {
 
 const Template: Story = (args) => (
   <VtmnPopover identifier="my-popover" {...args}>
-    <VtmnLink>Popover on the {args.position}</VtmnLink>
+    <VtmnButton>Popover on the {args.position}</VtmnButton>
   </VtmnPopover>
 );
 

--- a/packages/showcases/vue/stories/components/overlays/VtmnPopover/VtmnPopover.stories.js
+++ b/packages/showcases/vue/stories/components/overlays/VtmnPopover/VtmnPopover.stories.js
@@ -1,4 +1,4 @@
-import { VtmnPopover, VtmnLink } from '@vtmn/vue';
+import { VtmnPopover, VtmnButton } from '@vtmn/vue';
 import {
   argTypes,
   parameters,
@@ -12,11 +12,11 @@ export default {
 };
 
 const Template = (args) => ({
-  components: { VtmnPopover, VtmnLink },
+  components: { VtmnPopover, VtmnButton },
   setup() {
     return { args };
   },
-  template: `<VtmnPopover id="my-popover" v-bind="args"><VtmnLink>Popover on the {{ args.position }}</VtmnLink></VtmnPopover>`,
+  template: `<VtmnPopover id="my-popover" v-bind="args"><VtmnButton>Popover on the {{ args.position }}</VtmnButton></VtmnPopover>`,
 });
 
 export const Overview = Template.bind({});

--- a/packages/sources/react/src/components/overlays/VtmnPopover/VtmnPopover.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnPopover/VtmnPopover.tsx
@@ -41,6 +41,7 @@ export const VtmnPopover = ({
       data-position={position}
       aria-describedby={identifier}
       aria-labelledby={`${identifier}-title`}
+      tabIndex={0}
       {...props}
     >
       {children}

--- a/packages/sources/svelte/src/components/overlays/VtmnPopover/VtmnPopover.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnPopover/VtmnPopover.svelte
@@ -25,6 +25,7 @@
   data-position={position}
   aria-describedby={id}
   aria-labelledby={`${id}-title`}
+  tabindex="0"
   {...$$restProps}
 >
   <slot />


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Put back the `tabindex` to prevent display issue (on svelte especially).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

