### PR TITLE
refactor(@vtmn/css): full-card: title wraps correctly

### DIFF
--- a/packages/sources/css/src/components/structure/card/src/index.css
+++ b/packages/sources/css/src/components/structure/card/src/index.css
@@ -31,7 +31,6 @@
 .vtmn-card_content--title {
   font-size: var(--vtmn-typo_title-5-font-size);
   font-weight: var(--vtmn-typo_font-weight--bold);
-  min-inline-size: max-content;
 }
 
 .vtmn-card_content--body {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

- Remove `min-inline-size` property that prevent the content wrapping

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- Resolve #1305 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
