### PR TITLE
feat(@vtmn/css): add position relative on `VtmnListItem`

### DIFF
--- a/packages/sources/css/src/components/structure/list/src/index.css
+++ b/packages/sources/css/src/components/structure/list/src/index.css
@@ -84,6 +84,7 @@
 .vtmn-list_text {
   inline-size: 100%;
   display: flex;
+  position:relative;
   flex-direction: column;
   justify-content: center;
   border-block-end: rem(1px) solid var(--vtmn-semantic-color_border-primary);


### PR DESCRIPTION
Refer to #1382

With this new behaviour, the user can apply a `vtmn-absolute` in order to manage the text to add ellipsis etc ...

Result : 
<img width="780" alt="image" src="https://user-images.githubusercontent.com/2856778/224072155-280c4088-3762-4be6-b00d-7bd8972bce5b.png">

No breaking changes