### PR TITLE
feat(@vtmn/svelte): add doc on style preprocessing

### DIFF
--- a/packages/sources/svelte/README.md
+++ b/packages/sources/svelte/README.md
@@ -58,6 +58,38 @@ import 'typeface-roboto-condensed';
 
 To use this package, you need to use the source files and compile on your side. To do so, you can start with [+SvelteKit](https://kit.svelte.dev/) for example.
 
+You should then preprocess the component CSS since they are imported in each corresponding component with an [`@import`](https://developer.mozilla.org/fr/docs/Web/CSS/@import) rule. There are several ways to resolve path of an `@import` rule, our recommended way is to use the [postcss-import](https://github.com/postcss/postcss-import) plugin.
+
+For example, here is a working `svelte.config.js`:
+
+```javascript
+import adapter from '@sveltejs/adapter-auto';
+import preprocess from 'svelte-preprocess';
+import atImport from 'postcss-import';
+
+const config = {
+  preprocess: preprocess({
+    postcss: {
+      plugins: [
+        atImport({
+          root: process.cwd(),
+          // import should default to node_modules, then look into src
+          path: [
+            join(process.cwd(), 'node_modules'),
+            join(process.cwd(), 'src'),
+          ],
+        }),
+      ],
+    },
+  }),
+  kit: {
+    adapter: adapter(),
+  },
+};
+
+export default config;
+```
+
 Then, you just need to import components you need. Example with `VtmnButton`:
 
 ```js


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Closes #1331 :  improve the current documentation of @vtmn/svelte with the preprocess part.

An explanation has been added in the corresponding README.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
In #1326 an issue was reported that the use of Vitamin svelte components is not clear, especially on the treatment of the CSS which was reporting errors .

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
