### PR TITLE
fix(@vtmn/svelte, @vtmn/react, @vtmn/vue): `VtmnNavbarLink` force rel noopener noreferrer if target blank

### DIFF
--- a/packages/sources/react/src/components/actions/VtmnLink/VtmnLink.tsx
+++ b/packages/sources/react/src/components/actions/VtmnLink/VtmnLink.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import '@vtmn/css-link/dist/index-with-vars.css';
 import clsx from 'clsx';
 import { VtmnLinkSize } from './types';
+import { computeRel } from '@/utils/link';
 
 export interface VtmnLinkProps extends React.ComponentPropsWithoutRef<'a'> {
   /**
@@ -47,17 +48,7 @@ export const VtmnLink = ({
   className,
   ...props
 }: VtmnLinkProps) => {
-  const relAttrValues = Array.from(
-    new Set([
-      // If component has a given "rel" attribute, keep values
-      ...(props?.rel?.split(' ') ?? []),
-      // If comp has "target" set to "blank", add some values
-      ...(props?.target === '_blank' ? ['noopener', 'noreferrer'] : []),
-    ]),
-  )
-    .join(' ')
-    .trim();
-
+  const relAttrValues = props?.target && computeRel(props.target, props.rel);
   return (
     <a
       className={clsx(

--- a/packages/sources/react/src/components/navigation/VtmnNavbarLink/VtmnNavbarLink.tsx
+++ b/packages/sources/react/src/components/navigation/VtmnNavbarLink/VtmnNavbarLink.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import clsx from 'clsx';
 import '@vtmn/css-navbar/dist/index-with-vars.css';
 import { VtmnIcon } from '../../../guidelines/iconography/VtmnIcon';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
+import { computeRel } from '@/utils/link';
 
 export interface VtmnNavbarLinkProps
   extends React.ComponentPropsWithoutRef<'a'> {
@@ -38,15 +40,24 @@ export const VtmnNavbarLink = ({
   children,
   ...props
 }: VtmnNavbarLinkProps) => {
+  const relAttrValues = props?.target && computeRel(props.target, props.rel);
   return showLabel ? (
-    <a className={`vtmn-navbar_link ${className}`} {...props}>
+    <a
+      className={clsx('vtmn-navbar_link', className)}
+      {...props}
+      {...(relAttrValues && { rel: relAttrValues })}
+    >
       {children}
       <VtmnIcon value={icon} aria-hidden={true} />
       {label}
     </a>
   ) : (
     <a
-      className={`vtmn-navbar_link vtmn-navbar_link--icon-alone ${className}`}
+      className={clsx(
+        'vtmn-navbar_link',
+        'vtmn-navbar_link--icon-alone',
+        className,
+      )}
       {...props}
     >
       {children}

--- a/packages/sources/svelte/src/components/actions/VtmnLink/VtmnLink.svelte
+++ b/packages/sources/svelte/src/components/actions/VtmnLink/VtmnLink.svelte
@@ -56,9 +56,9 @@
   let computedRel = computeRel($$restProps['target'], $$restProps['rel']);
 </script>
 
-<a {href} class={componentClass} rel={computedRel} on:click {...$$restProps}
-  ><slot /></a
->
+<a {href} class={componentClass} on:click {...$$restProps} rel={computedRel}>
+  <slot />
+</a>
 
 <style lang="css">
   @import '@vtmn/css-link';

--- a/packages/sources/svelte/src/components/actions/VtmnLink/test/VtmnLink.spec.js
+++ b/packages/sources/svelte/src/components/actions/VtmnLink/test/VtmnLink.spec.js
@@ -75,6 +75,6 @@ describe('VtmnLink', () => {
     const { container } = render(VtmnLink, {
       props: { ...links, target: '_blank', rel: 'noopener' },
     });
-    expect(getLink(container)).toHaveAttribute('rel', 'noopener');
+    expect(getLink(container)).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });

--- a/packages/sources/svelte/src/components/navigation/VtmnNavbarLink/VtmnNavbarLink.svelte
+++ b/packages/sources/svelte/src/components/navigation/VtmnNavbarLink/VtmnNavbarLink.svelte
@@ -1,6 +1,7 @@
 <script>
   import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.svelte';
   import { cn } from '../../../utils/classnames';
+  import { computeRel } from '../../../utils/link';
 
   /** @restProps { a } */
 
@@ -37,12 +38,13 @@
     !showLabel && 'vtmn-navbar_link--icon-alone',
     className,
   );
