### PR TITLE
fix(@vtmn/svelte, @vtmn/vue, @vtmn/react): interactive `VtmnRating` have duplicate `$$restProps`

### DIFF
--- a/packages/sources/react/src/components/indicators/VtmnRating/VtmnRating.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnRating/VtmnRating.tsx
@@ -105,7 +105,7 @@ export const VtmnRating = ({
         className,
       )}
       aria-disabled={disabled}
-      {...props}
+      {...(readonly && props)}
     >
       {/**
        * Interactive mode
@@ -116,6 +116,7 @@ export const VtmnRating = ({
           aria-label="Rate the article"
           role="radiogroup"
           data-rating={position}
+          {...props}
         >
           {Array.from(Array(5).keys()).map((index) => (
             <React.Fragment key={`rating-${index + 1}`}>

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/VtmnRating.svelte
@@ -72,7 +72,11 @@
   $: starsCnt = compact && readonly ? 1 : 5;
 </script>
 
-<div class={componentClass} aria-disabled={disabled} {...$$restProps}>
+<div
+  class={componentClass}
+  aria-disabled={disabled}
+  {...readonly && $$restProps}
+>
   {#if readonly}
     {#each Array(starsCnt) as _, index}
       {@const position = index + 1}

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
@@ -354,6 +354,16 @@ describe('VtmnRating', () => {
       expect(inputs[1].checked).toEqual(true);
       expect(getInteractive(container)).toHaveAttribute('data-rating', '2');
     });
+
+    test('Should not contains restProps many times', () => {
+      const { getAllByLabelText } = render(VtmnRating, {
+        name: 'rating',
+        'aria-label': 'test-rating',
+        readonly: false,
+        value: 0,
+      });
+      expect(getAllByLabelText('test-rating').length).toEqual(1);
+    });
   });
 
   describe('computeRatingFill', () => {

--- a/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
+++ b/packages/sources/svelte/src/components/indicators/VtmnRating/test/VtmnRating.spec.js
@@ -355,7 +355,7 @@ describe('VtmnRating', () => {
       expect(getInteractive(container)).toHaveAttribute('data-rating', '2');
     });
 
-    test('Should not contains restProps many times', () => {
+    test('Should not have repeated restProps', () => {
       const { getAllByLabelText } = render(VtmnRating, {
         name: 'rating',
         'aria-label': 'test-rating',

--- a/packages/sources/vue/src/components/indicators/VtmnRating/VtmnRating.vue
+++ b/packages/sources/vue/src/components/indicators/VtmnRating/VtmnRating.vue
@@ -67,12 +67,13 @@ export default /*#__PURE__*/ defineComponent({
 </script>
 
 <template>
-  <div :class="classes" :aria-disabled="disabled" v-bind="$attrs">
+  <div :class="classes" :aria-disabled="disabled" v-bind="readonly && $attrs">
     <div
       v-if="!readonly"
       class="vtmn-rating--interactive"
       aria-label="Rate this"
       role="radiogroup"
+      v-bind="$attrs"
     >
       <template v-for="i in 5" :key="i">
         <input


### PR DESCRIPTION
Closes #1385 

## Changes description
Add on the `VtmnRating` svelte component a check on the restProps in order to not apply it on the root level of the component and under if the rating is interactive.
No changes on the class, only on props like aria-label etc ...

## Context
In some case, if the component is interactive, the class are applied twice, on the root level and under.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

Tested on svelte / react / vue on storybook.