### PR TITLE
feat(@vtmn/css): update price to allow no-padding

### DIFF
--- a/packages/showcases/core/csf/components/indicators/price.csf.js
+++ b/packages/showcases/core/csf/components/indicators/price.csf.js
@@ -27,4 +27,10 @@ export const argTypes = {
       options: ['xsmall', 'small', 'medium', 'large'],
     },
   },
+  padding: {
+    type: { name: 'boolean', required: false },
+    description: 'Add padding to the price.',
+    defaultValue: true,
+    control: { type: 'boolean' },
+  },
 };

--- a/packages/showcases/core/csf/components/indicators/price.csf.js
+++ b/packages/showcases/core/csf/components/indicators/price.csf.js
@@ -27,10 +27,10 @@ export const argTypes = {
       options: ['xsmall', 'small', 'medium', 'large'],
     },
   },
-  padding: {
+  noPadding: {
     type: { name: 'boolean', required: false },
-    description: 'Add padding to the price.',
-    defaultValue: true,
+    description: 'Remove padding to the price.',
+    defaultValue: false,
     control: { type: 'boolean' },
   },
 };

--- a/packages/sources/css/src/components/indicators/price/src/index.css
+++ b/packages/sources/css/src/components/indicators/price/src/index.css
@@ -9,11 +9,8 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  min-block-size: rem(28px);
   line-height: 1;
-  block-size: rem(28px);
   inline-size: fit-content;
-  padding-block: rem(2px);
   font-family: var(--vtmn-typo_font-family);
   font-size: var(--vtmn-typo_text-2-font-size);
   font-weight: var(--vtmn-typo_font-weight--bold);
@@ -33,12 +30,14 @@
   background-color: var(--vtmn-semantic-color_background-accent);
   color: var(--vtmn-semantic-color_content-accent);
   padding-inline: var(--vtmn-spacing_2);
