### PR TITLE
refactor(vtmn/icons): reorder font src, woff2 in first position for performance

### DIFF
--- a/packages/sources/icons/src/generated/vitamix/font/vitamix.css
+++ b/packages/sources/icons/src/generated/vitamix/font/vitamix.css
@@ -1,8 +1,8 @@
 @font-face {
     font-family: "vitamix";
-    src: url("./vitamix.ttf?8880a93e7dbb625d98d1ee364132f425") format("truetype"),
-url("./vitamix.woff?8880a93e7dbb625d98d1ee364132f425") format("woff"),
-url("./vitamix.woff2?8880a93e7dbb625d98d1ee364132f425") format("woff2");
+    src: url("./vitamix.woff2?8880a93e7dbb625d98d1ee364132f425") format("woff2"),
+    url("./vitamix.woff?8880a93e7dbb625d98d1ee364132f425") format("woff"),
+    url("./vitamix.ttf?8880a93e7dbb625d98d1ee364132f425") format("truetype");
 }
 
 [class^="vtmx-"], [class*=" vtmx-"] {


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Reorder src of vitamix `@font-face`

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
The browser download and use the first font file supported so the order is important to ensure best performance.
Before is was ttf, woff, woff2 so the browser use the ttf version (62K)
After it's woff2, woff, ttf so it will take the woff2 version which is better (26K, 59% lighter 🚀 )

NB: it's a progressive enhancement, for [oldest](https://caniuse.com/woff2) browsers that doesn't support woff2 nor woff, they will continue to use the ttf version as before

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
