### PR TITLE
chore(bot): configure stale bot to ignore label "next"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,5 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-# Limit to only `issues` or `pulls`
-only: pulls
-
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 daysUntilStale: 30
 
@@ -12,7 +9,7 @@ daysUntilClose: 7
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
-  - next ⛳
+  - "next ⛳"
   
 # Label to use when marking an issue as stale
 staleLabel: wontfix 🚫

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,8 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
+# Limit to only `issues` or `pulls`
+only: pulls
+
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 daysUntilStale: 30
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Only configure stale bot for Pull Requests.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
