### PR TITLE
fix(@vtmn/svelte, @vtmn/react, @vtmn/vue): fix rounded value on `VtmnRating`

### DIFF
--- a/packages/showcases/core/csf/components/indicators/rating.csf.js
+++ b/packages/showcases/core/csf/components/indicators/rating.csf.js
@@ -59,7 +59,7 @@ export const argTypes = {
     description:
       'Rating value. NB: if readonly is set to false, the value step is 1.',
     defaultValue: 0,
-    control: { type: 'range', min: 0, max: 5, step: 0.5 },
+    control: { type: 'range', min: 0, max: 5, step: 0.1 },
   },
   comments: {
     type: { name: 'string', required: false },

--- a/packages/showcases/core/csf/components/indicators/rating.csf.js
+++ b/packages/showcases/core/csf/components/indicators/rating.csf.js
@@ -24,6 +24,7 @@ export const argTypes = {
     control: {
       type: 'boolean',
     },
+    if: { arg: 'readonly' },
   },
   size: {
     type: { name: 'string', required: false },
@@ -51,10 +52,11 @@ export const argTypes = {
     description: 'Display compact mode. Only if readonly is true.',
     defaultValue: false,
     control: { type: 'boolean' },
+    if: { arg: 'readonly' },
   },
   value: {
     type: { name: 'number', required: false },
-    description: 'Rating value.',
+    description: 'Rating value. NB: if readonly are false, value step is 1.',
     defaultValue: 0,
     control: { type: 'range', min: 0, max: 5, step: 0.5 },
   },
@@ -64,11 +66,13 @@ export const argTypes = {
       'Comments displayed after the rating. Only if readonly is true.',
     defaultValue: undefined,
     control: { type: 'text' },
+    if: { arg: 'readonly' },
   },
   showValue: {
     type: { name: 'boolean', required: false },
     description: 'Display the rating value. Only if readonly is true.',
     defaultValue: false,
     control: { type: 'boolean' },
+    if: { arg: 'readonly' },
   },
 };

--- a/packages/showcases/core/csf/components/indicators/rating.csf.js
+++ b/packages/showcases/core/csf/components/indicators/rating.csf.js
@@ -56,7 +56,8 @@ export const argTypes = {
   },
   value: {
     type: { name: 'number', required: false },
-    description: 'Rating value. NB: if readonly are false, value step is 1.',
+    description:
+      'Rating value. NB: if readonly is set to false, the value step is 1.',
     defaultValue: 0,
     control: { type: 'range', min: 0, max: 5, step: 0.5 },
   },

--- a/packages/sources/react/src/components/indicators/VtmnRating/VtmnRating.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnRating/VtmnRating.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import '@vtmn/css-rating/dist/index-with-vars.css';
 import * as React from 'react';
 import { VtmnRatingSize } from './types';
+import { computeRatingFill } from './utils';
 
 export interface VtmnRatingProps
   extends Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
@@ -154,13 +155,7 @@ export const VtmnRating = ({
             Array.from(Array(5).keys()).map((index) => (
               <span
                 key={`rating-readonly-${index + 1}`}
-                className={
-                  index <= position && position - index >= 0.5
-                    ? position - index < 1 && position - index >= 0.5
-                      ? 'vtmx-star-half-fill'
-                      : 'vtmx-star-fill'
-                    : 'vtmx-star-line'
-                }
+                className={`vtmx-star-${computeRatingFill(index + 1, value)}`}
                 role="presentation"
               />
             ))

--- a/packages/sources/react/src/components/indicators/VtmnRating/utils.ts
+++ b/packages/sources/react/src/components/indicators/VtmnRating/utils.ts
@@ -2,20 +2,14 @@ import { isFloat, roundToNearestHalf } from '../../../utils/math';
 
 /**
  * Compute the vtmn-icon who has to be displayed on the position
- * @param {boolean} isCompact If the rating is compact
  * @param {number} currentRatingStarPosition Current position of the star on the component (range [1-5])
  * @param {number} ratingValue Value of the rating
  * @returns {'line'|'half-fill'|'fill'} Vtmn icon id
  */
 export const computeRatingFill = (
-  isCompact,
-  currentRatingStarPosition,
-  ratingValue,
+  currentRatingStarPosition: number,
+  ratingValue: number,
 ) => {
-  if (isCompact) {
-    return ratingValue === 0 ? 'line' : 'fill';
-  }
-
   const computedRating = roundToNearestHalf(ratingValue);
   if (currentRatingStarPosition <= computedRating) {
     return 'fill';

--- a/packages/sources/react/src/utils/math.ts
+++ b/packages/sources/react/src/utils/math.ts
@@ -1,0 +1,7 @@
+export function isFloat(n: number) {
+  return n === +n && n !== (n | 0);
+}
+
+export function roundToNearestHalf(number: number) {
+  return Math.round(number * 2) / 2;
+}

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
@@ -1,8 +1,8 @@
 <script>
   import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
   import { cn } from '../../../utils/classnames';
-  import { isFloat } from '../../../utils/math';
   import { VTMN_RATING_SIZE } from './enum';
+  import { computeRatingFill } from './vtmnRating.util';
 
   /**
    * @type {string} name used on interactive mode to name the inputs
@@ -70,23 +70,6 @@
     className,
   );
   $: starsCnt = compact && readonly ? 1 : 5;
-
-  const computeRatingFill = (currentRatingStar) => {
-    if (starsCnt === 1) {
-      return value === 0 ? 'line' : 'fill';
-    }
-    if (currentRatingStar <= value) {
-      return 'fill';
-    }
-    if (
-      value < currentRatingStar &&
-      isFloat(value) &&
-      Math.ceil(value) === currentRatingStar
-    ) {
-      return 'half-fill';
-    }
-    return 'line';
-  };
 </script>
 
 <div class={componentClass} aria-disabled={disabled} {...$$restProps}>
@@ -94,7 +77,7 @@
     {#each Array(starsCnt) as _, index}
       {@const position = index + 1}
       <VtmnIcon
-        value={`star-${computeRatingFill(position)}`}
+        value={`star-${computeRatingFill(compact, position, value)}`}
         role="presentation"
       />
     {/each}

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/svelte';
 import VtmnRating from '../VtmnRating.svelte';
+import { computeRatingFill } from '../vtmnRating.util';
 
 describe('VtmnRating', () => {
   const getRating = (container) =>
@@ -228,6 +229,20 @@ describe('VtmnRating', () => {
       expect(spans[3]).toHaveClass('vtmx-star-line');
       expect(spans[4]).toHaveClass('vtmx-star-line');
     });
+    test("Should have 5 span with class 'vtmx-star-fill' if rating > 4.5 and compact = false", () => {
+      const { container } = render(VtmnRating, {
+        name: 'rating',
+        readonly: true,
+        compact: false,
+        value: 4.6,
+      });
+      const spans = getReadonlyPresentations(container);
+      expect(spans.length).toEqual(5);
+      for (let i = 0, ii = spans.length; i < ii; i++) {
+        expect(spans[i]).toBeVisible();
+        expect(spans[i]).toHaveClass('vtmx-star-fill');
+      }
+    });
     test("Should have 5 span with class 'vtmx-star-fill' if rating = 5 and compact = false", () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
@@ -338,6 +353,24 @@ describe('VtmnRating', () => {
       await fireEvent.click(inputs[1]);
       expect(inputs[1].checked).toEqual(true);
       expect(getInteractive(container)).toHaveAttribute('data-rating', '2');
+    });
+  });
+
+  describe('computeRatingFill', () => {
+    test('Should return line if isCompact and rattingValue is 0', () => {
+      expect(computeRatingFill(true, 1, 0)).toBe('line');
+    });
+    test('Should return fill if isCompact and rattingValue is > 0', () => {
+      expect(computeRatingFill(true, 1, 0.1)).toBe('fill');
+    });
+    test('Should return fill if current position < ratingValue', () => {
+      expect(computeRatingFill(false, 1, 2)).toBe('fill');
+    });
+    test('Should return half-fill if current position is floating value and ratingValue < position', () => {
+      expect(computeRatingFill(false, 1, 0.5)).toBe('half-fill');
+    });
+    test('Should return line if current value < position', () => {
+      expect(computeRatingFill(false, 4, 1)).toBe('line');
     });
   });
 });

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
@@ -207,7 +207,7 @@ describe('VtmnRating', () => {
       }
       expect(spans[0]).toHaveClass('vtmx-star-fill');
       expect(spans[1]).toHaveClass('vtmx-star-fill');
-      expect(spans[2]).toHaveClass('vtmx-star-half-fill');
+      expect(spans[2]).toHaveClass('vtmx-star-line');
       expect(spans[3]).toHaveClass('vtmx-star-line');
       expect(spans[4]).toHaveClass('vtmx-star-line');
     });
@@ -225,16 +225,16 @@ describe('VtmnRating', () => {
       }
       expect(spans[0]).toHaveClass('vtmx-star-fill');
       expect(spans[1]).toHaveClass('vtmx-star-fill');
-      expect(spans[2]).toHaveClass('vtmx-star-half-fill');
+      expect(spans[2]).toHaveClass('vtmx-star-fill');
       expect(spans[3]).toHaveClass('vtmx-star-line');
       expect(spans[4]).toHaveClass('vtmx-star-line');
     });
-    test("Should have 5 span with class 'vtmx-star-fill' if rating > 4.5 and compact = false", () => {
+    test("Should have 5 span with class 'vtmx-star-fill' if rating > 4.75 and compact = false", () => {
       const { container } = render(VtmnRating, {
         name: 'rating',
         readonly: true,
         compact: false,
-        value: 4.6,
+        value: 4.75,
       });
       const spans = getReadonlyPresentations(container);
       expect(spans.length).toEqual(5);

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/vtmnRating.util.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/vtmnRating.util.js
@@ -2,10 +2,10 @@ import { isFloat } from '../../../utils/math';
 
 /**
  * Compute the vtmn-icon who has to be displayed on the position
- * @param isCompact if the rating are compact
- * @param currentRatingStarPosition current position of the star
- * @param ratingValue value of the rating
- * @returns {string} icon id
+ * @param {boolean} isCompact If the rating are compact
+ * @param {number} currentRatingStarPosition Current position of the star on the component (range [1-5])
+ * @param {number} ratingValue Value of the rating
+ * @returns {'line'|'half-fill'|'fill'} Vtmn icon id
  */
 export const computeRatingFill = (
   isCompact,

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/vtmnRating.util.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/vtmnRating.util.js
@@ -1,4 +1,4 @@
-import { isFloat } from '../../../utils/math';
+import { isFloat, roundToNearestHalf } from '../../../utils/math';
 
 /**
  * Compute the vtmn-icon who has to be displayed on the position
@@ -15,15 +15,13 @@ export const computeRatingFill = (
   if (isCompact) {
     return ratingValue === 0 ? 'line' : 'fill';
   }
-  if (currentRatingStarPosition <= ratingValue || 4.5 < ratingValue) {
+
+  const computedRating = roundToNearestHalf(ratingValue);
+  if (currentRatingStarPosition <= computedRating) {
     return 'fill';
   }
-  if (
-    ratingValue < currentRatingStarPosition &&
-    isFloat(ratingValue) &&
-    Math.ceil(ratingValue) === currentRatingStarPosition
-  ) {
-    return 'half-fill';
-  }
-  return 'line';
+  return Math.ceil(computedRating) === currentRatingStarPosition &&
+    isFloat(computedRating)
+    ? 'half-fill'
+    : 'line';
 };

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/vtmnRating.util.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/vtmnRating.util.js
@@ -1,0 +1,29 @@
+import { isFloat } from '../../../utils/math';
+
+/**
+ * Compute the vtmn-icon who has to be displayed on the position
+ * @param isCompact if the rating are compact
+ * @param currentRatingStarPosition current position of the star
+ * @param ratingValue value of the rating
+ * @returns {string} icon id
+ */
+export const computeRatingFill = (
+  isCompact,
+  currentRatingStarPosition,
+  ratingValue,
+) => {
+  if (isCompact) {
+    return ratingValue === 0 ? 'line' : 'fill';
+  }
+  if (currentRatingStarPosition <= ratingValue || 4.5 < ratingValue) {
+    return 'fill';
+  }
+  if (
+    ratingValue < currentRatingStarPosition &&
+    isFloat(ratingValue) &&
+    Math.ceil(ratingValue) === currentRatingStarPosition
+  ) {
+    return 'half-fill';
+  }
+  return 'line';
+};

--- a/packages/sources/svelte/src/utils/math.js
+++ b/packages/sources/svelte/src/utils/math.js
@@ -13,3 +13,7 @@ export function uuid() {
     return v.toString(16);
   });
 }
+
+export function roundToNearestHalf(number) {
+  return Math.round(number * 2) / 2;
+}

--- a/packages/sources/vue/src/components/indicators/VtmnRating/VtmnRating.vue
+++ b/packages/sources/vue/src/components/indicators/VtmnRating/VtmnRating.vue
@@ -3,6 +3,7 @@ import VtmnIcon from '../../../guidelines/iconography/VtmnIcon';
 import '@vtmn/css-rating/dist/index-with-vars.css';
 import { computed, defineComponent, PropType, reactive } from 'vue';
 import { VtmnRatingSize } from './types';
+import { computeRatingFill } from './utils';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnRating',
@@ -50,6 +51,7 @@ export default /*#__PURE__*/ defineComponent({
     props = reactive(props);
 
     return {
+      computeRatingFill,
       styleObject: {
         color: 'inherit',
         fontSize: 'none',
@@ -88,13 +90,7 @@ export default /*#__PURE__*/ defineComponent({
     <template v-else-if="!compact">
       <template v-for="i in 5" :key="i">
         <VtmnIcon
-          :value="
-            i <= value
-              ? 'star-fill'
-              : i > value && i - 0.5 <= value
-              ? 'star-half-fill'
-              : 'star-line'
-          "
+          :value="computeRatingFill(i, value)"
           :style="styleObject"
           role="presentation"
         />

--- a/packages/sources/vue/src/components/indicators/VtmnRating/utils.ts
+++ b/packages/sources/vue/src/components/indicators/VtmnRating/utils.ts
@@ -2,26 +2,20 @@ import { isFloat, roundToNearestHalf } from '../../../utils/math';
 
 /**
  * Compute the vtmn-icon who has to be displayed on the position
- * @param {boolean} isCompact If the rating is compact
  * @param {number} currentRatingStarPosition Current position of the star on the component (range [1-5])
  * @param {number} ratingValue Value of the rating
  * @returns {'line'|'half-fill'|'fill'} Vtmn icon id
  */
 export const computeRatingFill = (
-  isCompact,
-  currentRatingStarPosition,
-  ratingValue,
+  currentRatingStarPosition: number,
+  ratingValue: number,
 ) => {
-  if (isCompact) {
-    return ratingValue === 0 ? 'line' : 'fill';
-  }
-
   const computedRating = roundToNearestHalf(ratingValue);
   if (currentRatingStarPosition <= computedRating) {
-    return 'fill';
+    return 'star-fill';
   }
   return Math.ceil(computedRating) === currentRatingStarPosition &&
     isFloat(computedRating)
-    ? 'half-fill'
-    : 'line';
+    ? 'star-half-fill'
+    : 'star-line';
 };

--- a/packages/sources/vue/src/utils/math.ts
+++ b/packages/sources/vue/src/utils/math.ts
@@ -1,0 +1,7 @@
+export function isFloat(n: number) {
+  return n === +n && n !== (n | 0);
+}
+
+export function roundToNearestHalf(number: number) {
+  return Math.round(number * 2) / 2;
+}


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
After checking the Decathlon website, I saw many products that the stars are stuck at 4.5.
<img width="962" alt="image" src="https://user-images.githubusercontent.com/2856778/221352934-468fed41-50f0-4733-8168-56814089efa4.png">

But some of them are a rating > 4.7.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

The rule on the current component is : 
- If my value are a floating value, always round on the 0.5 above.

But here with a value > 4.5 we don't round.

The question here is, what we defined when a number is > 4.5.
I've discuss with @lauthieb, we need to speak about it, maybe take the example of Google that round the value with the nearest one.

And write this rule on the Design System website so that there are no more questions about it.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No breaking changes

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

This PR aims to enhancer the storybook
- Add conditional values in order to display only specific fields when `readonly` are true / false

| Readonly = false |  Readonly = true |
|---|---|
|<img width="967" alt="image" src="https://user-images.githubusercontent.com/2856778/221353323-3261aa5c-bbff-4ece-9dd5-a8e3b46f1933.png">|<img width="957" alt="image" src="https://user-images.githubusercontent.com/2856778/221353391-fc57a25a-1931-4740-8e5c-5fe9710297b8.png"> |


Improve tests
- Move the function who compute the `VtmnIcon` who has to be displayed. Add more tests on this function.
- Add more test on the component 