### PR TITLE
fix: convert breakpoints variables to values instead of strings

### DIFF
--- a/packages/sources/css/src/design-tokens/src/breakpoints.css
+++ b/packages/sources/css/src/design-tokens/src/breakpoints.css
@@ -1,10 +1,10 @@
 :root {
-  --vtmn-breakpoint_mobile-max: '599px';
-  --vtmn-breakpoint_tablet-min: '600px';
-  --vtmn-breakpoint_tablet-max: '899px';
-  --vtmn-breakpoint_small-desktop-min: '900px';
-  --vtmn-breakpoint_small-desktop-max: '1199px';
-  --vtmn-breakpoint_medium-desktop-min: '1200px';
-  --vtmn-breakpoint_medium-desktop-max: '1799px';
-  --vtmn-breakpoint_large-desktop-min: '1800px';
+  --vtmn-breakpoint_mobile-max: 599px;
+  --vtmn-breakpoint_tablet-min: 600px;
+  --vtmn-breakpoint_tablet-max: 899px;
+  --vtmn-breakpoint_small-desktop-min: 900px;
+  --vtmn-breakpoint_small-desktop-max: 1199px;
+  --vtmn-breakpoint_medium-desktop-min: 1200px;
+  --vtmn-breakpoint_medium-desktop-max: 1799px;
+  --vtmn-breakpoint_large-desktop-min: 1800px;
 }


### PR DESCRIPTION
## Changes description

Change value of Breakpoints design tokens from strings to values to be used in `var()`

## Context

[With Web Checkout](https://github.com/dktunited/web-checkout-front/pull/89), we try to rely the most on Vitamin design tokens. But i have an issue when using the breakpoints design tokens. Currently, they are strings and can't be used as value in `var()`

```css
/* Don't work */
--foo: "900px";
max-width: var(--foo);

/* Works */
--foo: 900px;
max-width: var(--foo);
```

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?

If these tokens are used as strings somewhere, it could be a breaking change.
But any others design tokens are values and not strings. I've checked in the codebase any use as strings but didn't found any, so it should not be a problem here
