### PR TITLE
fix: make open property of VtmnAccordion reactive

### DIFF
--- a/packages/sources/svelte/src/components/structure/VtmnAccordion/VtmnAccordion.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnAccordion/VtmnAccordion.svelte
@@ -41,7 +41,7 @@
   class={componentClass}
   aria-disabled={disabled}
   aria-expanded={open}
-  {open}
+  bind:open
   {...$$restProps}
 >
   <summary>


### PR DESCRIPTION
## Changes description

This is a bugfix to the VtmnAccordion component. The `open` prop was *binded* in the details element.

## Context

The previous implementation only allows us to pass the `open` prop down, but changes are not reflected. In particular, we cannot let the parent of the VtmnAccordion know when it is open and when not. So this is just a missing feature, but: there is also a bug in the previous implementation: the line `aria-expanded={open}` means that the `aria-expanded` property is always set to the initial value. It will never be changed.

When the accordion is closed, it does not have the `open` prop and we have `aria-expanded=false`, which is correct:

![Bildschirmfoto 2023-09-14 um 16 50 15](https://github.com/Decathlon/vitamin-web/assets/119947035/bd20a7fa-4e90-4867-bed2-e0abeb6472cd)

But when it is opened, the `open` prop is added, **but `aria-expanded=false` stays.**

![Bildschirmfoto 2023-09-14 um 16 51 12](https://github.com/Decathlon/vitamin-web/assets/119947035/c4fe8955-f61e-481f-b713-1dda4ef2321b)


This pull request fixes this bug.

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
- No