### PR TITLE
fix(@vtmn/vue): cancel event is not present in `VtmnChip` component (input variant)

### DIFF
--- a/packages/showcases/vue/stories/components/selection-controls/VtmnChip/VtmnChip.stories.js
+++ b/packages/showcases/vue/stories/components/selection-controls/VtmnChip/VtmnChip.stories.js
@@ -13,10 +13,16 @@ export default {
 
 const Template = (args) => ({
   components: { VtmnChip },
+
   setup() {
-    return { args };
+    return {
+      args,
+      handleCancel: () => {
+        console.log('cancel');
+      },
+    };
   },
-  template: `<VtmnChip v-bind="args">Chip</VtmnChip>`,
+  template: `<VtmnChip @cancel="handleCancel()" v-bind="args">Chip</VtmnChip>`,
 });
 
 export const Overview = Template.bind({});

--- a/packages/sources/vue/src/components/selection-controls/VtmnChip/VtmnChip.vue
+++ b/packages/sources/vue/src/components/selection-controls/VtmnChip/VtmnChip.vue
@@ -43,7 +43,7 @@ export default /*#__PURE__*/ defineComponent({
       default: 0,
     },
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'cancel'],
   setup(props, { emit }) {
     props = reactive(props);
 
@@ -54,6 +54,10 @@ export default /*#__PURE__*/ defineComponent({
           (event.target as HTMLInputElement).checked,
         );
       }
+    };
+
+    const handleCancel = () => {
+      return emit('cancel');
     };
 
     return {
@@ -69,6 +73,7 @@ export default /*#__PURE__*/ defineComponent({
         ['vtmn-chip--disabled']: props.disabled,
       })),
       handleChange,
+      handleCancel,
     };
   },
 });
@@ -95,6 +100,7 @@ export default /*#__PURE__*/ defineComponent({
       :iconAlone="'close-line'"
       :size="size"
       :disabled="disabled"
+      @click.prevent="handleCancel"
       aria-label="Unselect the selection"
     />
     <VtmnBadge


### PR DESCRIPTION
## Changes description
Fix the close button of the Chip component for Vue.

## Context
It was not possible to interact with the input variant of the Chip component in Vue.

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?

- No

## Other information
