### PR TITLE
feat: use clsx library for className props

### DIFF
--- a/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@vtmn/css-tooltip/dist/index-with-vars.css';
 import { VtmnTooltipPosition } from './types';
+import clsx from 'clsx';
 
 export interface VtmnTooltipProps
   extends React.ComponentPropsWithoutRef<'span'> {
@@ -35,7 +36,7 @@ export const VtmnTooltip = ({
       <span
         tabIndex={0}
         role="tooltip"
-        className={`vtmn-tooltip ${className ?? className}`}
+        className={clsx('vtmn-tooltip', className)}
         data-tooltip={tooltip}
         data-position={position}
         {...props}


### PR DESCRIPTION
## Changes description
Use clsx instead of null operator because it was returning undefined. 
As you can see in the followinf snapshot
<img width="352" alt="image" src="https://user-images.githubusercontent.com/90247150/214342433-2b985426-fb67-449e-a404-1308bc3e5749.png">

## Context
It brings more clarity in html. We could see sometime undefined and bring questioning.

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
- No

## Other information