+  let computedRel = computeRel($$restProps['target'], $$restProps['rel']);
 </script>
 
 <!-- svelte-ignore a11y-missing-attribute -->
 <!-- because href comes through $$restProps -->
 {#if showLabel}
-  <a class={componentClass} {...$$restProps}>
+  <a class={componentClass} {...$$restProps} rel={computedRel}>
     <slot />
     <VtmnIcon value={icon} aria-hidden="true" />
     {label}

--- a/packages/sources/vue/src/components/actions/VtmnLink/VtmnLink.vue
+++ b/packages/sources/vue/src/components/actions/VtmnLink/VtmnLink.vue
@@ -2,6 +2,7 @@
 import '@vtmn/css-link/dist/index-with-vars.css';
 import { reactive, computed, defineComponent, PropType } from 'vue';
 import { VtmnLinkSize } from './types';
+import { computeRel } from '@/utils/link';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnLink',
@@ -29,20 +30,7 @@ export default /*#__PURE__*/ defineComponent({
   setup(props, { attrs }) {
     props = reactive(props);
 
-    let computedRel = String(attrs['rel']);
-
-    // If target is set to '_blank', rel should be at least
-    // set to 'noopener noreferrer'
-    if (String(attrs['target']) === '_blank') {
-      const currentRel = attrs['rel'] ?? '';
-      computedRel = Array.from(
-        new Set(String(currentRel).split(' '))
-          .add('noopener')
-          .add('noreferrer'),
-      )
-        .join(' ')
-        .trim();
-    }
+    let computedRel = (attrs['target'] && computeRel(<string>attrs['target'], <string | undefined>attrs['rel'])) || '';
 
     return {
       classes: computed(() => ({

--- a/packages/sources/vue/src/components/navigation/VtmnNavbarLink/VtmnNavbarLink.vue
+++ b/packages/sources/vue/src/components/navigation/VtmnNavbarLink/VtmnNavbarLink.vue
@@ -3,6 +3,7 @@ import '@vtmn/css-navbar/dist/index-with-vars.css';
 import { VitamixId } from '@vtmn/icons/dist/vitamix/font/vitamix';
 import { reactive, computed, defineComponent, PropType } from 'vue';
 import VtmnIcon from '../../../guidelines/iconography/VtmnIcon/VtmnIcon.vue';
+import { computeRel } from '@/utils/link';
 
 export default /*#__PURE__*/ defineComponent({
   name: 'VtmnNavbarLink',
@@ -20,8 +21,9 @@ export default /*#__PURE__*/ defineComponent({
       default: true,
     },
   },
-  setup(props) {
+  setup(props, { attrs }) {
     props = reactive(props);
+    let computedRel = (attrs['target'] && computeRel(<string>attrs['target'], <string | undefined>attrs['rel'])) || '';
     return {
       styleObject: {
         color: 'inherit',
@@ -31,6 +33,7 @@ export default /*#__PURE__*/ defineComponent({
         'vtmn-navbar_link': true,
         'vtmn-navbar_link--icon-alone': !props.showLabel,
       })),
+      computedRel,
     };
   },
 });
@@ -38,13 +41,13 @@ export default /*#__PURE__*/ defineComponent({
 
 <template>
   <template v-if="showLabel">
-    <a :class="classes" v-bind="$attrs">
+    <a :class="classes" v-bind="$attrs" :rel="computedRel">
       <slot />
       <VtmnIcon :value="icon" aria-hidden="true" />{{ label }}</a
     >
   </template>
   <template v-else>
-    <a :class="classes" v-bind="$attrs">
+    <a :class="classes" v-bind="$attrs" :rel="computedRel">
       <slot />
       <VtmnIcon :value="icon" aria-hidden="true" />
       <span class="vtmn-sr-only">{{ label }}</span>


### PR DESCRIPTION
## Changes description

Compute the rel on the `VtmnLink` and `VtmnNavbarLink` components.
Fix issue with the class on the `VtmnNavbarLink` which can displayed `class="undefined"`

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
