### PR TITLE
feat(@vtmn/react, @vtmn/vue): manage height parameter of `VtmnSkeleton` component

### DIFF
--- a/packages/showcases/core/csf/components/structure/skeleton.csf.js
+++ b/packages/showcases/core/csf/components/structure/skeleton.csf.js
@@ -10,21 +10,19 @@ export const parameters = {
 
 export const argTypes = {
   width: {
-    type: { name: 'number', required: false },
+    type: { name: 'string', required: false },
     description: 'Width of the skeleton.',
-    defaultValue: 100,
+    defaultValue: '100%',
     control: {
-      type: 'number',
-      min: 0,
+      type: 'text',
     },
   },
   height: {
-    type: { name: 'number', required: false },
+    type: { name: 'string', required: false },
     description: 'Height of the skeleton.',
     defaultValue: undefined,
     control: {
-      type: 'number',
-      min: 0,
+      type: 'text',
     },
   },
   shape: {

--- a/packages/sources/react/src/components/structure/VtmnSkeleton/VtmnSkeleton.tsx
+++ b/packages/sources/react/src/components/structure/VtmnSkeleton/VtmnSkeleton.tsx
@@ -6,10 +6,15 @@ import { VtmnSkeletonShape } from './types';
 export interface VtmnSkeletonProps
   extends React.ComponentPropsWithoutRef<'span'> {
   /**
-   * Width of the skeleton (in percentage)..
-   * @defaultValue 100
+   * Width of the skeleton
+   * @defaultValue 100%
    */
-  width?: number;
+  width?: string;
+
+  /**
+   * Height of the skeleton
+   */
+  height?: string;
 
   /**
    * Define the type of shape.
@@ -19,7 +24,8 @@ export interface VtmnSkeletonProps
 }
 
 export const VtmnSkeleton = ({
-  width = 100,
+  width = '100%',
+  height,
   shape = 'line',
   className,
   ...props
@@ -27,7 +33,7 @@ export const VtmnSkeleton = ({
   return (
     <span
       className={clsx('vtmn-skeleton', `vtmn-skeleton_${shape}`, className)}
-      style={{ width: `${width}%` }}
+      style={{ width, height }}
       {...props}
     ></span>
   );

--- a/packages/sources/vue/src/components/structure/VtmnSkeleton/VtmnSkeleton.vue
+++ b/packages/sources/vue/src/components/structure/VtmnSkeleton/VtmnSkeleton.vue
@@ -8,9 +8,11 @@ export default /*#__PURE__*/ defineComponent({
   inheritAttrs: false,
   props: {
     width: {
-      type: Number as PropType<number>,
-      default: 0,
-      validator: (val: number) => val >= 0 && val <= 100,
+      type: String as PropType<string>,
+      default: '100%',
+    },
+    height: {
+      type: String as PropType<string>,
     },
     shape: {
       type: String as PropType<VtmnSkeletonShape>,
@@ -26,7 +28,8 @@ export default /*#__PURE__*/ defineComponent({
         [`vtmn-skeleton_${props.shape}`]: props.shape,
       })),
       styles: computed(() => ({
-        width: `${props.width}%`,
+        width: props.width,
+        height: props.height,
       })),
     };
   },


### PR DESCRIPTION
## Changes description
`unit` has non-sense to be managed inside this component, we should instead rely on CSS API instead of managing all possible unit values inside our components. 
If the value is not correct, CSS will manage it its way. 


from `<VtmnSkeleton width="100" />` to `<VtmnSkeleton width="100%" />` or `<VtmnSkeleton width="100px" />`

Also add a `height` parameter which follows this same logic too. 
`<VtmnSkeleton width="100%" height="2em" />`

## Context
Closes https://github.com/Decathlon/vitamin-web/issues/1403

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes

## Other information

Linked to https://github.com/Decathlon/vitamin-web/pull/1404 (svelte impl)

BREAKING CHANGE: remove `unit` from `VtmnSkeleton`, it should now be passed in the `width` or `height` directly
