### PR TITLE
build: add sideEffects false to allow treeshaking

### DIFF
--- a/packages/sources/react/package.json
+++ b/packages/sources/react/package.json
@@ -17,6 +17,7 @@
     "type": "git",
     "url": "git+https://github.com/Decathlon/vitamin-web.git"
   },
+  "sideEffects": false,
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -18,6 +18,7 @@
     "url": "git+https://github.com/Decathlon/vitamin-web.git"
   },
   "license": "Apache-2.0",
+  "sideEffects": false,
   "files": [
     "src",
     "dist"

--- a/packages/sources/vue/package.json
+++ b/packages/sources/vue/package.json
@@ -21,6 +21,7 @@
   "main": "dist/vtmn/vue.cjs.js",
   "module": "dist/vtmn/vue.es.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist",
     "dist/*.d.ts"


### PR DESCRIPTION
Signed-off-by: Shyrro <zakaria.sahmane@decathlon.com>

## Changes description
Allow treeshaking by adding `sideEffects: false` in `package.json` of every framework. 
This will allow the callers that use modern bundlers (Webpack 5, Vite, Rollup etc), to only import the components they use instead of everything. 

Currently, if we do `import { VtmnAccordion } from '@vtmn/react'` we will only have one big `index.js` in the build, whereas we only need the chunk related to the Accordion and its deps.

## Context
It reduces perf issues for all apps. 

Here is an example of Vitamin in a Next 12 app : 

![vtmn/react dist in a next app](https://i.ibb.co/pxX3nQ5/Capture-d-e-cran-2023-01-11-a-14-54-41.png)

We can see that Vitamin dist only contains an `index.es.js` instead of different chunks of used components like the other modules. This is a small app and and we can see that `@vtmn/react` is taking a lot of space on its own without the ability to load a small portion of it.
This change would allow the bundler to understand that the package is written in `ESM` and that it can treeshake it without worrying about anything.

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [ ] ~~I have tested on related showcases.~~
- [ ] ~~If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.~~

## Does this introduce a breaking change?
- No

## Other information

This is a small change that can improve everyones lives when working with `esm`
