### PR TITLE
feat(@vtmn/react): add ref forwarding on form elements

### DIFF
--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -13,44 +13,50 @@ export interface VtmnSelectProps extends React.ComponentPropsWithRef<'select'> {
   labelProps?: React.ComponentPropsWithoutRef<'label'>;
 }
 
-export const VtmnSelect = ({
-  className,
-  error = false,
-  errorText,
-  id,
-  labelText,
-  labelClassName,
-  labelProps,
-  options = [],
-  ...props
-}: VtmnSelectProps) => {
-  const errorTextId = `error-text-${id}`;
-  const hasErrorText = error && errorText;
+export const VtmnSelect = React.forwardRef<HTMLSelectElement, VtmnSelectProps>(
+  (
+    {
+      className,
+      error = false,
+      errorText,
+      id,
+      labelText,
+      labelClassName,
+      labelProps,
+      options = [],
+      ...props
+    },
+    ref,
+  ) => {
+    const errorTextId = `error-text-${id}`;
+    const hasErrorText = error && errorText;
 
-  return (
-    <div className="vtmn-select_container">
-      <label className={labelClassName || ''} htmlFor={id} {...labelProps}>
-        {labelText}
-      </label>
-      <select
-        id={id}
-        className={clsx('vtmn-select', className, {
-          'vtmn-select--error': error,
-        })}
-        aria-describedby={hasErrorText ? errorTextId : undefined}
-        {...props}
-      >
-        {options.map((option) => option)}
-      </select>
+    return (
+      <div className="vtmn-select_container">
+        <label className={labelClassName || ''} htmlFor={id} {...labelProps}>
+          {labelText}
+        </label>
+        <select
+          id={id}
+          className={clsx('vtmn-select', className, {
+            'vtmn-select--error': error,
+          })}
+          aria-describedby={hasErrorText ? errorTextId : undefined}
+          ref={ref}
+          {...props}
+        >
+          {options.map((option) => option)}
+        </select>
 
-      {hasErrorText && (
-        <p id={errorTextId} className="vtmn-select_error-text">
-          {errorText}
-        </p>
-      )}
-    </div>
-  );
-};
+        {hasErrorText && (
+          <p id={errorTextId} className="vtmn-select_error-text">
+            {errorText}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
 
 const MemoVtmnSelect = React.memo(VtmnSelect);
 

--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -2,7 +2,8 @@ import '@vtmn/css-select/dist/index-with-vars.css';
 import clsx from 'clsx';
 import React from 'react';
 
-export interface VtmnSelectProps extends React.ComponentPropsWithRef<'select'> {
+export interface VtmnSelectProps
+  extends React.ComponentPropsWithoutRef<'select'> {
   error?: boolean;
   errorText?: string;
   id: string;

--- a/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
@@ -82,83 +82,93 @@ export type VtmnTextInputProps = React.ComponentPropsWithoutRef<'textarea'> &
   React.ComponentPropsWithoutRef<'input'> &
   VtmnTextInputAdditionalProps;
 
-export const VtmnTextInput = ({
-  className,
-  disabled = false,
-  error = false,
-  helperText,
-  icon = undefined,
-  identifier,
-  labelText,
-  placeholder,
-  valid = false,
-  onIconClick,
-  labelClassName,
-  labelProps,
-  ...props
-}: VtmnTextInputProps) => {
-  const { multiline, ...rest } = props;
-  return (
-    <>
-      {labelText && (
-        <label
-          className={`vtmn-text-input_label ${labelClassName || ''}`}
-          htmlFor={identifier}
-          {...labelProps}
-        >
-          {labelText}
-        </label>
-      )}
-      {multiline ? (
-        <textarea
-          className={clsx('vtmn-text-input', className, {
-            'vtmn-text-input--error': error,
-            'vtmn-text-input--valid': valid,
-          })}
-          id={identifier}
-          placeholder={placeholder}
-          disabled={disabled}
-          aria-invalid={(error && !disabled) || undefined}
-          aria-describedby={
-            (helperText && `${identifier}-helper-text`) || undefined
-          }
-          {...rest}
-        />
-      ) : (
-        <div className="vtmn-text-input_container">
-          <input
-            className={clsx(
-              'vtmn-text-input',
-              className,
-              { 'vtmn-text-input--valid': valid && !disabled },
-              { 'vtmn-text-input--error': error && !disabled },
-            )}
+export const VtmnTextInput = React.forwardRef<
+  HTMLTextAreaElement & HTMLInputElement,
+  VtmnTextInputProps
+>(
+  (
+    {
+      className,
+      disabled = false,
+      error = false,
+      helperText,
+      icon = undefined,
+      identifier,
+      labelText,
+      placeholder,
+      valid = false,
+      onIconClick,
+      labelClassName,
+      labelProps,
+      ...props
+    },
+    ref,
+  ) => {
+    const { multiline, ...rest } = props;
+    return (
+      <>
+        {labelText && (
+          <label
+            className={`vtmn-text-input_label ${labelClassName || ''}`}
+            htmlFor={identifier}
+            {...labelProps}
+          >
+            {labelText}
+          </label>
+        )}
+        {multiline ? (
+          <textarea
+            className={clsx('vtmn-text-input', className, {
+              'vtmn-text-input--error': error,
+              'vtmn-text-input--valid': valid,
+            })}
             id={identifier}
-            type="text"
             placeholder={placeholder}
             disabled={disabled}
             aria-invalid={(error && !disabled) || undefined}
             aria-describedby={
               (helperText && `${identifier}-helper-text`) || undefined
             }
+            ref={ref}
             {...rest}
           />
-          {icon && <VtmnIcon value={icon} onClick={onIconClick} />}
-        </div>
-      )}
-      {helperText && (
-        <p
-          id={`${identifier}-helper-text`}
-          className={clsx('vtmn-text-input_helper-text', className, {
-            'vtmn-text-input_helper-text--error': error,
-          })}
-        >
-          {helperText}
-        </p>
-      )}
-    </>
-  );
-};
+        ) : (
+          <div className="vtmn-text-input_container">
+            <input
+              className={clsx(
+                'vtmn-text-input',
+                className,
+                { 'vtmn-text-input--valid': valid && !disabled },
+                { 'vtmn-text-input--error': error && !disabled },
+              )}
+              id={identifier}
+              type="text"
+              placeholder={placeholder}
+              disabled={disabled}
+              aria-invalid={(error && !disabled) || undefined}
+              aria-describedby={
+                (helperText && `${identifier}-helper-text`) || undefined
+              }
+              ref={ref}
+              {...rest}
+            />
+            {icon && <VtmnIcon value={icon} onClick={onIconClick} />}
+          </div>
+        )}
+        {helperText && (
+          <p
+            id={`${identifier}-helper-text`}
+            className={clsx('vtmn-text-input_helper-text', className, {
+              'vtmn-text-input_helper-text--error': error,
+            })}
+          >
+            {helperText}
+          </p>
+        )}
+      </>
+    );
+  },
+);
 
 const MemoVtmnTextInput = React.memo(VtmnTextInput);
 

--- a/packages/sources/react/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.tsx
@@ -38,30 +38,39 @@ export interface VtmnCheckboxProps
   disabled?: boolean;
 }
 
-export const VtmnCheckbox = ({
-  identifier,
-  labelText,
-  checked = false,
-  defaultChecked = undefined,
-  disabled = false,
-  ...props
-}: VtmnCheckboxProps) => {
-  return (
-    <div>
-      <input
-        className="vtmn-checkbox"
-        type="checkbox"
-        id={identifier}
-        {...(typeof defaultChecked !== 'undefined'
-          ? { defaultChecked }
-          : { checked })}
-        disabled={disabled}
-        {...props}
-      />
-      <label htmlFor={identifier}>{labelText}</label>
-    </div>
-  );
-};
+export const VtmnCheckbox = React.forwardRef<
+  HTMLInputElement,
+  VtmnCheckboxProps
+>(
+  (
+    {
+      identifier,
+      labelText,
+      checked = false,
+      defaultChecked = undefined,
+      disabled = false,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div>
+        <input
+          className="vtmn-checkbox"
+          type="checkbox"
+          id={identifier}
+          {...(typeof defaultChecked !== 'undefined'
+            ? { defaultChecked }
+            : { checked })}
+          disabled={disabled}
+          ref={ref}
+          {...props}
+        />
+        <label htmlFor={identifier}>{labelText}</label>
+      </div>
+    );
+  },
+);
 
 const MemoVtmnCheckbox = React.memo(VtmnCheckbox);
 

--- a/packages/sources/react/src/components/selection-controls/VtmnRadioButton/VtmnRadioButton.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnRadioButton/VtmnRadioButton.tsx
@@ -38,31 +38,39 @@ export interface VtmnRadioButtonProps
   disabled?: boolean;
 }
 
-export const VtmnRadioButton = ({
-  identifier,
-  labelText,
-  checked = false,
-  defaultChecked = undefined,
-  disabled = false,
-  ...props
-}: VtmnRadioButtonProps) => {
-  return (
-    <div>
-      <input
-        className="vtmn-radio-button"
-        type="radio"
-        id={identifier}
-        {...(typeof defaultChecked !== 'undefined'
-          ? { defaultChecked }
-          : { checked })}
-        disabled={disabled}
-        {...props}
-      />
-      <label htmlFor={identifier}>{labelText}</label>
-    </div>
-  );
-};
-
+export const VtmnRadioButton = React.forwardRef<
+  HTMLInputElement,
+  VtmnRadioButtonProps
+>(
+  (
+    {
+      identifier,
+      labelText,
+      checked = false,
+      defaultChecked = undefined,
+      disabled = false,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div>
+        <input
+          className="vtmn-radio-button"
+          type="radio"
+          id={identifier}
+          {...(typeof defaultChecked !== 'undefined'
+            ? { defaultChecked }
+            : { checked })}
+          disabled={disabled}
+          ref={ref}
+          {...props}
+        />
+        <label htmlFor={identifier}>{labelText}</label>
+      </div>
+    );
+  },
+);
 const MemoVtmnRadioButton = React.memo(VtmnRadioButton);
 
 MemoVtmnRadioButton.displayName = 'VtmnRadioButton';

--- a/packages/sources/react/src/components/selection-controls/VtmnToggle/VtmnToggle.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnToggle/VtmnToggle.tsx
@@ -39,33 +39,39 @@ export interface VtmnToggleProps
   disabled?: boolean;
 }
 
-export const VtmnToggle = ({
-  className,
-  identifier,
-  labelText,
-  size = 'medium',
-  checked = false,
-  disabled = false,
-  ...props
-}: VtmnToggleProps) => {
-  return (
-    <div
-      className={clsx('vtmn-toggle', `vtmn-toggle_size--${size}`, className)}
-    >
-      <div className="vtmn-toggle_switch">
-        <input
-          type="checkbox"
-          id={identifier}
-          checked={checked}
-          disabled={disabled}
-          {...props}
-        />
-        <span aria-hidden="true"></span>
+export const VtmnToggle = React.forwardRef<HTMLInputElement, VtmnToggleProps>(
+  (
+    {
+      className,
+      identifier,
+      labelText,
+      size = 'medium',
+      checked = false,
+      disabled = false,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={clsx('vtmn-toggle', `vtmn-toggle_size--${size}`, className)}
+      >
+        <div className="vtmn-toggle_switch">
+          <input
+            type="checkbox"
+            id={identifier}
+            checked={checked}
+            disabled={disabled}
+            ref={ref}
+            {...props}
+          />
+          <span aria-hidden="true"></span>
+        </div>
+        <label htmlFor={identifier}>{labelText}</label>
       </div>
-      <label htmlFor={identifier}>{labelText}</label>
-    </div>
-  );
-};
+    );
+  },
+);
 
 const MemoVtmnToggle = React.memo(VtmnToggle);
 


### PR DESCRIPTION
## Changes description
This PR add actual form elements refs in following Vtmn form components :
 `VtmnTextInput`, `VtmnSelect`, `VtmnCheckbox`, `VtmnRadioButton` & `VtmnToggle`

_(refs are already forwarded in `VtmnButton` and `VtmnQuantity`)_

## Context
The purpose is to be able to access actual form element. 
It allows an easy read/write on those.
[React Hook Form](https://react-hook-form.com/) - which seems like one of the best solution rn in terms of form validation - base its implementation on those

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

