### PR TITLE
fix(@vtmn/svelte): remove font import into `VtmnIcon` component

### DIFF
--- a/packages/sources/svelte/src/guidelines/iconography/VtmnIcon/VtmnIcon.svelte
+++ b/packages/sources/svelte/src/guidelines/iconography/VtmnIcon/VtmnIcon.svelte
@@ -63,7 +63,6 @@
 <span class={componentClass} style={componentStyle} {...$$restProps} />
 
 <style>
-  @import '@vtmn/icons/dist/vitamix/font/vitamix.css';
   .vtmn-icon-size {
     color: var(--vtmn-icon-semantic-color);
     font-size: var(--vtmn-icon-size);


### PR DESCRIPTION
## Changes description
Delete font import from VtmnIcon svelte, to follow the readme logic

## Context
We use the package of Vitamin in a svelte app injected into some prestashop page, this import is causing us a lot of 404 on our application, since it searches for the fonts for the current page (which is not fetchable, since we are injected on a prestashop route, example: our app is loaded on [decathlon.at/some/page](http://decathlon.at/some/page), we will get 404 for [decathlon.at/some/page/vitamix.ttf/woff/woff2](http://decathlon.at/some/page/vitamix.ttf/woff/woff2))
## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?

- No

## Other information
![image](https://user-images.githubusercontent.com/97243839/203571153-bfef2501-b6ad-4c22-96c2-367fd350fc48.png)
