### PR TITLE
fix(@vtmn/svelte): fix events accessibility `VtmnListItem`

### DIFF
--- a/packages/showcases/svelte/stories/components/structure/VtmnList/VtmnList.stories.svelte
+++ b/packages/showcases/svelte/stories/components/structure/VtmnList/VtmnList.stories.svelte
@@ -27,13 +27,21 @@
   <div style="width: 700px; display: flex; justify-content: center">
     <VtmnList>
       {#each listItems() as { buttonText }, index}
-        <VtmnListItem>
+        <VtmnListItem
+          role="button"
+          on:click={(e) => console.log('Click on list element')}
+        >
           <VtmnButton
             iconAlone="heart-line"
             variant="ghost"
             slot="start-visual"
-            on:click={() =>
-              console.log(`List item button ${buttonText} clicked !`)}
+            on:keydown={(e) => {
+              e.stopPropagation();
+            }}
+            on:click={(e) => {
+              e.stopPropagation();
+              console.log(`List item button ${buttonText} clicked !`);
+            }}
           />
 
           <span slot="text">Lorem ipsum</span>
@@ -41,9 +49,11 @@
 
           <VtmnButton
             slot="end-action"
-            on:click={() =>
-              console.log(`List item button ${buttonText} clicked !`)}
-            >{buttonText}</VtmnButton
+            on:keydown={(e) => e.stopPropagation()}
+            on:click={(e) => {
+              e.stopPropagation();
+              console.log(`List item button ${buttonText} clicked !`);
+            }}>{buttonText}</VtmnButton
           >
         </VtmnListItem>
       {/each}
@@ -98,13 +108,19 @@
           href="/"
           target="_blank"
           aria-label="Redirection link {index}"
+          role="button"
+          on:click={(e) => console.log('Click on list element')}
+          on:keydown={(e) => e.stopPropagation()}
         >
           <span slot="text">Lorem ipsum</span>
           <span slot="subtext">Lorem ipsum dolor sit amet</span>
           <VtmnButton
             slot="end-action"
-            on:click={() => console.log(`List item button clicked !`)}
-            >Button</VtmnButton
+            on:keydown={(e) => e.stopPropagation()}
+            on:click={(e) => {
+              e.stopPropagation();
+              console.log(`List item button clicked !`);
+            }}>Button</VtmnButton
           >
         </VtmnListItem>
       {/each}

--- a/packages/showcases/svelte/stories/components/structure/VtmnListItem/VtmnListItem.stories.svelte
+++ b/packages/showcases/svelte/stories/components/structure/VtmnListItem/VtmnListItem.stories.svelte
@@ -28,6 +28,11 @@
       control: { type: 'text' },
       if: { arg: 'href' },
     },
+    role: {
+      description: 'Role of the li',
+      control: { type: 'text' },
+      defaultValue: 'listitem',
+    },
     rel: {
       description: 'Rel of the link.',
       control: { type: 'text' },

--- a/packages/sources/svelte/src/components/actions/VtmnButton/VtmnButton.svelte
+++ b/packages/sources/svelte/src/components/actions/VtmnButton/VtmnButton.svelte
@@ -55,7 +55,13 @@
   );
 </script>
 
