### PR TITLE
fix(@vtmn/react): support style prop for `VtmnDropdown` component

### DIFF
--- a/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
+++ b/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
@@ -40,7 +40,7 @@ export const VtmnDropdown = ({
   label = undefined,
   summary = 'Dropdown',
   disabled = false,
-  className,
+  className = '',
   style,
   children,
   onChange,

--- a/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
+++ b/packages/sources/react/src/components/actions/VtmnDropdown/VtmnDropdown.tsx
@@ -41,12 +41,17 @@ export const VtmnDropdown = ({
   summary = 'Dropdown',
   disabled = false,
   className,
+  style,
   children,
   onChange,
   ...props
 }: VtmnDropdownProps) => {
   return (
-    <div className={`vtmn-dropdown ${className}`} aria-disabled={disabled}>
+    <div
+      className={`vtmn-dropdown ${className}`}
+      aria-disabled={disabled}
+      style={style}
+    >
       {label && <label htmlFor={props['id']}>{label}</label>}
       <details open={disabled ? false : undefined}>
         <summary aria-labelledby={props['id']}>{summary}</summary>


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Closes #1400 (thanks @jdeca-decat for reporting this)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
For your information and to avoid breaking changes for people that already uses `VtmnDropdown`, I didn't spread all the `props` object. I preferred to only pass through the `style` prop.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
