### PR TITLE
feat: bump packages to 1.x.x

### DIFF
--- a/packages/sources/assets/package.json
+++ b/packages/sources/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/assets",
-  "version": "0.3.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin assets library",
   "keywords": [
     "design-system",

--- a/packages/sources/css/package.json
+++ b/packages/sources/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css",
-  "version": "0.96.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin global CSS styles library",
   "keywords": [
     "design-system",

--- a/packages/sources/css/presets/tailwind/package.json
+++ b/packages/sources/css/presets/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-tailwind-preset",
-  "version": "0.35.56",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin CSS Tailwind preset",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/actions/button/package.json
+++ b/packages/sources/css/src/components/actions/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-button",
-  "version": "0.15.3",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for button component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/actions/dropdown/package.json
+++ b/packages/sources/css/src/components/actions/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-dropdown",
-  "version": "0.7.8",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for alert component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/actions/link/package.json
+++ b/packages/sources/css/src/components/actions/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-link",
-  "version": "0.9.2",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for link component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/forms/select/package.json
+++ b/packages/sources/css/src/components/forms/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-select",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for select component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/forms/text-input/package.json
+++ b/packages/sources/css/src/components/forms/text-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-text-input",
-  "version": "0.17.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for text input component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/indicators/badge/package.json
+++ b/packages/sources/css/src/components/indicators/badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-badge",
-  "version": "0.13.2",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for badge component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/indicators/loader/package.json
+++ b/packages/sources/css/src/components/indicators/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-loader",
-  "version": "0.4.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for loader component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/indicators/price/package.json
+++ b/packages/sources/css/src/components/indicators/price/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-price",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for price component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/indicators/progressbar/package.json
+++ b/packages/sources/css/src/components/indicators/progressbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-progressbar",
-  "version": "0.7.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for progressbar component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/indicators/rating/package.json
+++ b/packages/sources/css/src/components/indicators/rating/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-rating",
-  "version": "0.5.23",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for rating component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/indicators/tag/package.json
+++ b/packages/sources/css/src/components/indicators/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-tag",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for tag component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/navigation/breadcrumb/package.json
+++ b/packages/sources/css/src/components/navigation/breadcrumb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-breadcrumb",
-  "version": "0.7.7",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for breadcrumb component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/navigation/navbar/package.json
+++ b/packages/sources/css/src/components/navigation/navbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-navbar",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for navbar component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/navigation/search/package.json
+++ b/packages/sources/css/src/components/navigation/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-search",
-  "version": "0.7.23",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for search component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/navigation/tabs/package.json
+++ b/packages/sources/css/src/components/navigation/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-tabs",
-  "version": "0.7.5",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for tabs component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/overlays/alert/package.json
+++ b/packages/sources/css/src/components/overlays/alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-alert",
-  "version": "0.8.6",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for alert component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/overlays/modal/package.json
+++ b/packages/sources/css/src/components/overlays/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-modal",
-  "version": "0.8.8",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for modal component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/overlays/popover/package.json
+++ b/packages/sources/css/src/components/overlays/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-popover",
-  "version": "0.7.6",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for popover component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/overlays/snackbar/package.json
+++ b/packages/sources/css/src/components/overlays/snackbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-snackbar",
-  "version": "0.7.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for snackbar component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/overlays/toast/package.json
+++ b/packages/sources/css/src/components/overlays/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-toast",
-  "version": "0.7.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for toast component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/overlays/tooltip/package.json
+++ b/packages/sources/css/src/components/overlays/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-tooltip",
-  "version": "0.8.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for tooltip component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/selection-controls/checkbox/package.json
+++ b/packages/sources/css/src/components/selection-controls/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-checkbox",
-  "version": "0.8.5",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for checkbox component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/selection-controls/chip/package.json
+++ b/packages/sources/css/src/components/selection-controls/chip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-chip",
-  "version": "0.9.5",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for chip component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/selection-controls/quantity/package.json
+++ b/packages/sources/css/src/components/selection-controls/quantity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-quantity",
-  "version": "0.10.1",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for quantity component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/selection-controls/radio-button/package.json
+++ b/packages/sources/css/src/components/selection-controls/radio-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-radio-button",
-  "version": "0.8.5",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for radio button component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/selection-controls/toggle/package.json
+++ b/packages/sources/css/src/components/selection-controls/toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-toggle",
-  "version": "0.8.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for toggle component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/structure/accordion/package.json
+++ b/packages/sources/css/src/components/structure/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-accordion",
-  "version": "0.5.19",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for accordion component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/structure/card/package.json
+++ b/packages/sources/css/src/components/structure/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-card",
-  "version": "0.11.1",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for card component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/structure/divider/package.json
+++ b/packages/sources/css/src/components/structure/divider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-divider",
-  "version": "0.5.3",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for divider component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/structure/list/package.json
+++ b/packages/sources/css/src/components/structure/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-list",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for list component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/components/structure/skeleton/package.json
+++ b/packages/sources/css/src/components/structure/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-skeleton",
-  "version": "0.5.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for skeleton component",
   "keywords": [
     "design-system",

--- a/packages/sources/css/src/design-tokens/package.json
+++ b/packages/sources/css/src/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-design-tokens",
-  "version": "0.20.2",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for design tokens",
   "homepage": "https://github.com/Decathlon/vitamin-web/tree/main/packages/sources/css/src/design-tokens",
   "repository": {

--- a/packages/sources/css/src/utilities/package.json
+++ b/packages/sources/css/src/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/css-utilities",
-  "version": "0.4.4",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin specific CSS styles for utilities",
   "homepage": "https://github.com/Decathlon/vitamin-web/tree/main/packages/sources/css/src/utilities",
   "repository": {

--- a/packages/sources/icons/package.json
+++ b/packages/sources/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/icons",
-  "version": "0.21.8",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin icons library",
   "keywords": [
     "design-system",

--- a/packages/sources/react/package.json
+++ b/packages/sources/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/react",
-  "version": "0.67.3",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin React components library",
   "keywords": [
     "design-system",

--- a/packages/sources/svelte/package.json
+++ b/packages/sources/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/svelte",
-  "version": "0.67.3",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin Svelte components library",
   "keywords": [
     "design-system",

--- a/packages/sources/vue/package.json
+++ b/packages/sources/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtmn/vue",
-  "version": "0.55.3",
+  "version": "1.0.0",
   "description": "Decathlon Design System - Vitamin Vue components library",
   "keywords": [
     "design-system",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5662,6 +5662,192 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-3.2.0.tgz#a1484089dd85d6528f435743f84cdd0d215bbb54"
   integrity sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==
 
+"@vtmn/css-accordion@^0.5.19":
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-accordion/-/css-accordion-0.5.19.tgz#c9f7b5fd23a230f6e19d061c9cff1f79154dc417"
+  integrity sha512-CiJXe2iEaZy1QFkFpJgwin6nKAylNU5foia2CQAwy3kRypx1Qrv8ooCoWCSpHdUtC923gYO+DZdVrvYuAC0eGw==
+  dependencies:
+    "@vtmn/icons" "^0.21.8"
+
+"@vtmn/css-alert@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-alert/-/css-alert-0.8.6.tgz#4fbbb16dcb3936be253c8badc1017d574db8b357"
+  integrity sha512-xkWhczsH0zBjQxt4XC1TzwoYNkcf133g4JwnInDU4G/D6s97FzZphFKrFdbyOkX6EWCJ8ETUHkQraPaAa2q2kg==
+
+"@vtmn/css-badge@^0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-badge/-/css-badge-0.13.2.tgz#97f89a3820dabf28de0637334ec01b817bda4ca7"
+  integrity sha512-xRVKP0cTBwQG5sqMvhxdtabPPBTrX/HofEe7ngLRBmI9JLmHQgLllg6hN7fcOphbGg5/HzcLnfx4RgQSDNsrAw==
+
+"@vtmn/css-breadcrumb@^0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-breadcrumb/-/css-breadcrumb-0.7.7.tgz#42d190671a6ef679286d52123a9d4cc66c582eb5"
+  integrity sha512-oC5H7gFdffu23g6gvsveAMK9rtniCP9RtnqF4aagZ9CL0JW2Zld6FOggDKqL6KALuik64cvW8kfuWlNmkNDCIA==
+
+"@vtmn/css-button@^0.15.3":
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-button/-/css-button-0.15.3.tgz#c817c76cc514f5588ef63683ea896624a0d8abb8"
+  integrity sha512-kM2Hb6DDFc04soVLyo/wwnNMj3b5Mf95rFKBOQwa/Oz2nikllrQHAx9OF911h8esaN68h12ADFLE9xwzb3GOAg==
+
+"@vtmn/css-card@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-card/-/css-card-0.11.1.tgz#89e82e275cd055fc8e5d8851bf8c79cb71772b12"
+  integrity sha512-yAbPM5nyNvzE0Ql0W0RVAn1+a6ptkPLnTBVARYtcV9SC7UKpCM53CGipfgfu3WS71FfM3d1Y+QdTmMaEj+VqNA==
+
+"@vtmn/css-checkbox@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-checkbox/-/css-checkbox-0.8.5.tgz#eca85ac1e4152afaeb28ceaa37e043ea0d8775fe"
+  integrity sha512-LYWbU2JmKxkSazlGlM4I67DlTPVmoF6DaqrqsNs+2rf+r3wPI8z1vr0+86lXQAAyDhvJwBvH+mSIXY0XC1ONeg==
+
+"@vtmn/css-chip@^0.9.5":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-chip/-/css-chip-0.9.5.tgz#768bd4eb6b3ccd961514a47bea4d1baf60d76b75"
+  integrity sha512-yN/idMOb+q1YSbXlq9g4YWxLeejTthN3PBBEYa4OqBMchpoRC5e2ucwWys0XJG1EGYeG8caEjAimGJuhmyJFMg==
+
+"@vtmn/css-design-tokens@^0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-design-tokens/-/css-design-tokens-0.20.2.tgz#254cb831d0dc3f581ac19fb3861c099ea56aae2d"
+  integrity sha512-gs4FgYN6Mbu8Zd78RP5sNw3tW8lMzBCd787UvKXWPZCiWylblmEYCC1eNHZZJPGPv3CC3lW/yAsz2RGqR/fwEQ==
+
+"@vtmn/css-divider@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-divider/-/css-divider-0.5.3.tgz#161d718bc213dd05001039752146d95f7af4c218"
+  integrity sha512-QnPp2P6tMq3Q5QDrK13PjjUg2Z6ujL7/JBuJ4To4RLO09da2P0xb7rZuaInAp0eu+88BGRAgQPPOTpdpLJhDCg==
+
+"@vtmn/css-dropdown@^0.7.8":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-dropdown/-/css-dropdown-0.7.8.tgz#301a7b0b116b5fad688bd2835e18ae1c67ec706e"
+  integrity sha512-k9NyFTt+/8I/g8nvIj4vtVLgHsIi4OopRwkG4EIQRWiWHJLxdYeZLbHIpxv5xQVRnuu9It8RrpBqDX81szMj3w==
+
+"@vtmn/css-link@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-link/-/css-link-0.9.2.tgz#ca7ae0aeaae9e7e59f4a4154235a6deaaa194229"
+  integrity sha512-EqasqlAuIuBfl6LMwUASgNPXrgMeQwxqCH8zT8x7Xb9dlFWp6Y7e4EGzsx0aIUK11f3b9e2GITJSHKRqBEKb7Q==
+
+"@vtmn/css-list@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-list/-/css-list-0.7.0.tgz#140314e2eeff71317e7fcf9bfccd5fb919e415fc"
+  integrity sha512-jMDVcfq+tcAZIqQ8Zu86eoln3twaaNlN+TEtodgSgeEqssazDJUp21zvV7y6UBbHYe+XLfQRTQGueyN5Jp3Mjg==
+
+"@vtmn/css-loader@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-loader/-/css-loader-0.4.4.tgz#9597ecd4bd8b3fead7ca5aac0e26eb35f6629649"
+  integrity sha512-GgxV/4vF4jZmEk1Odo3D5SHlRQTYIU+bM7GQI41rHJqyXBydqgJQ767L46iPfaG6h/a/aPIBUroPPH+AzM/+PQ==
+
+"@vtmn/css-modal@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-modal/-/css-modal-0.8.8.tgz#963fcedd881056b1866b5f420ae58cdcf24d15b8"
+  integrity sha512-6xv2QIZtbg/3S/oRGJcI3T3IpNE1hJX0dWHyY0qwlG5TzisU77Uf4HsMhoD1X2J1dwmhEPg/qrHNrZg0dKrXaA==
+
+"@vtmn/css-navbar@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-navbar/-/css-navbar-0.4.0.tgz#62cf5942784fb11bca8d9d37f25e6da3779e93a2"
+  integrity sha512-xSdQE6qIooxUNgv9Y1geC4qH6EbvfCUg5vdBumbpH7+Shd7u6zazoJBwsdiOT1tGlReB6gLCoV7wO1mq4W2/yA==
+
+"@vtmn/css-popover@^0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-popover/-/css-popover-0.7.6.tgz#584fd66206aa00cb632b2287bacd4342dbc9df5d"
+  integrity sha512-piYJB877bxkkAhGc1BU6JlpN6kcyfe/hWp34N7npngBvvmhHhefhGdAHhHz3oPvE/HhBCTwNMyipuIpZVJPkkQ==
+
+"@vtmn/css-price@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-price/-/css-price-0.8.0.tgz#c48a8246f8187ce1b6e4817bab70cac3d5b86152"
+  integrity sha512-chtL+Jh6qBV668s+h0Suw2iNuNE2SfRrwNbOwpWutqsnYn4K834tQtScZYbsrySV82CiAA6DM1+oJex26mjaKA==
+
+"@vtmn/css-progressbar@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-progressbar/-/css-progressbar-0.7.4.tgz#e3e134a75f9cf0ed2344ffdc94374c1d2effd056"
+  integrity sha512-ke1aFm7Sr7UpnPxxzD0hTowOKiRyVoDE30h/2Fg28ucub7kjPvzgeY0dB1ycBYsmvxtOvXU1jnn70W3Fb1EE3g==
+
+"@vtmn/css-quantity@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-quantity/-/css-quantity-0.10.1.tgz#1a00097b55af07622de69a96d6cf5ffd6bd26b49"
+  integrity sha512-Ii0zlxUbGs6s18GuAgQjbFBDJ8tSDzwiz3cq1+DCyTmTJ95j5fg7A+fWtbPTtdOmR4FOZSkN0H5gcKEuRZrWHQ==
+
+"@vtmn/css-radio-button@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-radio-button/-/css-radio-button-0.8.5.tgz#635c4c78959f942c2fe54b8ff102fe0bd0840376"
+  integrity sha512-8rfQ0EJyYxEWywLPodfCW06dGPM8lnlzH2QU3Ypbnelt/mOl6KTrzZzd9Re++FBrgLK9vE82SeBvP8Tmm9SQgw==
+
+"@vtmn/css-rating@^0.5.23":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-rating/-/css-rating-0.5.23.tgz#9a3c2930f3ba43481f36869ad86814aff5590c17"
+  integrity sha512-YMqkOpYtXlm/NeN5e3mVB5NgyfyyR5b2AoYO/xVSp1xdjGM3xVQA/l0BJbPHoRyTvR03Jv5eCYf8jQXXFTrveQ==
+  dependencies:
+    "@vtmn/icons" "^0.21.8"
+
+"@vtmn/css-search@^0.7.23":
+  version "0.7.23"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-search/-/css-search-0.7.23.tgz#bff187f7af9a99037e1949ccc32783ea61fdaba1"
+  integrity sha512-EK5YmA8HIoxVnrnfn/uksmp24ThawFtf1xXA/BIZ33ajx3PADb30/njdUS4PgguE4G1/ZQrNY9x1ntV95KGvxw==
+  dependencies:
+    "@vtmn/icons" "^0.21.8"
+
+"@vtmn/css-select@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-select/-/css-select-0.9.0.tgz#7491428d0f4a065c021b9a8b4fcf62e57c8f701b"
+  integrity sha512-rrzSA5WfYa7f07H6vQCCJEjRP16pghnaeXSi/23Ax6EDi65NzLAvvykz18JQ52JKap0Qf97HJwhq8JbNjS2Yxg==
+
+"@vtmn/css-skeleton@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-skeleton/-/css-skeleton-0.5.4.tgz#bbf249a161253f0971a6f81ee961428658b59072"
+  integrity sha512-jkA25vnx6mO4ciSN3ZhNC62fQkuUI7FHc8WGvzOQ5wbo8EM5hbGNMLCIBiIZJ13CeRSqnLKje7QsIpZ9ENARjA==
+
+"@vtmn/css-snackbar@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-snackbar/-/css-snackbar-0.7.4.tgz#42be424e31d1fa64fe08beb4dc5a291471714089"
+  integrity sha512-5Knmi6lZEFH8S+0SeBfoAA4S/jCZZl332CYpZ0LdiyFlwjIJCPkttpnBWIRz0CncaDZ1eKGDS9qf6vXUKD210w==
+
+"@vtmn/css-tabs@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-tabs/-/css-tabs-0.7.5.tgz#eeeb73357addc66b24cd94c4a85fca419bfee2b4"
+  integrity sha512-ROooTjfVTPBf4eCtcya2SacM74/ByBFmEfFbq9iTcJgBTDnlY45nwtbNRZZwHCGNxl69cRU8u63f6RX3IgsCIw==
+
+"@vtmn/css-tag@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-tag/-/css-tag-0.8.0.tgz#1929a6b08557c41a36191f856b81aee1a6a96724"
+  integrity sha512-vBkI7C3MGUu09U/0WlcUg0n4+JTSPgbWpv2Xvzfy8KvCQo3i+b9XWgO9Do5HXIOlVSt4PZuT4t0qxp36jZgmYA==
+
+"@vtmn/css-tailwind-preset@^0.35.56":
+  version "0.35.56"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-tailwind-preset/-/css-tailwind-preset-0.35.56.tgz#067c8099d25dd9928590ba3fcb29e4543e168ccc"
+  integrity sha512-H2MIPaSjeqCPeJtIdPvAa9qJIS1CrEq7nZTXjVWYj7e32Cuhegy8do2yKphpgcxJm7yk5d+yeWAdakv5hax/VA==
+
+"@vtmn/css-text-input@^0.17.4":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-text-input/-/css-text-input-0.17.4.tgz#8da24e668fe63426697f252e4a20864a97014005"
+  integrity sha512-ox9DwlbtMdN07mPAdOGrxiSvZThr3HHU9GoSUBdulx4LLcme6c+q8LV/nLFsa+pS/d00Z5nkKtBrENc8g1uEHQ==
+
+"@vtmn/css-toast@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-toast/-/css-toast-0.7.4.tgz#d2770380a48ad244bd9434a3fadd064e72f80b1e"
+  integrity sha512-qBnyFbJRJTiIQOpPMzKnR6RcBU1y5XXsvIFYcawewdxB8a5/c7W68In3p7hz1cxyB0AL+XABwjqDcdnPeIF9Gg==
+
+"@vtmn/css-toggle@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-toggle/-/css-toggle-0.8.4.tgz#b0391856be7a616e6040ae06c3f994ce598036b6"
+  integrity sha512-CRi1I0zg3cC7H3iWHxk2TX+UDwHbpQ9+2sm6IdM1O+HGQXUjuTF66FpcSnSLWhoXwvr9vU45yP5401LwsNC+bw==
+
+"@vtmn/css-tooltip@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-tooltip/-/css-tooltip-0.8.4.tgz#aeeb24e4bf8ff3089eca6bcd9697e6add1cd0e47"
+  integrity sha512-4Kd+sEhpoIEd7F4qvtJoaW8gPAxpyvC7qBfi5gzotLloDkqmPTygsXE3y7JUx8bkr2x0jUeTt3GfsfH5lzoqAg==
+
+"@vtmn/css-utilities@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css-utilities/-/css-utilities-0.4.4.tgz#74c21e91de340b7359ba28314006e4aea5062f15"
+  integrity sha512-XVpcLNSwXWLC0Ct1Os/3JqxFJutGO7tdUiouiVmo3kvGRVN5MWc1bPeEqr5RWbw7VehqqZIQmDwsd2fC4LUkKw==
+
+"@vtmn/css@^0.96.4":
+  version "0.96.4"
+  resolved "https://registry.yarnpkg.com/@vtmn/css/-/css-0.96.4.tgz#78ec614eeafed9ca4a2eff87e4590915c4ac0352"
+  integrity sha512-V/NF26JGC1VtkDgYu624VUY/rwEs5F2xdrCNOt0ALCV/WNLbwxCc0jASktXLAZRmr2islt0dCGQvyN0gqCoh+g==
+
+"@vtmn/icons@^0.21.8":
+  version "0.21.8"
+  resolved "https://registry.yarnpkg.com/@vtmn/icons/-/icons-0.21.8.tgz#d907f4df12c6c7b5c9bd0124e637425a090ba658"
+  integrity sha512-CKmpXx/KyHbEplvRv86vTwaeY5H2MT8M+tAB+mrVdzvnWA6Z5PFaC47jLmQW0y/XHgD10muvyo2MCeLFE4P+fA==
+
 "@vue/babel-helper-vue-jsx-merge-props@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.4.0.tgz#8d53a1e21347db8edbe54d339902583176de09f2"


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in detail. -->
We upgrade our packages to a stable version for each `1.x.xù.
The idea behind this is to mark the fact that Vitamin now considers itself stable and this is related to the decision to build a new, more modern, accessibility-aware, design token-based and right-to-left compatible implementation.

There is no breaking change, it's just a switch from version `0.x.x` to `1.x.x`.

Technically, with Lerna it is impossible to bump automatically from `0.x.x` to `1.x.x` via a simple commit message following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) with "BREAKING CHANGE" because it is a `0.x.x` and technically, it can break at each minor version change too, that's why this PR proposes to bumper manually all packages in 1.0.0. So they will once be merged PR create 1.1.0 releases on all of our packages `@vtmn/xxx`.

Thanks

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
