### PR TITLE
feat(`vtmn/svelte`): change `vtmnChip` in order to set a different type of node

### DIFF
--- a/packages/sources/svelte/src/components/selection-controls/VtmnChip/VtmnChip.svelte
+++ b/packages/sources/svelte/src/components/selection-controls/VtmnChip/VtmnChip.svelte
@@ -40,6 +40,11 @@
    */
   export let badgeValue = 0;
 
+  /**
+   * Root node type
+   */
+  export let element = 'div';
+
   let className = undefined;
   /**
    * @type {string} Custom classes to apply to the component.
@@ -79,7 +84,8 @@
   };
 </script>
 
-<div
+<svelte:element
+  this={element}
   class={componentClass}
   role="button"
   aria-disabled={disabled}
@@ -89,6 +95,7 @@
   on:keyup
   on:keypress
   tabindex={disabled ? undefined : 0}
+  {...$$restProps}
 >
   {#if displayLeftIcon}
     <VtmnIcon value={icon} aria-hidden="true" />
@@ -107,7 +114,7 @@
   {#if displayFilterBadge}
     <VtmnBadge value={badgeValue} />
   {/if}
-</div>
+</svelte:element>
 
 <style lang="css">
   @import '@vtmn/css-chip';


### PR DESCRIPTION
## Changes description

Switch the default div element to a `svelte:element` with by default `div` value
Add the restProps inside the component.

## Context
In some cases, the VtmnChip can be a link (for apply a filter -> redirect to a new page ...)
Today, if we want to apply a chip with a redirect, we have to wrap it inside a `<a>` tag like that 

```svelte
<a>
  <VtmnChip />
</a>
```

But this way introduce a issue with a double focus and a bad semantic (link with a button inside)
So that why I propose to move to a `<svelte:element>

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No breaking changes for the PR :) 

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
