### PR TITLE
feat(`@vtmn/svelte`, `@vtmn/react`, `vtmn/vue`): use `VtmnAlert` as a component

### DIFF
--- a/packages/showcases/react/stories/components/overlays/VtmnAlert/VtmnAlert.stories.tsx
+++ b/packages/showcases/react/stories/components/overlays/VtmnAlert/VtmnAlert.stories.tsx
@@ -36,3 +36,14 @@ const OverviewTemplate: Story = (args) => {
 
 export const Overview = OverviewTemplate.bind({});
 Overview.args = {};
+
+const AlertItemTemplate: Story = (args) => {
+  return (
+    <div>
+      <VtmnAlert {...args} timeout={0} />
+    </div>
+  );
+};
+
+export const AlertItem = AlertItemTemplate.bind({});
+AlertItem.args = {};

--- a/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
@@ -34,6 +34,7 @@
     ariaLabelCloseButton: {
       type: { name: 'string', required: false },
       description: 'Aria label displayed for the close button',
+      defaultValue: 'Close alert',
       control: {
         type: 'text',
       },

--- a/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
@@ -1,12 +1,17 @@
 <script>
   import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
-  import { vtmnAlertStore, VtmnAlert, VtmnButton } from '@vtmn/svelte';
+  import {
+    vtmnAlertStore,
+    VtmnAlert,
+    VtmnButton,
+    VtmnAlertItem,
+  } from '@vtmn/svelte';
   import { parameters } from '@vtmn/showcase-core/csf/components/overlays/alert.csf';
   import README from '@vtmn/svelte/src/components/overlays/VtmnAlert/README.md';
 
   const argTypes = {
     title: {
-      type: { name: 'string', required: true },
+      type: { name: 'string' },
       description: 'Title of the modal',
       defaultValue: 'This is the title of the alert',
       control: { type: 'text' },
@@ -24,6 +29,13 @@
       defaultValue: false,
       control: {
         type: 'boolean',
+      },
+    },
+    ariaLabelButton: {
+      type: { name: 'string', required: false },
+      description: 'Aria label displayed for the close button',
+      control: {
+        type: 'text',
       },
     },
     variant: {
@@ -56,6 +68,7 @@
     on:click={() => {
       vtmnAlertStore.send({
         ...args,
+        ariaLabelButton: 'Close alert',
         'aria-labelledby': 'Storybook',
         'aria-describedby': args.variant,
       });
@@ -65,3 +78,19 @@
 </Template>
 
 <Story name="Overview" />
+
+<Story
+  name="Alert item"
+  args={{
+    timeout: undefined,
+    title: undefined,
+    description: undefined,
+    ariaLabelButton: 'Close alert',
+  }}
+  let:args
+>
+  <VtmnAlertItem {...args}>
+    <svelte:fragment slot="title">Slot title</svelte:fragment>
+    <svelte:fragment slot="description">Slot description</svelte:fragment>
+  </VtmnAlertItem>
+</Story>

--- a/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
@@ -82,9 +82,9 @@
 <Story
   name="Alert item"
   args={{
-    timeout: undefined,
     title: undefined,
     description: undefined,
+    timeout: 0,
     ariaLabelCloseButton: 'Close alert',
   }}
   let:args

--- a/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
+++ b/packages/showcases/svelte/stories/components/overlays/VtmnAlert/VtmnAlert.stories.svelte
@@ -31,7 +31,7 @@
         type: 'boolean',
       },
     },
-    ariaLabelButton: {
+    ariaLabelCloseButton: {
       type: { name: 'string', required: false },
       description: 'Aria label displayed for the close button',
       control: {
@@ -68,7 +68,7 @@
     on:click={() => {
       vtmnAlertStore.send({
         ...args,
-        ariaLabelButton: 'Close alert',
+        ariaLabelCloseButton: 'Close alert',
         'aria-labelledby': 'Storybook',
         'aria-describedby': args.variant,
       });
@@ -85,7 +85,7 @@
     timeout: undefined,
     title: undefined,
     description: undefined,
-    ariaLabelButton: 'Close alert',
+    ariaLabelCloseButton: 'Close alert',
   }}
   let:args
 >

--- a/packages/showcases/vue/stories/components/overlays/VtmnAlert/VtmnAlert.stories.js
+++ b/packages/showcases/vue/stories/components/overlays/VtmnAlert/VtmnAlert.stories.js
@@ -33,3 +33,18 @@ const Template = (args) => ({
 
 export const Overview = Template.bind({});
 Overview.args = {};
+
+const AlertItemTemplate = (args) => ({
+  components: { VtmnAlert },
+  setup() {
+    return {
+      args,
+    };
+  },
+  template: `<VtmnAlert v-bind="args" />`,
+});
+
+export const AlertItem = AlertItemTemplate.bind({});
+AlertItem.args = {
+  timeout: 0,
+};

--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -22,6 +22,11 @@ export interface VtmnAlertProps
   variant: VtmnAlertVariant;
 
   /**
+   * Aria label applied on the close button
+   */
+  ariaLabelButton: string;
+
+  /**
    * The alert callback close function
    * @type {function}
    */
@@ -33,6 +38,7 @@ export const VtmnAlert = ({
   title,
   message,
   onClose,
+  ariaLabelButton,
   className,
 }: VtmnAlertProps) => {
   return (
@@ -54,7 +60,7 @@ export const VtmnAlert = ({
               size="small"
               variant="ghost-reversed"
               iconAlone="close-line"
-              aria-label="Close toast"
+              aria-label={ariaLabelButton}
               onClick={onClose}
             ></VtmnButton>
           )}

--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -27,6 +27,12 @@ export interface VtmnAlertProps
   ariaLabelCloseButton: string;
 
   /**
+   * time (ms) before the alert disappears
+   * Set to 0 to keep the alert visible
+   */
+  timeout: number;
+
+  /**
    * The alert callback close function
    * @type {function}
    */
@@ -39,6 +45,7 @@ export const VtmnAlert = ({
   message,
   onClose,
   ariaLabelCloseButton,
+  timeout = 8000,
   className,
 }: VtmnAlertProps) => {
   return (
@@ -48,7 +55,7 @@ export const VtmnAlert = ({
       className={clsx(
         'vtmn-alert',
         `vtmn-alert_variant--${variant}`,
-        'show',
+        timeout > 0 && 'show',
         className,
       )}
     >

--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -44,7 +44,7 @@ export const VtmnAlert = ({
   title,
   message,
   onClose,
-  ariaLabelCloseButton,
+  ariaLabelCloseButton = 'Close alert',
   timeout = 8000,
   className,
 }: VtmnAlertProps) => {

--- a/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
+++ b/packages/sources/react/src/components/overlays/VtmnAlert/VtmnAlert.tsx
@@ -24,7 +24,7 @@ export interface VtmnAlertProps
   /**
    * Aria label applied on the close button
    */
-  ariaLabelButton: string;
+  ariaLabelCloseButton: string;
 
   /**
    * The alert callback close function
@@ -38,7 +38,7 @@ export const VtmnAlert = ({
   title,
   message,
   onClose,
-  ariaLabelButton,
+  ariaLabelCloseButton,
   className,
 }: VtmnAlertProps) => {
   return (
@@ -60,7 +60,7 @@ export const VtmnAlert = ({
               size="small"
               variant="ghost-reversed"
               iconAlone="close-line"
-              aria-label={ariaLabelButton}
+              aria-label={ariaLabelCloseButton}
               onClick={onClose}
             ></VtmnButton>
           )}

--- a/packages/sources/svelte/src/components/index.js
+++ b/packages/sources/svelte/src/components/index.js
@@ -27,6 +27,7 @@ export { default as VtmnTabsItem } from './navigation/VtmnTabsItem/VtmnTabsItem.
 
 // Overlays
 export { default as VtmnAlert } from './overlays/VtmnAlert/VtmnAlert.svelte';
+export { default as VtmnAlertItem } from './overlays/VtmnAlert/VtmnAlertItem.svelte';
 export { vtmnAlertStore } from './overlays/VtmnAlert/vtmnAlertStore';
 export { default as VtmnModal } from './overlays/VtmnModal/VtmnModal.svelte';
 export { default as VtmnPopover } from './overlays/VtmnPopover/VtmnPopover.svelte';

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -3,6 +3,12 @@
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { cn } from '../../../utils/classnames';
   import { VTMN_ALERT_VARIANT } from './enums';
+  import { uuid } from '../../../utils/math';
+
+  /**
+   * @type {string} unique id suffix for the component
+   */
+  export let id = uuid();
 
   /**
    * @type {'info'|'success'|'danger'|'warning'} variant of the alert
@@ -29,8 +35,10 @@
 
   /**
    * @type {number} time (ms) before the alert disappears
+   * Can't be above 8000ms.
+   * Set to 0 to keep the alert visible
    */
-  export let timeout = undefined;
+  export let timeout = 8000;
 
   /**
    * @type {string} aria label on the button
@@ -52,7 +60,7 @@
   onMount(_setTimeout);
   $: componentClass = cn(
     'vtmn-alert',
-    timeout && 'show',
+    timeout > 0 && 'show',
     variant && `vtmn-alert_variant--${variant}`,
     className,
   );
@@ -60,7 +68,7 @@
 
 <div class={componentClass} role="alert" tabindex="-1" {...$$restProps}>
   <div class="vtmn-alert_content" role="document">
-    <div id="alert-title" class="vtmn-alert_content-title">
+    <div id="alert-title-{id}" class="vtmn-alert_content-title">
       {#if $$slots.title}
         <slot name="title" />
       {:else}
@@ -77,13 +85,13 @@
       {/if}
     </div>
     {#if description || $$slots.description}
-      <p id="alert-text" class="vtmn-alert_content-description">
+      <span id="alert-text-{id}" class="vtmn-alert_content-description">
         {#if $$slots.description}
           <slot name="description" />
         {:else}
           {description}
         {/if}
-      </p>
+      </span>
     {/if}
   </div>
 </div>

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -3,12 +3,6 @@
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { cn } from '../../../utils/classnames';
   import { VTMN_ALERT_VARIANT } from './enums';
-  import { uuid } from '../../../utils/math';
-
-  /**
-   * @type {string} unique id suffix for the component
-   */
-  export let id = uuid();
 
   /**
    * @type {'info'|'success'|'danger'|'warning'} variant of the alert
@@ -68,7 +62,7 @@
 
 <div class={componentClass} role="alert" tabindex="-1" {...$$restProps}>
   <div class="vtmn-alert_content" role="document">
-    <div id="alert-title-{id}" class="vtmn-alert_content-title">
+    <div class="vtmn-alert_content-title">
       {#if $$slots.title}
         <slot name="title" />
       {:else}
@@ -85,7 +79,7 @@
       {/if}
     </div>
     {#if description || $$slots.description}
-      <span id="alert-text-{id}" class="vtmn-alert_content-description">
+      <span class="vtmn-alert_content-description">
         {#if $$slots.description}
           <slot name="description" />
         {:else}

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -37,7 +37,7 @@
   /**
    * @type {string} aria label on the button
    */
-  export let ariaLabelCloseButton;
+  export let ariaLabelCloseButton = 'Close alert';
 
   let className = undefined;
   /**

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -12,11 +12,13 @@
 
   /**
    * @type {string} title of the alert
+   * Can also be set with a slot="title"
    */
-  export let title;
+  export let title = undefined;
 
   /**
    * @type {string} description of the alert
+   * Can also be set with a slot="description"
    */
   export let description = undefined;
 
@@ -28,7 +30,12 @@
   /**
    * @type {number} time (ms) before the alert disappears
    */
-  export let timeout;
+  export let timeout = undefined;
+
+  /**
+   * @type {string} aria label on the button
+   */
+  export let ariaLabelButton;
 
   let className = undefined;
   /**
@@ -39,12 +46,13 @@
   const dispatch = createEventDispatcher();
   const closeHandler = () => dispatch('close');
   const _clearTimeout = () => timeoutId && clearTimeout(timeoutId);
-  const _setTimeout = () => (timeoutId = setTimeout(closeHandler, timeout));
+  const _setTimeout = () =>
+    (timeoutId = timeout && setTimeout(closeHandler, timeout));
   onDestroy(_clearTimeout);
   onMount(_setTimeout);
   $: componentClass = cn(
     'vtmn-alert',
-    'show',
+    timeout && 'show',
     variant && `vtmn-alert_variant--${variant}`,
     className,
   );
@@ -53,10 +61,14 @@
 <div class={componentClass} role="alert" tabindex="-1" {...$$restProps}>
   <div class="vtmn-alert_content" role="document">
     <div id="alert-title" class="vtmn-alert_content-title">
-      {title}
+      {#if $$slots.title}
+        <slot name="title" />
+      {:else}
+        {title}
+      {/if}
       {#if withCloseButton}
         <VtmnButton
-          aria-label="Close alert"
+          aria-label={ariaLabelButton}
           variant="ghost-reversed"
           size="small"
           iconAlone="close-line"
@@ -64,9 +76,13 @@
         />
       {/if}
     </div>
-    {#if description}
+    {#if description || $$slots.description}
       <p id="alert-text" class="vtmn-alert_content-description">
-        {description}
+        {#if $$slots.description}
+          <slot name="description" />
+        {:else}
+          {description}
+        {/if}
       </p>
     {/if}
   </div>

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -35,7 +35,7 @@
   /**
    * @type {string} aria label on the button
    */
-  export let ariaLabelButton;
+  export let ariaLabelCloseButton;
 
   let className = undefined;
   /**
@@ -68,7 +68,7 @@
       {/if}
       {#if withCloseButton}
         <VtmnButton
-          aria-label={ariaLabelButton}
+          aria-label={ariaLabelCloseButton}
           variant="ghost-reversed"
           size="small"
           iconAlone="close-line"

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/test/VtmnAlertItemWithSlots.test.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/test/VtmnAlertItemWithSlots.test.svelte
@@ -1,0 +1,8 @@
+<script>
+  import VtmnAlertItem from '../VtmnAlertItem.svelte';
+</script>
+
+<VtmnAlertItem {...$$restProps} on:close>
+  <svelte:fragment slot="title">Slot title</svelte:fragment>
+  <svelte:fragment slot="description">Slot description</svelte:fragment>
+</VtmnAlertItem>

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
@@ -139,7 +139,7 @@ describe('VtmnAlertItem', () => {
     const { getByLabelText } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
       timeout,
-      ariaLabelButton: 'Close alert',
+      ariaLabelCloseButton: 'Close alert',
       withCloseButton: true,
     });
     expect(getByLabelText('Close alert')).toBeVisible();
@@ -149,7 +149,7 @@ describe('VtmnAlertItem', () => {
     const { getByLabelText, component } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
       timeout,
-      ariaLabelButton: 'Close alert',
+      ariaLabelCloseButton: 'Close alert',
       withCloseButton: true,
     });
     await expectedCloseOnElement(getByLabelText('Close alert'), component, 1);

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/test/vtmnAlertItem.spec.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import VtmnAlertItem from '../VtmnAlertItem.svelte';
+import VtmnAlertItemWithSlot from './VtmnAlertItemWithSlots.test.svelte';
 
 const timeout = 5000;
 
@@ -138,6 +139,7 @@ describe('VtmnAlertItem', () => {
     const { getByLabelText } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
       timeout,
+      ariaLabelButton: 'Close alert',
       withCloseButton: true,
     });
     expect(getByLabelText('Close alert')).toBeVisible();
@@ -147,6 +149,7 @@ describe('VtmnAlertItem', () => {
     const { getByLabelText, component } = render(VtmnAlertItem, {
       title: 'Alert unit-test',
       timeout,
+      ariaLabelButton: 'Close alert',
       withCloseButton: true,
     });
     await expectedCloseOnElement(getByLabelText('Close alert'), component, 1);
@@ -164,5 +167,11 @@ describe('VtmnAlertItem', () => {
     await waitFor(() => expect(handleClick).toHaveBeenCalledTimes(1), {
       timeout: 100,
     });
+  });
+
+  test('Should display the component with the slots', async () => {
+    const { getByText } = render(VtmnAlertItemWithSlot, {});
+    expect(getByText('Slot title')).toBeVisible();
+    expect(getByText('Slot description')).toBeVisible();
   });
 });

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
@@ -6,7 +6,14 @@ class VtmnAlertStore {
     this._alerts = writable([]);
   }
 
-  send({ variant, title, description, withCloseButton, ...attributes }) {
+  send({
+    variant,
+    title,
+    description,
+    withCloseButton,
+    ariaLabelButton,
+    ...attributes
+  }) {
     this._alerts.update((state) => [
       ...state,
       {
@@ -15,6 +22,7 @@ class VtmnAlertStore {
         title,
         description,
         withCloseButton,
+        ariaLabelButton,
         id: `vtmn-alert-${uuid()}`,
       },
     ]);

--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/vtmnAlertStore.js
@@ -11,7 +11,7 @@ class VtmnAlertStore {
     title,
     description,
     withCloseButton,
-    ariaLabelButton,
+    ariaLabelCloseButton,
     ...attributes
   }) {
     this._alerts.update((state) => [
@@ -22,7 +22,7 @@ class VtmnAlertStore {
         title,
         description,
         withCloseButton,
-        ariaLabelButton,
+        ariaLabelCloseButton,
         id: `vtmn-alert-${uuid()}`,
       },
     ]);

--- a/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
+++ b/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
@@ -26,6 +26,9 @@ export default /*#__PURE__*/ defineComponent({
       type: Boolean as PropType<boolean>,
       default: false,
     },
+    ariaLabelButton: {
+      type: String as PropType<string>,
+    },
     timeout: {
       type: Number as PropType<number>,
       default: 8000,
@@ -64,7 +67,7 @@ export default /*#__PURE__*/ defineComponent({
           iconAlone="close-line"
           variant="ghost-reversed"
           size="small"
-          aria-label="close"
+          :aria-label="ariaLabelButton"
           @click.prevent="handleClose"
         />
       </div>

--- a/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
+++ b/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
@@ -28,6 +28,7 @@ export default /*#__PURE__*/ defineComponent({
     },
     ariaLabelCloseButton: {
       type: String as PropType<string>,
+      default: 'Close alert'
     },
     timeout: {
       type: Number as PropType<number>,

--- a/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
+++ b/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
@@ -26,7 +26,7 @@ export default /*#__PURE__*/ defineComponent({
       type: Boolean as PropType<boolean>,
       default: false,
     },
-    ariaLabelButton: {
+    ariaLabelCloseButton: {
       type: String as PropType<string>,
     },
     timeout: {
@@ -67,7 +67,7 @@ export default /*#__PURE__*/ defineComponent({
           iconAlone="close-line"
           variant="ghost-reversed"
           size="small"
-          :aria-label="ariaLabelButton"
+          :aria-label="ariaLabelCloseButton"
           @click.prevent="handleClose"
         />
       </div>

--- a/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
+++ b/packages/sources/vue/src/components/overlays/VtmnAlert/VtmnAlert.vue
@@ -48,7 +48,7 @@ export default /*#__PURE__*/ defineComponent({
     return {
       classes: computed(() => ({
         'vtmn-alert': true,
-        show: true,
+        show: props.timeout > 0,
         [`vtmn-alert_variant--${props.variant}`]: props.variant,
       })),
       handleClose,
@@ -60,7 +60,7 @@ export default /*#__PURE__*/ defineComponent({
 <template>
   <div :class="classes" role="alert" tabindex="-1" v-bind="$attrs">
     <div class="vtmn-alert_content" role="document">
-      <div id="alert-title" class="vtmn-alert_content-title">
+      <div class="vtmn-alert_content-title">
         {{ title }}
         <VtmnButton
           v-if="withCloseButton"
@@ -71,7 +71,7 @@ export default /*#__PURE__*/ defineComponent({
           @click.prevent="handleClose"
         />
       </div>
-      <p v-if="message" id="alert-text" class="vtmn-alert_content-description">
+      <p v-if="message" class="vtmn-alert_content-description">
         {{ message }}
       </p>
     </div>


### PR DESCRIPTION
## Changes description
![image](https://github.com/Decathlon/vitamin-web/assets/2856778/cc9fdd42-ea82-4b00-84cf-6c20f9d2f202)

Svelte part : 
- Export the VtmnAlertItem component in order to be used without the VtmnAlert.
- Title / description can be set with a slot
- Change the `<p>` to `<span>` in order to be ISO with other frameworks

Svelte / React / Vue : 
- Add a new property ariaLabelCloseButton
- Remove the `id` no really necessary
- Set the timeout property to 0 in order to keep the alert visible

Also checked https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/examples/alertdialog/
The div with a role alert doesn't need to have a aria-labelledby /describeby
![image](https://github.com/Decathlon/vitamin-web/assets/2856778/46072694-9527-4596-890b-5c2cb3d29b1c)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- Yes
- [x] No (checked on the DKT project, the id is not used)

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
