### PR TITLE
fix(@vtmn/react): missing accessible name on VtmnAlert

### DIFF
--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -37,6 +37,7 @@ export const VtmnAlert = ({
 }: VtmnAlertProps) => {
   return (
     <div
+      aria-label={title}
       role="dialog"
       className={clsx(
         'vtmn-alert',


### PR DESCRIPTION
## Changes description
Added an aria-label to the alert component

## Context
aria labelling is mandatory on dialog-role elements :
https://dequeuniversity.com/rules/axe/4.4/aria-dialog-name?application=axeAPI

It's missing on VtmnAlert component : 
![image](https://user-images.githubusercontent.com/22882255/197741744-21fe636f-2a41-4017-ab71-c9257078ddd4.png)



## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?

- No
