### PR TITLE
feat(textinput): add custom label

### DIFF
--- a/packages/showcases/react/stories/components/forms/VtmnTextInput/VtmnTextInput.stories.tsx
+++ b/packages/showcases/react/stories/components/forms/VtmnTextInput/VtmnTextInput.stories.tsx
@@ -25,7 +25,21 @@ export default {
 
 const Template: Story = (args) => <VtmnTextInput {...args} />;
 
+const LabelComponent: Story = (args) => (
+  <VtmnTextInput
+    identifier="comp"
+    labelComponent={
+      <p>
+        Label <i>(Optionnal)</i>
+      </p>
+    }
+    {...args}
+  />
+);
+
 export const Overview = Template.bind({});
 Overview.args = {
   onIconClick: () => action('icon clicked'),
 };
+
+export const WithCustomLabel = LabelComponent.bind({});

--- a/packages/showcases/svelte/stories/components/forms/VtmnTextInput/VtmnTextInput.stories.svelte
+++ b/packages/showcases/svelte/stories/components/forms/VtmnTextInput/VtmnTextInput.stories.svelte
@@ -40,8 +40,13 @@
   {parameters}
 />
 
-<Template let:args>
+<Story name="Overview" args={textinputArgs} let:args>
   <VtmnTextInput {...args} />
-</Template>
-
-<Story name="Overview" args={textinputArgs} />
+</Story>
+<Story name="With custom label" args={textinputArgs} let:args>
+  <VtmnTextInput {...args}>
+    <p slot="labelComponent">
+      Label <i>(Optionnal)</i>
+    </p>
+  </VtmnTextInput>
+</Story>

--- a/packages/showcases/vue/stories/components/forms/VtmnTextInput/VtmnTextInput.stories.js
+++ b/packages/showcases/vue/stories/components/forms/VtmnTextInput/VtmnTextInput.stories.js
@@ -19,5 +19,14 @@ const Template = (args) => ({
   template: `<VtmnTextInput v-bind="args"/>`,
 });
 
+const LabelComponent = (args) => ({
+  components: { VtmnTextInput },
+  setup() {
+    return { args };
+  },
+  template: `<VtmnTextInput v-bind="args"><template #labelComponent><p>Label <i>(Optionnal)</i></p></template></VtmnTextInput>`,
+});
+
 export const Overview = Template.bind({});
 Overview.args = {};
+export const WithCustomLabel = LabelComponent.bind({});

--- a/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
+++ b/packages/sources/react/src/components/forms/VtmnTextInput/VtmnTextInput.tsx
@@ -18,6 +18,12 @@ type VtmnTextInputAdditionalProps = {
   labelText?: string;
 
   /**
+   * Label element for the input
+   * @type {JSX.Element}
+   */
+  labelComponent?: JSX.Element | JSX.Element[];
+
+  /**
    * Helper text to help the user
    * @type {string}
    * @defaultValue undefined
@@ -100,6 +106,7 @@ export const VtmnTextInput = React.forwardRef<
       onIconClick,
       labelClassName,
       labelProps,
+      labelComponent,
       ...props
     },
     ref,
@@ -107,13 +114,13 @@ export const VtmnTextInput = React.forwardRef<
     const { multiline, ...rest } = props;
     return (
       <>
-        {labelText && (
+        {(labelComponent || labelText) && (
           <label
             className={`vtmn-text-input_label ${labelClassName || ''}`}
             htmlFor={identifier}
             {...labelProps}
           >
-            {labelText}
+            {labelComponent || labelText}
           </label>
         )}
         {multiline ? (

--- a/packages/sources/svelte/src/components/forms/VtmnTextInput/VtmnTextInput.svelte
+++ b/packages/sources/svelte/src/components/forms/VtmnTextInput/VtmnTextInput.svelte
@@ -14,13 +14,13 @@
    * Label text linked to the input
    * @type {string}
    */
-  export let labelText;
+  export let labelText = undefined;
 
   /**
    * Plaholder of the input
    * @type {string}
    */
-  export let placeholder;
+  export let placeholder = undefined;
 
   /**
    * Whether input should be disabled or not
@@ -78,8 +78,14 @@
   );
 </script>
 
-{#if labelText}
-  <label class="vtmn-text-input_label" for={id}>{labelText}</label>
+{#if $$slots.labelComponent || labelText}
+  <label class="vtmn-text-input_label" for={id}>
+    {#if $$slots.labelComponent}
+      <slot name="labelComponent" />
+    {:else}
+      {labelText}
+    {/if}
+  </label>
 {/if}
 {#if multiline}
   <textarea

--- a/packages/sources/svelte/src/components/forms/VtmnTextInput/test/VtmnTextInput.spec.js
+++ b/packages/sources/svelte/src/components/forms/VtmnTextInput/test/VtmnTextInput.spec.js
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 
 import { render, fireEvent } from '@testing-library/svelte';
 import VtmnTextInput from '../VtmnTextInput.svelte';
+import VtmnTextInputSlot from './VtmnTextInputSlot.svelte';
 
 describe('VtmnTextInput', () => {
   const params = {
@@ -51,6 +52,18 @@ describe('VtmnTextInput', () => {
       expect(getTextLabel(container)).toHaveAttribute('for', 'text-input');
       expect(getTextInput(container)).toHaveAttribute('id', 'text-input');
     });
+
+    test('Should display the label component if labelComponent is defined', () => {
+      const { container, queryByText } = render(VtmnTextInputSlot, {
+        ...params,
+      });
+      expect(queryByText(/Label/)).toBeVisible();
+      expect(queryByText(/(Optionnal)/)).toBeVisible();
+      expect(queryByText(/Unit test label/i)).toBeNull();
+      expect(getTextLabel(container)).toHaveAttribute('for', 'text-input');
+      expect(getTextInput(container)).toHaveAttribute('id', 'text-input');
+    });
+
     test('Should display the placeholder', () => {
       const { container } = render(VtmnTextInput, { ...params });
       expect(getTextInput(container)).toHaveAttribute(

--- a/packages/sources/svelte/src/components/forms/VtmnTextInput/test/VtmnTextInputSlot.svelte
+++ b/packages/sources/svelte/src/components/forms/VtmnTextInput/test/VtmnTextInputSlot.svelte
@@ -1,0 +1,9 @@
+<script>
+  import VtmnTextInput from '../VtmnTextInput.svelte';
+</script>
+
+<VtmnTextInput {...$$restProps}>
+  <p slot="labelComponent">
+    Label <i>(Optionnal)</i>
+  </p>
+</VtmnTextInput>

--- a/packages/sources/vue/src/components/forms/VtmnTextInput/VtmnTextInput.vue
+++ b/packages/sources/vue/src/components/forms/VtmnTextInput/VtmnTextInput.vue
@@ -79,7 +79,8 @@ export default /*#__PURE__*/ defineComponent({
 
 <template>
   <label :v-if="labelText" class="vtmn-text-input_label" :for="identifier">
-    {{ labelText }}
+    <slot name="labelComponent" v-if="$slots.labelComponent" />
+    <template v-else>{{ labelText }}</template>
   </label>
   <textarea
     v-if="multiline"


### PR DESCRIPTION
## Changes description

Currently, we only have the ability to have a text as a label in the Input. More often than not, you want to put more things that needs to be customizable ( Optionnal text, tooltip icons etc )

Closes : #1428

## Context

Currently, it is impossible to convey more information to the user about the input. One of the most important aspects is the ability to tell if a field is required or not. 

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?

- No

