### PR TITLE
chore: support treeshaking

### DIFF
--- a/packages/sources/react/package.json
+++ b/packages/sources/react/package.json
@@ -17,8 +17,12 @@
     "type": "git",
     "url": "git+https://github.com/Decathlon/vitamin-web.git"
   },
-  "license": "Apache-2.0",
+  "sideEffects": [
+    "dist/packages/**/*.js",
+    "dist/node_modules/**/*.js"
+  ],
   "type": "module",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "jsnext:main": "dist/index.js",
@@ -41,7 +45,7 @@
     "@babel/plugin-syntax-flow": "^7.17.12",
     "@babel/plugin-transform-react-jsx": "^7.17.12",
     "@rollup/plugin-commonjs": "^23.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^9.0.0",
     "@rollup/plugin-url": "^8.0.0",
     "@svgr/rollup": "^6.2.1",

--- a/packages/sources/react/src/components/actions/VtmnButton/VtmnButton.tsx
+++ b/packages/sources/react/src/components/actions/VtmnButton/VtmnButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-button/dist/index-with-vars.css';
+import '@vtmn/css-button';
 import { VtmnButtonVariant, VtmnButtonSize } from './types';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';

--- a/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
+++ b/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-dropdown/dist/index-with-vars.css';
+import '@vtmn/css-dropdown';
 
 export interface VtmnDropdownProps
   extends React.ComponentPropsWithoutRef<'div'> {

--- a/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdownItem.tsx
+++ b/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdownItem.tsx
@@ -1,4 +1,4 @@
-import '@vtmn/css-dropdown/dist/index-with-vars.css';
+import '@vtmn/css-dropdown';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import * as React from 'react';
 import { VtmnDivider } from '../../structure/VtmnDivider/VtmnDivider';

--- a/packages/sources/react/src/components/actions/VtmnLink/VtmnLink.tsx
+++ b/packages/sources/react/src/components/actions/VtmnLink/VtmnLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-link/dist/index-with-vars.css';
+import '@vtmn/css-link';
 import clsx from 'clsx';
 import { VtmnLinkSize } from './types';
 

--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -1,4 +1,4 @@
-import '@vtmn/css-select/dist/index-with-vars.css';
+import '@vtmn/css-select';
 import clsx from 'clsx';
 import React from 'react';
 

--- a/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-text-input/dist/index-with-vars.css';
+import '@vtmn/css-text-input';
 import clsx from 'clsx';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';

--- a/packages/sources/react/src/components/indicators/VtmnBadge/VtmnBadge.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnBadge/VtmnBadge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-badge/dist/index-with-vars.css';
+import '@vtmn/css-badge';
 import { VtmnBadgeVariant } from './types';
 
 export interface VtmnBadgeProps extends React.ComponentPropsWithoutRef<'span'> {

--- a/packages/sources/react/src/components/indicators/VtmnLoader/VtmnLoader.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnLoader/VtmnLoader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-loader/dist/index-with-vars.css';
+import '@vtmn/css-loader';
 import { VtmnLoaderSize } from './types';
 
 export interface VtmnLoaderProps extends React.ComponentPropsWithoutRef<'div'> {

--- a/packages/sources/react/src/components/indicators/VtmnPrice/VtmnPrice.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnPrice/VtmnPrice.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-price/dist/index-with-vars.css';
+import '@vtmn/css-price';
 import { VtmnPriceVariant, VtmnPriceSize } from './types';
 import clsx from 'clsx';
 

--- a/packages/sources/react/src/components/indicators/VtmnProgressbar/VtmnProgressbar.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnProgressbar/VtmnProgressbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-progressbar/dist/index-with-vars.css';
+import '@vtmn/css-progressbar';
 import clsx from 'clsx';
 import {
   VtmnProgressbarVariant,

--- a/packages/sources/react/src/components/indicators/VtmnRating/VtmnRating.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnRating/VtmnRating.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import '@vtmn/css-rating/dist/index-with-vars.css';
+import '@vtmn/css-rating';
 import * as React from 'react';
 import { VtmnRatingSize } from './types';
 

--- a/packages/sources/react/src/components/indicators/VtmnTag/VtmnTag.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnTag/VtmnTag.tsx
@@ -1,4 +1,4 @@
-import '@vtmn/css-tag/dist/index-with-vars.css';
+import '@vtmn/css-tag';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import * as React from 'react';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';

--- a/packages/sources/react/src/components/navigation/VtmnBreadcrumb/VtmnBreadcrumb.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnBreadcrumb/VtmnBreadcrumb.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-breadcrumb/dist/index-with-vars.css';
+import '@vtmn/css-breadcrumb';
 import clsx from 'clsx';
 
 export interface VtmnBreadcrumbProps

--- a/packages/sources/react/src/components/navigation/VtmnBreadcrumb/VtmnBreadcrumbItem.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnBreadcrumb/VtmnBreadcrumbItem.tsx
@@ -1,4 +1,4 @@
-import '@vtmn/css-breadcrumb/dist/index-with-vars.css';
+import '@vtmn/css-breadcrumb';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import * as React from 'react';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';

--- a/packages/sources/react/src/components/navigation/VtmnNavbar/VtmnNavbar.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnNavbar/VtmnNavbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-navbar/dist/index-with-vars.css';
+import '@vtmn/css-navbar';
 
 export interface VtmnNavbarProps extends React.ComponentPropsWithoutRef<'nav'> {
   /**

--- a/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnSearch/VtmnSearch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-search/dist/index-with-vars.css';
+import '@vtmn/css-search';
 import clsx from 'clsx';
 import { VtmnSearchVariant, VtmnSearchSize } from './types';
 import { VtmnButton } from '../../actions/VtmnButton/VtmnButton';

--- a/packages/sources/react/src/components/navigation/VtmnTabs/VtmnTabs.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnTabs/VtmnTabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-tabs/dist/index-with-vars.css';
+import '@vtmn/css-tabs';
 import { VtmnTabsAlign, VtmnTabsSize } from './types';
 import { VtmnDivider } from '../../../components/structure/VtmnDivider';
 import clsx from 'clsx';

--- a/packages/sources/react/src/components/navigation/VtmnTabs/VtmnTabsItem.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnTabs/VtmnTabsItem.tsx
@@ -1,4 +1,4 @@
-import '@vtmn/css-tabs/dist/index-with-vars.css';
+import '@vtmn/css-tabs';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import * as React from 'react';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';

--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-alert/dist/index-with-vars.css';
+import '@vtmn/css-alert';
 import { VtmnAlertVariant } from './types';
 import clsx from 'clsx';
 import { VtmnButton } from '../../actions/VtmnButton';

--- a/packages/sources/react/src/components/overlays/VtmnModal/VtmnModal.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnModal/VtmnModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-modal/dist/index-with-vars.css';
+import '@vtmn/css-modal';
 import clsx from 'clsx';
 import { VtmnButton } from '../../actions/VtmnButton/VtmnButton';
 

--- a/packages/sources/react/src/components/overlays/VtmnPopover/VtmnPopover.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnPopover/VtmnPopover.tsx
@@ -1,4 +1,4 @@
-import '@vtmn/css-popover/dist/index-with-vars.css';
+import '@vtmn/css-popover';
 import * as React from 'react';
 import { VtmnPopoverPosition } from './types';
 

--- a/packages/sources/react/src/components/overlays/VtmnSnackbar/VtmnSnackbar.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnSnackbar/VtmnSnackbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-snackbar/dist/index-with-vars.css';
+import '@vtmn/css-snackbar';
 import clsx from 'clsx';
 import { VtmnButton } from '../../actions/VtmnButton';
 

--- a/packages/sources/react/src/components/overlays/VtmnToast/VtmnToast.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnToast/VtmnToast.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-toast/dist/index-with-vars.css';
+import '@vtmn/css-toast';
 import clsx from 'clsx';
 import { VtmnButton } from '../../actions/VtmnButton';
 

--- a/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnTooltip/VtmnTooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-tooltip/dist/index-with-vars.css';
+import '@vtmn/css-tooltip';
 import { VtmnTooltipPosition } from './types';
 import clsx from 'clsx';
 

--- a/packages/sources/react/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnCheckbox/VtmnCheckbox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-checkbox/dist/index-with-vars.css';
+import '@vtmn/css-checkbox';
 
 export interface VtmnCheckboxProps
   extends React.ComponentPropsWithoutRef<'input'> {

--- a/packages/sources/react/src/components/selection-controls/VtmnChip/VtmnChip.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnChip/VtmnChip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import '@vtmn/css-chip/dist/index-with-vars.css';
+import '@vtmn/css-chip';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import { VtmnChipSize, VtmnChipVariant } from './types';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon/VtmnIcon';

--- a/packages/sources/react/src/components/selection-controls/VtmnQuantity/VtmnQuantity.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnQuantity/VtmnQuantity.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-quantity/dist/index-with-vars.css';
+import '@vtmn/css-quantity';
 import clsx from 'clsx';
 import { VtmnButton } from '../../actions/VtmnButton/VtmnButton';
 import { VtmnQuantitySize } from './types';

--- a/packages/sources/react/src/components/selection-controls/VtmnRadioButton/VtmnRadioButton.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnRadioButton/VtmnRadioButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-radio-button/dist/index-with-vars.css';
+import '@vtmn/css-radio-button';
 
 export interface VtmnRadioButtonProps
   extends React.ComponentPropsWithoutRef<'input'> {

--- a/packages/sources/react/src/components/selection-controls/VtmnToggle/VtmnToggle.tsx
+++ b/packages/sources/react/src/components/selection-controls/VtmnToggle/VtmnToggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-toggle/dist/index-with-vars.css';
+import '@vtmn/css-toggle';
 import clsx from 'clsx';
 import { VtmnToggleSize } from './types';
 

--- a/packages/sources/react/src/components/structure/VtmnAccordion/VtmnAccordion.tsx
+++ b/packages/sources/react/src/components/structure/VtmnAccordion/VtmnAccordion.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import '@vtmn/css-accordion/dist/index-with-vars.css';
+import '@vtmn/css-accordion';
 
 export interface VtmnAccordionProps
   extends React.ComponentPropsWithoutRef<'details'> {

--- a/packages/sources/react/src/components/structure/VtmnCard/VtmnCard.tsx
+++ b/packages/sources/react/src/components/structure/VtmnCard/VtmnCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import '@vtmn/css-card/dist/index-with-vars.css';
+import '@vtmn/css-card';
 import { VtmnCardVariant } from './types';
 
 export interface VtmnCardProps extends React.ComponentPropsWithoutRef<'div'> {

--- a/packages/sources/react/src/components/structure/VtmnDivider/VtmnDivider.tsx
+++ b/packages/sources/react/src/components/structure/VtmnDivider/VtmnDivider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import '@vtmn/css-divider/dist/index-with-vars.css';
+import '@vtmn/css-divider';
 import { VtmnDividerOrientation, VtmnDividerTextPosition } from './types';
 
 export interface VtmnDividerProps

--- a/packages/sources/react/src/components/structure/VtmnList/VtmnList.tsx
+++ b/packages/sources/react/src/components/structure/VtmnList/VtmnList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@vtmn/css-list/dist/index-with-vars.css';
+import '@vtmn/css-list';
 import clsx from 'clsx';
 import { VtmnListSize } from './types';
 import { computeRel } from '@/utils/link';

--- a/packages/sources/react/src/components/structure/VtmnSkeleton/VtmnSkeleton.tsx
+++ b/packages/sources/react/src/components/structure/VtmnSkeleton/VtmnSkeleton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import '@vtmn/css-skeleton/dist/index-with-vars.css';
+import '@vtmn/css-skeleton';
 import { VtmnSkeletonShape } from './types';
 
 export interface VtmnSkeletonProps

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,7 +3572,7 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-node-resolve@^15.0.0":
+"@rollup/plugin-node-resolve@^15.0.0", "@rollup/plugin-node-resolve@^15.0.1":
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz#72be449b8e06f6367168d5b3cd5e2802e0248971"
   integrity sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==


### PR DESCRIPTION
## Changes description
Support sideEffects to reduce imported size of components. 

Currently, the postCss rollup plugin, generates JS that is considered as sideEffects because not a part of our solution and gets treeshaken when `sideEffects: false` is active. 

Not having the sideEffects specified imports everything, even if you're only importing a button. 

Also, we used to use `index-with-vars.css`, which is not necessary since we could need to import and compute the vars at runtime, which is also done by another script which requires a lot of imports too. Using the already computed styles lightens this process and allow for more granular treeshake. 

As an example, now with a VtmnButton, we only import around 150kb instead of 440kb before. 
With three components, i am at 170kb. 

## Context
This improves loading time of all apps and allow people to lazy load some components.
Bundle size is lighter and represents more what we use. There is no need to have all the other components in the browser, if we only use a Button and a Tag.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?

- No

## Other information

Tested on : 

- CRA with Node 14
- CRA with Node 18
- Vite App
- Nextjs exisiting production app


Good to know: we can do better, currently, all the side effects are marked, so we always import all the scripts the are generated by the postCSS rollup module, i think we can do better, but we might require better tooling than rollup. So let's do this for now