### PR TITLE
feat(@vtmn/svelte): manage height parameter of `VtmnSkeleton` component

### DIFF
--- a/packages/showcases/core/csf/components/structure/skeleton.csf.js
+++ b/packages/showcases/core/csf/components/structure/skeleton.csf.js
@@ -18,13 +18,13 @@ export const argTypes = {
       min: 0,
     },
   },
-  unit: {
-    type: { name: 'string', required: false },
-    description: 'Unit of the width.',
-    defaultValue: '%',
+  height: {
+    type: { name: 'number', required: false },
+    description: 'Height of the skeleton.',
+    defaultValue: undefined,
     control: {
-      type: 'select',
-      options: ['%', 'em', 'rem', 'vw', 'ch', 'px'],
+      type: 'number',
+      min: 0,
     },
   },
   shape: {

--- a/packages/showcases/svelte/stories/components/structure/VtmnSkeleton/VtmnSkeleton.stories.svelte
+++ b/packages/showcases/svelte/stories/components/structure/VtmnSkeleton/VtmnSkeleton.stories.svelte
@@ -26,7 +26,7 @@
   <div class="post-example">
     <VtmnSkeleton shape="avatar" width="20%" />
     <div class="post-example_body">
-      <VtmnSkeleton shape="line" width="55%" />
+      <VtmnSkeleton shape="line" width="55%" height="2em" />
       <p class="vtmn-mt-2">
         <VtmnSkeleton shape="line" width="84%" />
         <VtmnSkeleton shape="line" width="90%" />

--- a/packages/showcases/svelte/stories/components/structure/VtmnSkeleton/VtmnSkeleton.stories.svelte
+++ b/packages/showcases/svelte/stories/components/structure/VtmnSkeleton/VtmnSkeleton.stories.svelte
@@ -24,14 +24,14 @@
 
 <Story name="With avatar" let:args>
   <div class="post-example">
-    <VtmnSkeleton shape="avatar" width="20" />
+    <VtmnSkeleton shape="avatar" width="20%" />
     <div class="post-example_body">
-      <VtmnSkeleton shape="line" width="55" />
+      <VtmnSkeleton shape="line" width="55%" />
       <p class="vtmn-mt-2">
-        <VtmnSkeleton shape="line" width="84" />
-        <VtmnSkeleton shape="line" width="90" />
-        <VtmnSkeleton shape="line" width="83" />
-        <VtmnSkeleton shape="line" width="60" />
+        <VtmnSkeleton shape="line" width="84%" />
+        <VtmnSkeleton shape="line" width="90%" />
+        <VtmnSkeleton shape="line" width="83%" />
+        <VtmnSkeleton shape="line" width="60%" />
       </p>
     </div>
   </div>
@@ -41,12 +41,12 @@
   <div id="skeleton-card-container">
     <VtmnCard class="skeleton-card">
       <svelte:fragment slot="img">
-        <VtmnSkeleton class="skeleton-card-image" width="100" />
+        <VtmnSkeleton class="skeleton-card-image" width="100%" />
       </svelte:fragment>
 
       <svelte:fragment slot="content">
-        <VtmnSkeleton width="95" />
-        <VtmnSkeleton width="70" />
+        <VtmnSkeleton width="95%" />
+        <VtmnSkeleton width="70%" />
       </svelte:fragment>
     </VtmnCard>
   </div>

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -1,24 +1,13 @@
 <script>
   import { cn } from '../../../utils/classnames';
-  import {
-    VTMN_SKELETON_SHAPE,
-    VTMN_SKELETON_UNIT,
-    VTMN_SKELETON_DEFAULT_UNIT,
-    VTMN_SKELETON_DEFAULT_WIDTH,
-  } from './enums';
+  import { VTMN_SKELETON_SHAPE, VTMN_SKELETON_DEFAULT_WIDTH } from './enums';
   import { objectToStyle } from '../../../utils/style';
 
   /**
-   * @type {number} Width applied on the skeleton.
-   * @defaultValue 100
+   * @type {string} Width applied on the skeleton.
+   * @defaultValue 100%
    */
   export let width = VTMN_SKELETON_DEFAULT_WIDTH;
-
-  /**
-   * @type {'%'|'rem'|'em'|'px'|'vw'|'ch'} Unit applied on the width.
-   * @defaultValue %
-   */
-  export let unit = VTMN_SKELETON_DEFAULT_UNIT;
 
   /**
    * @type {'line' | 'avatar' } Variant of the shape.
@@ -39,21 +28,8 @@
     className,
   );
 
-  let computedUnit;
-  let computedWidth;
-
-  $: {
-    if (width < 0 || !Object.values(VTMN_SKELETON_UNIT).includes(unit)) {
-      computedWidth = VTMN_SKELETON_DEFAULT_WIDTH;
-      computedUnit = VTMN_SKELETON_DEFAULT_UNIT;
-    } else {
-      computedWidth = width;
-      computedUnit = unit;
-    }
-  }
-
   $: componentStyle = objectToStyle({
-    '--skeleton-width': `${computedWidth}${computedUnit}`,
+    '--skeleton-width': width,
   });
 </script>
 

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/VtmnSkeleton.svelte
@@ -10,6 +10,11 @@
   export let width = VTMN_SKELETON_DEFAULT_WIDTH;
 
   /**
+   * @type {string} Height applied on the skeleton.
+   */
+  export let height = undefined;
+
+  /**
    * @type {'line' | 'avatar' } Variant of the shape.
    * @defaultValue line
    */
@@ -25,11 +30,13 @@
     'vtmn-skeleton',
     shape && `vtmn-skeleton_${shape}`,
     width && `skeleton-width`,
+    height && `skeleton-height`,
     className,
   );
 
   $: componentStyle = objectToStyle({
     '--skeleton-width': width,
+    '--skeleton-height': height,
   });
 </script>
 
@@ -39,5 +46,9 @@
   @import '@vtmn/css-skeleton';
   .skeleton-width {
     width: var(--skeleton-width, 100%);
+  }
+
+  .skeleton-height {
+    height: var(--skeleton-height);
   }
 </style>

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/enums.js
@@ -6,14 +6,4 @@ export const VTMN_SKELETON_SHAPE = {
   AVATAR: 'avatar',
 };
 
-export const VTMN_SKELETON_UNIT = {
-  EM: 'em',
-  REM: 'rem',
-  VW: 'vw',
-  CH: 'ch',
-  PERCENT: '%',
-  PX: 'px',
-};
-
-export const VTMN_SKELETON_DEFAULT_WIDTH = 100;
-export const VTMN_SKELETON_DEFAULT_UNIT = VTMN_SKELETON_UNIT.PERCENT;
+export const VTMN_SKELETON_DEFAULT_WIDTH = '100%';

--- a/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnSkeleton/test/vtmnSkeleton.spec.js
@@ -23,8 +23,8 @@ describe('VtmnSkeleton', () => {
     expect(getSkeleton(container)).toHaveClass('vtmn-skeleton_avatar');
   });
 
-  test("Should have a width 100% if width = '100'", () => {
-    const { container } = render(VtmnSkeleton, { width: '100' });
+  test("Should have a width 100% if width = '100%'", () => {
+    const { container } = render(VtmnSkeleton, { width: '100%' });
     expect(getSkeleton(container)).toHaveClass('skeleton-width');
     expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
   });
@@ -45,17 +45,7 @@ describe('VtmnSkeleton', () => {
   });
 
   test('Should change the unit', () => {
-    const { container } = render(VtmnSkeleton, { unit: 'px' });
+    const { container } = render(VtmnSkeleton, { width: '100px' });
     expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100px');
-  });
-
-  test('Should set the unit as % if unit not found', () => {
-    const { container } = render(VtmnSkeleton, { unit: 'foo', width: 50 });
-    expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
-  });
-
-  test('Should set the width as 0 if width are negative', () => {
-    const { container } = render(VtmnSkeleton, { width: -1, unit: 'px' });
-    expect(getSkeleton(container)).toHaveStyle('--skeleton-width:100%');
   });
 });

--- a/packages/sources/svelte/src/utils/style.js
+++ b/packages/sources/svelte/src/utils/style.js
@@ -5,5 +5,6 @@
  */
 export const objectToStyle = (obj) =>
   Object.entries(obj)
+    .filter(([, value]) => value != undefined)
     .map(([key, value]) => `${key}:${value}`)
     .join(';');


### PR DESCRIPTION
## Changes description
`unit` has non-sense to be managed inside this component, we should instead rely on CSS API instead of managing all possible unit values inside our components. 
If the value is not correct, CSS will manage it its way. 

from `<VtmnSkeleton width="100" />` to `<VtmnSkeleton width="100%" />` or `<VtmnSkeleton width="100px" />`


Also add a `height` parameter which follows this same logic too. 
`<VtmnSkeleton width="100%" height="2em" />`

Note: this should be done in other implementations too (React, Vue)

## Context
Closes https://github.com/Decathlon/vitamin-web/issues/1403

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes

## Other information

BREAKING CHANGE: remove `unit` from `VtmnSkeleton`, it should now be passed in the `width` or `height` directly
