### PR TITLE
chore: remove deprecated vscode extension npm

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
     "bierner.lit-html",
     "yzhang.markdown-all-in-one",
     "silvenon.mdx",
-    "eg2.vscode-npm-script",
     "christian-kohler.npm-intellisense",
     "csstools.postcss",
     "esbenp.prettier-vscode",


### PR DESCRIPTION
## Changes description
Remove recommendation (`.vscode/extensions.json`) for [npm vscode extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
This extension is [deprecated](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)


## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
