### PR TITLE
refactor(@vtmn/assets): delete sprite consumption mode

### DIFF
--- a/packages/sources/assets/README.md
+++ b/packages/sources/assets/README.md
@@ -25,7 +25,6 @@ Or you can also install it with a CDN like `unpkg.com`. You can browse content [
 Once you have installed this package, depending on your setup, you can include `@vtmn/assets` in a handful of ways.
 
 - Reference via `<img>` element
-- Use the SVG sprite
 - Include via CSS
 - Copy-paste SVGs as embedded HTML
 
@@ -43,18 +42,6 @@ Reference assets SVGs like normal images with the `<img>` element.
   width="32"
   height="32"
 />
-```
-
-### Sprite
-
-Use the SVG sprite to insert any icon through the `<use>` element. Use the icon’s filename as the fragment identifier (e.g., `home-fill` is `#home-fill`). SVG sprites allow you to reference an external file similar to an `<img>` element.
-
-```html
-<svg width="32" height="32" fill="#001018">
-  <use
-    xlink:href="/node_modules/@vtmn/assets/dist/vitamix/sprite/vitamix.svg#home-fill"
-  />
-</svg>
 ```
 
 ### CSS

--- a/packages/sources/assets/package.json
+++ b/packages/sources/assets/package.json
@@ -23,9 +23,8 @@
   ],
   "scripts": {
     "prebuild": "shx rm -rf dist",
-    "build": "yarn build:svg && yarn build:json && yarn build:sprite",
+    "build": "yarn build:svg && yarn build:json",
     "build:json": "shx rm -rf ./dist/assets/json && shx mkdir ./dist/assets/json && fantasticon",
-    "build:sprite": "shx rm -rf ./dist/assets/sprite && shx mkdir ./dist/assets/sprite && spritesh -i dist/assets/svg -o dist/assets/sprite/assets.svg && node src/scripts/add-sprite-declaration.js",
     "build:svg": "node src/scripts/build-svg.js && svgo -f dist/assets/svg"
   },
   "devDependencies": {
@@ -33,7 +32,6 @@
     "fantasticon": "^1.2.3",
     "fs-extra": "^10.0.0",
     "shx": "^0.3.4",
-    "spritesh": "^1.2.1",
     "svgo": "^2.7.0"
   },
   "publishConfig": {

--- a/packages/sources/assets/sprite.svg
+++ b/packages/sources/assets/sprite.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/packages/sources/assets/src/scripts/add-sprite-declaration.js
+++ b/packages/sources/assets/src/scripts/add-sprite-declaration.js
@@ -1,6 +1,0 @@
-const fs = require('fs');
-
-fs.writeFileSync(
-  `${process.cwd()}/dist/assets/sprite/assets.svg.d.ts`,
-  'export default SVGElement;',
-);


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in detail. -->

Hello everyone,

We just spent a few hours with the designers of the core team Design System to understand the problem of using sprite with our Vitamin assets (flags, payments, etc.).
In order to resolve it, we need to check all our different flags to remove masks & clip paths manually, and unfortunately, this is huge work & time-consuming which in regard to our team and the different priorities that we have, does not allow us to solve this soon.

That's why we took the decision to postpone the refactoring of all our flags in our next major release in design (@Decathlon/design-system-core-team-design), and so, we decided to no longer support the "sprite" consumption mode for `@vtmn/assets`.

So this PR can close #1313.

Thanks for your understanding.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names match our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No