### PR TITLE
feat: make extensible `Quantity` component

### DIFF
--- a/packages/showcases/core/csf/components/selection-controls/quantity.csf.js
+++ b/packages/showcases/core/csf/components/selection-controls/quantity.csf.js
@@ -49,6 +49,14 @@ export const argTypes = {
       type: 'boolean',
     },
   },
+  fullWidth: {
+    type: { name: 'boolean', required: false },
+    description: `Displays the quantity at 100% of its parent's width`,
+    defaultValue: false,
+    control: {
+      type: 'boolean',
+    },
+  },
   min: {
     type: { name: 'number', required: false },
     description: 'Minimum value of the input',

--- a/packages/showcases/css/stories/components/selection-controls/quantity/examples/overview.html
+++ b/packages/showcases/css/stories/components/selection-controls/quantity/examples/overview.html
@@ -27,13 +27,10 @@
 </div>
 
 <div class="block">
-  <div class="vtmn-quantity">
-    <label for="my-quantity-2">Label</label>
+  <div class="vtmn-quantity vtmn-quantity--full-width">
+    <label for="my-quantity-2">Label (full width)</label>
     <div class="vtmn-quantity_content">
-      <button
-        class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone"
-        disabled
-      >
+      <button class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone">
         <span class="vtmn-sr-only">
           substract one quantity of this article
         </span>
@@ -49,8 +46,8 @@
 </div>
 
 <div class="block">
-  <div class="vtmn-quantity" aria-disabled="true">
-    <label for="my-quantity-3" aria-disabled="true">Label</label>
+  <div class="vtmn-quantity">
+    <label for="my-quantity-3">Label</label>
     <div class="vtmn-quantity_content">
       <button
         class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone"
@@ -61,7 +58,29 @@
         </span>
         <span class="vtmx-subtract-line" aria-hidden="true"></span>
       </button>
-      <input type="number" id="my-quantity-3" disabled />
+      <input type="number" id="my-quantity-3" />
+      <button class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone">
+        <span class="vtmn-sr-only"> add one quantity of this article </span>
+        <span class="vtmx-add-line" aria-hidden="true"></span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="block">
+  <div class="vtmn-quantity" aria-disabled="true">
+    <label for="my-quantity-4" aria-disabled="true">Label</label>
+    <div class="vtmn-quantity_content">
+      <button
+        class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone"
+        disabled
+      >
+        <span class="vtmn-sr-only">
+          substract one quantity of this article
+        </span>
+        <span class="vtmx-subtract-line" aria-hidden="true"></span>
+      </button>
+      <input type="number" id="my-quantity-4" disabled />
       <button
         class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone"
         disabled
@@ -75,7 +94,7 @@
 
 <div class="block">
   <div class="vtmn-quantity">
-    <label for="my-quantity-4">Label</label>
+    <label for="my-quantity-5">Label</label>
     <div class="vtmn-quantity_content">
       <button class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone">
         <span class="vtmn-sr-only">
@@ -85,7 +104,7 @@
       </button>
       <input
         type="number"
-        id="my-quantity-4"
+        id="my-quantity-5"
         value="-2"
         min="0"
         aria-describedby="quantity-helper-1"
@@ -114,7 +133,7 @@
   <div class="accessibility-highlight_container">
     <div class="accessibility-highlight_container_component">
       <div class="vtmn-quantity">
-        <label for="my-quantity-4">Label</label>
+        <label for="my-quantity-6">Label</label>
         <div class="vtmn-quantity_content">
           <button
             class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone"
@@ -124,7 +143,7 @@
             </span>
             <span class="vtmx-subtract-line" aria-hidden="true"></span>
           </button>
-          <input type="number" id="my-quantity-4" />
+          <input type="number" id="my-quantity-6" />
           <button
             class="vtmn-btn vtmn-btn_variant--secondary vtmn-btn--icon-alone"
           >

--- a/packages/sources/css/src/components/selection-controls/quantity/src/index.css
+++ b/packages/sources/css/src/components/selection-controls/quantity/src/index.css
@@ -15,6 +15,10 @@
   inline-size: fit-content;
 }
 
