### PR TITLE
feat: add "without-image" variant on `VtmnCard` component with top actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "typescript": "^4.5.4"
   },
   "engines": {
-    "node": "^14 || ^15 || ^16",
+    "node": "^14 || ^15 || ^16 || ^18",
     "npm": "please-use-yarn",
     "yarn": ">= 1.19.1"
   },

--- a/packages/showcases/core/csf/components/structure/card.csf.js
+++ b/packages/showcases/core/csf/components/structure/card.csf.js
@@ -15,7 +15,7 @@ export const argTypes = {
     defaultValue: 'top-image',
     control: {
       type: 'select',
-      options: ['top-image', 'side-image', 'full-image'],
+      options: ['top-image', 'side-image', 'full-image', 'without-image'],
     },
   },
   fullImage: {

--- a/packages/showcases/react/stories/components/structure/VtmnCard/VtmnCard.stories.tsx
+++ b/packages/showcases/react/stories/components/structure/VtmnCard/VtmnCard.stories.tsx
@@ -19,6 +19,14 @@ export default {
         type: 'text',
       },
     },
+    topActions: {
+      type: { name: 'string', required: false },
+      description: 'The actions to render on the top of the component.',
+      defaultValue: 'Label',
+      control: {
+        type: 'text',
+      },
+    },
   },
   parameters,
 } as Meta;

--- a/packages/sources/css/src/components/structure/card/src/index.css
+++ b/packages/sources/css/src/components/structure/card/src/index.css
@@ -16,6 +16,19 @@
   position: relative;
 }
 
+.vtmn-card_top-action {
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+  margin-right: 16px;
+  margin-left: 16px;
+}
+
+.vtmn-card_top-action--body {
+  align-items: flex-end;
+  margin-left: auto;
+}
+
 .vtmn-card_content {
   margin: var(--vtmn-spacing_4);
   display: flex;

--- a/packages/sources/react/src/components/structure/VtmnCard/VtmnCard.tsx
+++ b/packages/sources/react/src/components/structure/VtmnCard/VtmnCard.tsx
@@ -45,6 +45,11 @@ export interface VtmnCardProps extends React.ComponentPropsWithoutRef<'div'> {
    * @defaultValue undefined
    */
   children?: React.ReactNode;
+  /**
+   * The content to render top right the component.
+   * @defaultValue undefined
+   */
+  topActions?: React.ReactNode;
 }
 
 export const VtmnCard = ({
@@ -56,6 +61,7 @@ export const VtmnCard = ({
   headingLevel = 2,
   children,
   className,
+  topActions,
 }: VtmnCardProps) => {
   const Heading =
     headingLevel >= 0 && headingLevel <= 6
@@ -63,21 +69,23 @@ export const VtmnCard = ({
       : 'h2';
 
   return (
-    <div className="vtmn-card-container">
-      <div
-        className={clsx(
-          'vtmn-card',
-          `vtmn-card_variant--${variant}`,
-          className,
+    <div className="vtmn-card">
+      {(variant == 'side-image' || variant == 'without-image') &&
+        topActions && (
+          <div className={clsx('vtmn-card_top-action')}>
+            <span className="vtmn-card_top-action--body">{topActions}</span>
+          </div>
         )}
-      >
-        <div
-          className={clsx('vtmn-card_image', {
-            'vtmn-card_image--full': fullImage && variant === 'top-image',
-          })}
-        >
-          {img && img}
-        </div>
+      <div className={clsx(`vtmn-card_variant--${variant}`, className)}>
+        {variant != 'without-image' && (
+          <div
+            className={clsx('vtmn-card_image', {
+              'vtmn-card_image--full': fullImage && variant === 'top-image',
+            })}
+          >
+            {img && img}
+          </div>
+        )}
         <div
           className={clsx('vtmn-card_content', {
             'vtmn-card_content--opaque':

--- a/packages/sources/react/src/components/structure/VtmnCard/types.ts
+++ b/packages/sources/react/src/components/structure/VtmnCard/types.ts
@@ -1,1 +1,5 @@
-export type VtmnCardVariant = 'top-image' | 'side-image' | 'full-image';
+export type VtmnCardVariant =
+  | 'top-image'
+  | 'side-image'
+  | 'full-image'
+  | 'without-image';


### PR DESCRIPTION
## Changes description
Introduction of the class 'without-image' to remove the rendering of the image
Introduction of the 'topActions' prop and component
Implementation of two CSS classes for 'topActions'
Update of Storybook by adding the 'topActions' component inside.
Update of engine restriction version to be compatible with 18

## Context
In Singapore we are using a custom component that introduce the topActions for the card 
<img width="1104" alt="CleanShot 2023-01-29 at 14 41 48@2x" src="https://user-images.githubusercontent.com/61679337/215309749-5e4076a2-ed0a-4b98-aa10-93a384e47a08.png">
## Does this introduce a breaking change?
- No