-<button on:click type="button" class={componentClass} {...$$restProps}>
+<button
+  on:click
+  on:keydown
+  type="button"
+  class={componentClass}
+  {...$$restProps}
+>
   {#if !iconAlone && iconLeft}
     <VtmnIcon value={iconLeft} />
   {/if}

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
@@ -3,7 +3,7 @@
   import { cn } from '../../../utils/classnames';
   import { computeRel } from '../../../utils/link';
   import { createEventDispatcher } from 'svelte';
-  import { ENTER, SPACE } from '../../../utils/keyCodes';
+  import { ENTER } from '../../../utils/keyCodes';
 
   /** @restProps */
 

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
@@ -9,7 +9,6 @@
 
   const SLOTS = $$props.$$slots;
   const dispatch = createEventDispatcher();
-  let listElement;
 
   /**
    * The size of the list.
@@ -26,6 +25,13 @@
    * @defaultValue true
    */
   export let divider = true;
+
+  /**
+   * role of the list element
+   * @type {string}
+   * @default listitem
+   */
+  export let role = 'listitem';
 
   /**
    * Set disabled state of list item.
@@ -86,11 +92,10 @@
 <!-- svelte-ignore a11y-role-has-required-aria-props -->
 <!-- This will be refactored in next major release -->
 <li
-  bind:this={listElement}
-  on:click|stopPropagation={handleSelectItem}
-  on:keydown|stopPropagation={handleSelectItem}
+  on:click={handleSelectItem}
+  on:keydown={handleSelectItem}
   class={componentClass}
-  role="option"
+  {role}
   tabindex={href ? -1 : 0}
   aria-disabled={disabled}
   {...$$restProps}
@@ -108,11 +113,7 @@
       aria-disabled={disabled}
     >
       {#if checkSlotExists('start-visual')}
-        <div
-          class="vtmn-list_start-visual"
-          on:click={(e) => e.stopPropagation()}
-          on:keydown={(e) => e.stopPropagation()}
-        >
+        <div class="vtmn-list_start-visual">
           <slot name="start-visual" />
         </div>
       {/if}
@@ -129,11 +130,7 @@
     </a>
   {:else}
     {#if checkSlotExists('start-visual')}
-      <div
-        class="vtmn-list_start-visual"
-        on:click={(e) => e.stopPropagation()}
-        on:keydown={(e) => e.stopPropagation()}
-      >
+      <div class="vtmn-list_start-visual">
         <slot name="start-visual" />
       </div>
     {/if}
@@ -149,11 +146,7 @@
     {/if}
   {/if}
   {#if checkSlotExists('end-action')}
-    <div
-      class="vtmn-list_end-action"
-      on:click={(e) => e.stopPropagation()}
-      on:keydown={(e) => e.stopPropagation()}
-    >
+    <div class="vtmn-list_end-action">
       <slot name="end-action" />
     </div>
   {/if}

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
@@ -2,10 +2,14 @@
   import { VTMN_LISTITEM_SIZE } from './enums';
   import { cn } from '../../../utils/classnames';
   import { computeRel } from '../../../utils/link';
+  import { createEventDispatcher } from 'svelte';
+  import { ENTER, SPACE } from '../../../utils/keyCodes';
 
   /** @restProps */
 
   const SLOTS = $$props.$$slots;
+  const dispatch = createEventDispatcher();
+  let listElement;
 
   /**
    * The size of the list.
@@ -71,12 +75,20 @@
   const checkSlotExists = (slotName) => {
     return SLOTS && SLOTS[slotName] && SLOTS[slotName].length;
   };
+
+  const handleSelectItem = (e) => {
+    if (!e.keyCode || e.keyCode === ENTER) {
+      dispatch('click');
+    }
+  };
 </script>
 
 <!-- svelte-ignore a11y-role-has-required-aria-props -->
 <!-- This will be refactored in next major release -->
 <li
-  on:click
+  bind:this={listElement}
+  on:click|stopPropagation={handleSelectItem}
+  on:keydown|stopPropagation={handleSelectItem}
   class={componentClass}
   role="option"
   tabindex={href ? -1 : 0}
@@ -89,12 +101,18 @@
       tabindex={disabled && -1}
       {href}
       {target}
+      on:click|stopPropagation
+      on:keydown={(e) => e.stopPropagation()}
       rel={computeRel(target, rel)}
       aria-label={$$restProps['aria-label']}
       aria-disabled={disabled}
     >
       {#if checkSlotExists('start-visual')}
-        <div class="vtmn-list_start-visual">
+        <div
+          class="vtmn-list_start-visual"
+          on:click={(e) => e.stopPropagation()}
+          on:keydown={(e) => e.stopPropagation()}
+        >
           <slot name="start-visual" />
         </div>
       {/if}
@@ -111,7 +129,11 @@
     </a>
   {:else}
     {#if checkSlotExists('start-visual')}
-      <div class="vtmn-list_start-visual">
+      <div
+        class="vtmn-list_start-visual"
+        on:click={(e) => e.stopPropagation()}
+        on:keydown={(e) => e.stopPropagation()}
+      >
         <slot name="start-visual" />
       </div>
     {/if}
@@ -127,7 +149,11 @@
     {/if}
   {/if}
   {#if checkSlotExists('end-action')}
-    <div class="vtmn-list_end-action">
+    <div
+      class="vtmn-list_end-action"
+      on:click={(e) => e.stopPropagation()}
+      on:keydown={(e) => e.stopPropagation()}
+    >
       <slot name="end-action" />
     </div>
   {/if}

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
@@ -6,40 +6,42 @@ import VtmnListItem from './VtmnListItemWithSlots.svelte';
 describe('VtmnListItem', () => {
   test('Should display a list-item with medium size and divider', () => {
     const { getByRole } = render(VtmnListItem, {});
-    expect(getByRole('option')).toBeVisible();
-    expect(getByRole('option')).toHaveClass('vtmn-list_item-size--medium');
-    expect(getByRole('option')).not.toHaveClass(
+    expect(getByRole('listitem')).toBeVisible();
+    expect(getByRole('listitem')).toHaveClass('vtmn-list_item-size--medium');
+    expect(getByRole('listitem')).not.toHaveClass(
       'vtmn-list_item--without-divider',
     );
-    expect(getByRole('option')).toHaveAttribute('aria-disabled', 'false');
-    expect(getByRole('option')).toHaveAttribute('tabindex', '0');
+    expect(getByRole('listitem')).toHaveAttribute('aria-disabled', 'false');
+    expect(getByRole('listitem')).toHaveAttribute('tabindex', '0');
   });
   test('Should apply custom class on component', () => {
     const { getByRole } = render(VtmnListItem, {
       class: 'custom-class',
     });
-    expect(getByRole('option')).toBeVisible();
-    expect(getByRole('option')).toHaveClass('custom-class');
+    expect(getByRole('listitem')).toBeVisible();
+    expect(getByRole('listitem')).toHaveClass('custom-class');
   });
   test('Should hide divider if divider is false', () => {
     const { getByRole } = render(VtmnListItem, { divider: false });
-    expect(getByRole('option')).toBeVisible();
-    expect(getByRole('option')).toHaveClass('vtmn-list_item--without-divider');
+    expect(getByRole('listitem')).toBeVisible();
+    expect(getByRole('listitem')).toHaveClass(
+      'vtmn-list_item--without-divider',
+    );
   });
   test('Should disable the item', () => {
     const { getByRole } = render(VtmnListItem, { disabled: true });
-    expect(getByRole('option')).toHaveAttribute('aria-disabled', 'true');
+    expect(getByRole('listitem')).toHaveAttribute('aria-disabled', 'true');
   });
   test('Should trigger click on element', async () => {
     const handleClick = jest.fn();
     const { getByRole, component } = render(VtmnListItem, {});
     component.$on('click', handleClick);
-    await fireEvent.click(getByRole('option'));
+    await fireEvent.click(getByRole('listitem'));
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
   test('Should change the size of the list', () => {
     const { getByRole } = render(VtmnListItem, { size: 'small' });
-    expect(getByRole('option')).toHaveClass('vtmn-list_item-size--small');
+    expect(getByRole('listitem')).toHaveClass('vtmn-list_item-size--small');
   });
   test('Should display the start-visual slot', () => {
     const { container } = render(VtmnListItem, {});
@@ -77,7 +79,7 @@ describe('VtmnListItem', () => {
     const handleClick = jest.fn();
     component.$on('click', handleClick);
     await fireEvent.click(getByRole('button'));
-    expect(handleClick).toHaveBeenCalledTimes(1);
+    // expect(handleClick).toHaveBeenCalledTimes(1);
   });
   test('Should have a link element disabled', () => {
     const { getByRole } = render(VtmnListItem, {

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
@@ -61,6 +61,24 @@ describe('VtmnListItem', () => {
     expect(getByRole('link')).toHaveAttribute('href', 'https://decathlon.fr');
     expect(getByRole('link')).toHaveAttribute('aria-disabled', 'false');
   });
+  test('Should trigger click when user click on the the link element', async () => {
+    const { getByRole, component } = render(VtmnListItem, {
+      href: 'https://decathlon.fr',
+    });
+    const handleClick = jest.fn();
+    component.$on('click', handleClick);
+    await fireEvent.click(getByRole('link'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+  test('Should trigger once click if href + click slot button', async () => {
+    const { getByRole, component } = render(VtmnListItem, {
+      href: 'https://decathlon.fr',
+    });
+    const handleClick = jest.fn();
+    component.$on('click', handleClick);
+    await fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
   test('Should have a link element disabled', () => {
     const { getByRole } = render(VtmnListItem, {
       href: 'https://decathlon.fr',

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
@@ -79,7 +79,7 @@ describe('VtmnListItem', () => {
     const handleClick = jest.fn();
     component.$on('click', handleClick);
     await fireEvent.click(getByRole('button'));
-    // expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledTimes(1);
   });
   test('Should have a link element disabled', () => {
     const { getByRole } = render(VtmnListItem, {

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItemWithSlots.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItemWithSlots.svelte
@@ -1,11 +1,21 @@
 <script>
   import VtmnListItem from '../VtmnListItem.svelte';
   import { VtmnIcon, VtmnButton } from '../../../..';
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
 </script>
 
 <VtmnListItem {...$$restProps} on:click>
   <VtmnIcon slot="start-visual" value="heart-line" />
   <span slot="text">Unit test text</span>
   <span slot="subtext">Unit test subtext</span>
-  <VtmnButton slot="end-action" on:click>Button</VtmnButton>
+  <VtmnButton
+    slot="end-action"
+    on:keydown
+    on:click={(e) => {
+      e.stopPropagation();
+      dispatch('click');
+    }}>Button</VtmnButton
+  >
 </VtmnListItem>

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItemWithSlots.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItemWithSlots.svelte
@@ -7,5 +7,5 @@
   <VtmnIcon slot="start-visual" value="heart-line" />
   <span slot="text">Unit test text</span>
   <span slot="subtext">Unit test subtext</span>
-  <VtmnButton slot="end-action">Button</VtmnButton>
+  <VtmnButton slot="end-action" on:click>Button</VtmnButton>
 </VtmnListItem>

--- a/packages/sources/svelte/src/utils/keyCodes.js
+++ b/packages/sources/svelte/src/utils/keyCodes.js
@@ -1,0 +1,10 @@
+export const ENTER = 13;
+export const ESCAPE = 27;
+export const SPACE = 32;
+export const PAGE_UP = 33;
+export const PAGE_DOWN = 34;
+export const ARROW_LEFT = 37;
+export const ARROW_UP = 38;
+export const ARROW_RIGHT = 39;
+export const ARROW_DOWN = 40;
+export const TAB = 9;


### PR DESCRIPTION
With the last version of `VtmnListItem` we have found some issues with accessibility.

This PR fixed all issue due to keypress / click / stop propagation on children.
For example : 
- `<li>` click action are not possible with keyboard, only mouse.

No breaking changes, just changes on the role by default for `VtmnListItem`