+.vtmn-quantity.vtmn-quantity--full-width {
+  inline-size: 100%;
+}
+
 .vtmn-quantity > label {
   font-size: var(--vtmn-typo_text-2-font-size);
   line-height: var(--vtmn-typo_text-2-line-height);
@@ -44,6 +48,10 @@
   appearance: textfield;
   transition: var(--vtmn-transition_focus-visible);
   border-radius: 0;
+}
+
+.vtmn-quantity.vtmn-quantity--full-width input[type='number'] {
+  inline-size: 100%;
 }
 
 .vtmn-quantity input[type='number']::placeholder {

--- a/packages/sources/react/src/components/selection-controls/VtmnQuantity/VtmnQuantity.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnQuantity/VtmnQuantity.tsx
@@ -40,6 +40,13 @@ export interface VtmnQuantityProps
   disabled?: boolean;
 
   /**
+   * Displays the quantity at 100% of its parent's width
+   * @type {boolean}
+   * @defaultValue false
+   */
+  fullWidth?: boolean;
+
+  /**
    * The minimum value of the quantity.
    * @type {number}
    * @defaultValue 0
@@ -79,6 +86,7 @@ export const VtmnQuantity = React.forwardRef<
       step = 1,
       label = undefined,
       disabled = false,
+      fullWidth = false,
       min = 0,
       max = Infinity,
       error = undefined,
@@ -91,7 +99,14 @@ export const VtmnQuantity = React.forwardRef<
     const [quantity, setQuantity] = React.useState(value);
 
     return (
-      <div className={clsx('vtmn-quantity', className)} {...props}>
+      <div
+        className={clsx(
+          'vtmn-quantity',
+          { 'vtmn-quantity--full-width': fullWidth },
+          className,
+        )}
+        {...props}
+      >
         {label && <label htmlFor={id}>{label}</label>}
 
         <div className="vtmn-quantity_content">

--- a/packages/sources/svelte/src/components/selection-controls/VtmnQuantity/VtmnQuantity.svelte
+++ b/packages/sources/svelte/src/components/selection-controls/VtmnQuantity/VtmnQuantity.svelte
@@ -24,6 +24,11 @@
   export let disabled = false;
 
   /**
+   * @type {boolean} displays the quantity at 100% of its parent's width
+   */
+  export let fullWidth = false;
+
+  /**
    * @type {string} error text displayed under the input
    */
   export let error = undefined;
@@ -68,7 +73,11 @@
     disabledMax = value >= max;
   }
 
-  $: componentClass = cn('vtmn-quantity', className);
+  $: componentClass = cn(
+    'vtmn-quantity',
+    fullWidth && 'vtmn-quantity--full-width',
+    className,
+  );
 </script>
 
 <div class={componentClass}>

--- a/packages/sources/vue/src/components/selection-controls/VtmnQuantity/VtmnQuantity.vue
+++ b/packages/sources/vue/src/components/selection-controls/VtmnQuantity/VtmnQuantity.vue
@@ -23,6 +23,10 @@ export default /*#__PURE__*/ defineComponent({
       type: Boolean as PropType<boolean>,
       default: false,
     },
+    fullWidth: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
     min: {
       type: Number as PropType<number>,
       default: -Infinity,
@@ -63,6 +67,7 @@ export default /*#__PURE__*/ defineComponent({
     return {
       classes: computed(() => ({
         'vtmn-quantity': true,
+        'vtmn-quantity--full-width': props.fullWidth,
       })),
       handleChange,
       handleSubstract,


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Closes #1356 

As we need to make it extensible without making breaking changes, I propose to add a new prop called `fullWidth` (boolean by default === 'false').

<img width="444" alt="CleanShot 2023-02-08 at 21 40 39@2x" src="https://user-images.githubusercontent.com/9600228/217651940-64d0047e-b075-4b5d-9e0c-5bbc2c4b742c.png">
<img width="984" alt="CleanShot 2023-02-08 at 21 52 08@2x" src="https://user-images.githubusercontent.com/9600228/217651944-d23bfec9-1d95-4400-9379-ffa8dc298e34.png">
<img width="891" alt="CleanShot 2023-02-08 at 22 10 00@2x" src="https://user-images.githubusercontent.com/9600228/217651950-b80cf46a-268e-4669-a6e9-97881d0919bc.png">
<img width="986" alt="CleanShot 2023-02-08 at 21 52 27@2x" src="https://user-images.githubusercontent.com/9600228/217651949-9fc15675-2dfa-49ff-8f60-1deaffb1be24.png">

For your information, in Figma, there's no prop (variant) because the behavior is like this: 
![CleanShot 2023-02-08 at 22 14 34](https://user-images.githubusercontent.com/9600228/217652381-ac76ab90-3fd5-4f7f-b96c-a901e2e25932.gif). That was I think the best thing to reproduce this behavior is to set a full width based on the quantity's parent.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
