### PR TITLE
fix(@VtmnReact): allow badge component to have 0 as a value

### DIFF
--- a/packages/sources/react/src/components/indicators/VtmnBadge/VtmnBadge.tsx
+++ b/packages/sources/react/src/components/indicators/VtmnBadge/VtmnBadge.tsx
@@ -29,7 +29,7 @@ export const VtmnBadge = ({
       }`}
       {...props}
     >
-      {value && value > 99 ? '99+' : value || ''}
+      {value && value > 99 ? '99+' : value ?? ''}
     </span>
   );
 };


### PR DESCRIPTION
## Changes description
Badge doesn't accept 0 as a value, but instead it's showing an empty string
![image](https://github.com/Decathlon/vitamin-web/assets/144375/703561ad-04c2-4bf7-b48e-87b0b83ccd0f) ![image](https://github.com/Decathlon/vitamin-web/assets/144375/8e0418bd-47c6-4adb-86f9-1218f5f9259c)

## Context
It should accept 0 as a value as fixed here
<img width="37" alt="image" src="https://github.com/Decathlon/vitamin-web/assets/144375/942b6b57-b156-449c-93c7-b2ec853d54d1">

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [ ] I have tested on related showcases.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes
- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