+  padding-block: rem(2px);
 }
 
 .vtmn-price_variant--alert {
   background-color: var(--vtmn-semantic-color_background-alert);
   color: var(--vtmn-semantic-color_content-primary-reversed);
   padding-inline: var(--vtmn-spacing_2);
+  padding-block: rem(2px);
 }
 
 .vtmn-price_variant--strikethrough {
@@ -50,29 +49,45 @@
 /* SIZES */
 
 /* XSmall */
-.vtmn-price_size--xsmall {
+.vtmn-price_variant--accent.vtmn-price_size--xsmall,
+.vtmn-price_variant--alert.vtmn-price_size--xsmall {
   min-block-size: rem(20px);
   block-size: rem(20px);
+}
+
+.vtmn-price_size--xsmall {
   font-size: var(--vtmn-typo_caption-1-font-size);
 }
 
 /* Small */
-.vtmn-price_size--small {
+.vtmn-price_variant--accent.vtmn-price_size--small,
+.vtmn-price_variant--alert.vtmn-price_size--small {
   min-block-size: rem(24px);
   block-size: rem(24px);
+}
+
+.vtmn-price_size--small {
   font-size: var(--vtmn-typo_text-3-font-size);
 }
 
 /* Medium */
-.vtmn-price_size--medium {
+.vtmn-price_variant--accent.vtmn-price_size--medium,
+.vtmn-price_variant--alert.vtmn-price_size--medium {
   min-block-size: rem(28px);
   block-size: rem(28px);
+}
+
+.vtmn-price_size--medium {
   font-size: var(--vtmn-typo_text-2-font-size);
 }
 
 /* Large */
-.vtmn-price_size--large {
+.vtmn-price_variant--accent.vtmn-price_size--large,
+.vtmn-price_variant--alert.vtmn-price_size--large {
   min-block-size: rem(32px);
   block-size: rem(32px);
+}
+
+.vtmn-price_size--large {
   font-size: var(--vtmn-typo_text-1-font-size);
 }

--- a/packages/sources/css/src/components/indicators/price/src/index.css
+++ b/packages/sources/css/src/components/indicators/price/src/index.css
@@ -76,7 +76,7 @@
   font-size: var(--vtmn-typo_text-1-font-size);
 }
 
-/* PADDING */
+/* NO-PADDING */
 
 .vtmn-price--no-padding {
   min-block-size: 0;

--- a/packages/sources/css/src/components/indicators/price/src/index.css
+++ b/packages/sources/css/src/components/indicators/price/src/index.css
@@ -9,8 +9,12 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  min-block-size: rem(28px);
   line-height: 1;
+  block-size: rem(28px);
   inline-size: fit-content;
+  padding-block: rem(2px);
+  padding-inline: var(--vtmn-spacing_2);
   font-family: var(--vtmn-typo_font-family);
   font-size: var(--vtmn-typo_text-2-font-size);
   font-weight: var(--vtmn-typo_font-weight--bold);
@@ -29,15 +33,11 @@
 .vtmn-price_variant--accent {
   background-color: var(--vtmn-semantic-color_background-accent);
   color: var(--vtmn-semantic-color_content-accent);
-  padding-inline: var(--vtmn-spacing_2);
-  padding-block: rem(2px);
 }
 
 .vtmn-price_variant--alert {
   background-color: var(--vtmn-semantic-color_background-alert);
   color: var(--vtmn-semantic-color_content-primary-reversed);
-  padding-inline: var(--vtmn-spacing_2);
-  padding-block: rem(2px);
 }
 
 .vtmn-price_variant--strikethrough {
@@ -49,45 +49,37 @@
 /* SIZES */
 
 /* XSmall */
-.vtmn-price_variant--accent.vtmn-price_size--xsmall,
-.vtmn-price_variant--alert.vtmn-price_size--xsmall {
+.vtmn-price_size--xsmall {
   min-block-size: rem(20px);
   block-size: rem(20px);
-}
-
-.vtmn-price_size--xsmall {
   font-size: var(--vtmn-typo_caption-1-font-size);
 }
 
 /* Small */
-.vtmn-price_variant--accent.vtmn-price_size--small,
-.vtmn-price_variant--alert.vtmn-price_size--small {
+.vtmn-price_size--small {
   min-block-size: rem(24px);
   block-size: rem(24px);
-}
-
-.vtmn-price_size--small {
   font-size: var(--vtmn-typo_text-3-font-size);
 }
 
 /* Medium */
-.vtmn-price_variant--accent.vtmn-price_size--medium,
-.vtmn-price_variant--alert.vtmn-price_size--medium {
+.vtmn-price_size--medium {
   min-block-size: rem(28px);
   block-size: rem(28px);
-}
-
-.vtmn-price_size--medium {
   font-size: var(--vtmn-typo_text-2-font-size);
 }
 
 /* Large */
-.vtmn-price_variant--accent.vtmn-price_size--large,
-.vtmn-price_variant--alert.vtmn-price_size--large {
+.vtmn-price_size--large {
   min-block-size: rem(32px);
   block-size: rem(32px);
+  font-size: var(--vtmn-typo_text-1-font-size);
 }
 
-.vtmn-price_size--large {
-  font-size: var(--vtmn-typo_text-1-font-size);
+/* PADDING */
+
+.vtmn-price--no-padding {
+  min-block-size: 0;
+  block-size: auto;
+  padding: 0;
 }

--- a/packages/sources/react/src/components/indicators/VtmnPrice/VtmnPrice.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnPrice/VtmnPrice.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-price/dist/index-with-vars.css';
 import { VtmnPriceVariant, VtmnPriceSize } from './types';
+import clsx from 'clsx';
 
 export interface VtmnPriceProps extends React.ComponentPropsWithoutRef<'span'> {
   /**
@@ -16,6 +17,12 @@ export interface VtmnPriceProps extends React.ComponentPropsWithoutRef<'span'> {
   size?: VtmnPriceSize;
 
   /**
+   * No padding on the price.
+   * @defaultValue false
+   */
+  noPadding?: boolean;
+
+  /**
    * The content to render inside the component.
    * @defaultValue undefined
    */
@@ -24,15 +31,24 @@ export interface VtmnPriceProps extends React.ComponentPropsWithoutRef<'span'> {
 
 export const VtmnPrice = React.forwardRef<HTMLButtonElement, VtmnPriceProps>(
   (
-    { variant = 'default', size = 'medium', children, className, ...props },
+    {
+      variant = 'default',
+      size = 'medium',
+      noPadding = false,
+      children,
+      className,
+      ...props
+    },
     ref,
   ) => {
     return (
       <span
         ref={ref}
-        className={`vtmn-price vtmn-price_variant--${variant} vtmn-price_size--${size} ${
-          className ? className : ''
-        }`}
+        className={clsx(
+          `vtmn-price vtmn-price_variant--${variant} vtmn-price_size--${size}`,
+          noPadding && 'vtmn-price--no-padding',
+          className ? className : '',
+        )}
         {...props}
       >
         {children}

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -17,11 +17,11 @@
   export let variant = VTMN_PRICE_VARIANT.DEFAULT;
 
   /**
-   * Padding on the price
+   * No padding on the price
    * @type boolean
-   * @defaultValue true
+   * @defaultValue false
    */
-  export let padding = true;
+  export let noPadding = false;
 
   let className = undefined;
   /**
@@ -33,7 +33,7 @@
     'vtmn-price',
     size && `vtmn-price_size--${size}`,
     variant && `vtmn-price_variant--${variant}`,
-    !padding && 'vtmn-price--no-padding',
+    noPadding && 'vtmn-price--no-padding',
     className,
   );
 </script>

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/VtmnPrice.svelte
@@ -16,6 +16,13 @@
    */
   export let variant = VTMN_PRICE_VARIANT.DEFAULT;
 
+  /**
+   * Padding on the price
+   * @type boolean
+   * @defaultValue true
+   */
+  export let padding = true;
+
   let className = undefined;
   /**
    * @type {string} Custom classes to apply to the component.
@@ -26,6 +33,7 @@
     'vtmn-price',
     size && `vtmn-price_size--${size}`,
     variant && `vtmn-price_variant--${variant}`,
+    !padding && 'vtmn-price--no-padding',
     className,
   );
 </script>

--- a/packages/sources/svelte/src/components/indicators/VtmnPrice/test/VtmnPrice.spec.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnPrice/test/VtmnPrice.spec.js
@@ -31,6 +31,11 @@ describe('VtmnPrice', () => {
     );
     expect(getPrice(container)).toBeVisible();
   });
+  test('Should apply no padding parameter', () => {
+    const { container } = render(VtmnPrice, { noPadding: true });
+    expect(getPrice(container)).toHaveClass('vtmn-price--no-padding');
+    expect(getPrice(container)).toBeVisible();
+  });
   test('Should apply custom class on component', () => {
     const { container } = render(VtmnPrice, { class: 'custom-class' });
     expect(getPrice(container)).toHaveClass('custom-class');

--- a/packages/sources/vue/src/components/indicators/VtmnPrice/VtmnPrice.vue
+++ b/packages/sources/vue/src/components/indicators/VtmnPrice/VtmnPrice.vue
@@ -19,6 +19,10 @@ export default /*#__PURE__*/ defineComponent({
       validator: (val: VtmnPriceSize) =>
         ['xsmall', 'small', 'medium', 'large'].includes(val),
     },
+    noPadding: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
   },
   setup(props) {
     props = reactive(props);
@@ -31,6 +35,7 @@ export default /*#__PURE__*/ defineComponent({
         'vtmn-price': true,
         [`vtmn-price_variant--${props.variant}`]: props.variant,
         [`vtmn-price_size--${props.size}`]: true,
+        'vtmn-price--no-padding': props.noPadding,
       })),
     };
   },


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

## Context
Issue here https://github.com/Decathlon/vitamin-design/issues/167

This PR is for completed this one : https://github.com/Decathlon/vitamin-web/pull/1341

To avoid some breaking changes, we've decided to create a new props called "noPadding" to remove the padding of the Price component.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
