### PR TITLE
build(@vtmn/react): remove sourcemap and improve treeshaking

### DIFF
--- a/packages/sources/react/package.json
+++ b/packages/sources/react/package.json
@@ -19,9 +19,10 @@
   },
   "sideEffects": false,
   "license": "Apache-2.0",
-  "main": "dist/index.js",
-  "module": "dist/index.es.js",
-  "jsnext:main": "dist/index.es.js",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "jsnext:main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
     "dist"

--- a/packages/sources/react/package.json
+++ b/packages/sources/react/package.json
@@ -17,7 +17,6 @@
     "type": "git",
     "url": "git+https://github.com/Decathlon/vitamin-web.git"
   },
-  "sideEffects": false,
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/sources/react/rollup.config.js
+++ b/packages/sources/react/rollup.config.js
@@ -5,24 +5,22 @@ import url from '@rollup/plugin-url';
 import svgr from '@svgr/rollup';
 import external from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
-import pkg from './package.json';
 
-const TARGETS = [
-  { format: 'cjs', dir: './dist', tsconfig: './tsconfig.cjs.json' },
-  { format: 'es', file: pkg.module, tsconfig: './tsconfig.es.json' },
-];
+const formatOutput = (format) => ({
+  format,
+  exports: 'named',
+  sourcemap: false,
+  dir: 'dist',
+  preserveModules: true,
+  preserveModulesRoot: 'src',
+  entryFileNames: `[name].${format === 'es' ? 'js' : 'cjs'}`,
+});
 
-export default TARGETS.map((target) => ({
+export default {
   input: 'src/index.ts',
-  output: {
-    file: target.file,
-    format: target.format,
-    exports: 'named',
-    sourcemap: true,
-    dir: target.dir,
-  },
+  output: [formatOutput('es'), formatOutput('cjs')],
   plugins: [
-    typescript({ tsconfig: target.tsconfig }),
+    typescript(),
     external(),
     resolve(),
     url({ exclude: ['**/*.svg'] }),
@@ -32,4 +30,4 @@ export default TARGETS.map((target) => ({
     }),
     commonjs(),
   ],
-}));
+};

--- a/packages/sources/react/tsconfig.cjs.json
+++ b/packages/sources/react/tsconfig.cjs.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "declarationDir": "./dist"
-  }
-}

--- a/packages/sources/react/tsconfig.es.json
+++ b/packages/sources/react/tsconfig.es.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "declaration": false
-  }
-}

--- a/packages/sources/react/tsconfig.json
+++ b/packages/sources/react/tsconfig.json
@@ -6,7 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "rootDir": ".",
     "declaration": true,
-    "sourceMap": true,
+    "declarationDir": "dist",
     "allowJs": false,
     "jsx": "react-jsx",
     "moduleResolution": "node",
@@ -24,10 +24,10 @@
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "outDir": "dist"
   },
   "include": ["*.js", "src/**/*.ts", "src/**/*.tsx", "scripts/**/*.js"],
   "exclude": [

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -18,7 +18,6 @@
     "url": "git+https://github.com/Decathlon/vitamin-web.git"
   },
   "license": "Apache-2.0",
-  "sideEffects": false,
   "files": [
     "src",
     "dist"

--- a/packages/sources/vue/package.json
+++ b/packages/sources/vue/package.json
@@ -21,7 +21,6 @@
   "main": "dist/vtmn/vue.cjs.js",
   "module": "dist/vtmn/vue.es.js",
   "types": "dist/index.d.ts",
-  "sideEffects": false,
   "files": [
     "dist",
     "dist/*.d.ts"


### PR DESCRIPTION
Signed-off-by: Shyrro <zakaria.sahmane@decathlon.com>

## Changes description

Removes sourcemap to solve this issue : https://github.com/Decathlon/vitamin-web/issues/1322

Since sourcemaps are mainly for debug purposes, we're also splitting the files to improve treeshake and thus improve debugging capabilities.

## Context
It solves two problems : 

- Sourcemaps warnings 
- Improves bundle size ( the fact that sourcemaps are gone makes the package around 200kb lighter, and the fact that it is now treeshakable also makes consumer apps lighter )


## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?

- No
