### PR TITLE
fix(@vtmn/react): remove default label value in `VtmnDropdown`

### DIFF
--- a/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
+++ b/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
@@ -37,7 +37,7 @@ export interface VtmnDropdownProps
 }
 
 export const VtmnDropdown = ({
-  label = 'Label',
+  label = undefined,
   summary = 'Dropdown',
   disabled = false,
   className,
@@ -47,7 +47,7 @@ export const VtmnDropdown = ({
 }: VtmnDropdownProps) => {
   return (
     <div className={`vtmn-dropdown ${className}`} aria-disabled={disabled}>
-      <label htmlFor={props['id']}>{label}</label>
+      {label && <label htmlFor={props['id']}>{label}</label>}
       <details open={disabled ? false : undefined}>
         <summary aria-labelledby={props['id']}>{summary}</summary>
         <div


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

This P.R aims to solve  #1399 .

VtmnDropdown's label has been set  to undefined by default to match the component's specification : 
![image](https://user-images.githubusercontent.com/20931885/228043181-b56886b2-e090-4109-bb8a-d5ea3cd3d1e8.png)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [X] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [X] Check your code additions will fail neither code linting checks.
- [X] I have reviewed the submitted code.
- [X] I have tested on related showcases.
- [X] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
