### PR TITLE
feat(`@vtmn/svelte`): add property for ol attributes `VtmnBreadcrumb`

### DIFF
--- a/packages/sources/svelte/src/components/navigation/VtmnBreadcrumb/VtmnBreadcrumb.svelte
+++ b/packages/sources/svelte/src/components/navigation/VtmnBreadcrumb/VtmnBreadcrumb.svelte
@@ -8,11 +8,17 @@
    */
   export let className = undefined;
 
+  /**
+   * Properties applied on the `ol` node
+   * @type {object}
+   */
+  export let orderedListAttributes = {};
+
   $: componentClass = cn('vtmn-breadcrumb', className);
 </script>
 
 <nav class={componentClass} {...$$restProps}>
-  <ol>
+  <ol {...orderedListAttributes}>
     <slot />
   </ol>
 </nav>

--- a/packages/sources/svelte/src/components/navigation/VtmnBreadcrumb/test/VtmnBreadcrumb.spec.js
+++ b/packages/sources/svelte/src/components/navigation/VtmnBreadcrumb/test/VtmnBreadcrumb.spec.js
@@ -16,6 +16,15 @@ describe('VtmnBreadcrumbWithSlot', () => {
     expect(container.querySelector('ol').children.length).toEqual(3);
   });
 
+  test('Should apply property on the ol node', () => {
+    const { getByTestId } = render(VtmnBreadcrumbWithSlot, {
+      orderedListAttributes: {
+        'data-testid': 'foo',
+      },
+    });
+    expect(getByTestId('foo')).toBeVisible();
+  });
+
   test('Should apply a custom class on the breadcrumb', () => {
     const { container } = render(VtmnBreadcrumbWithSlot, {
       class: 'custom-class',


### PR DESCRIPTION
## Changes description
Add new input in order to set properties on the `<ol>` node.

## Context
Missing accessibility properties like `aria-label`

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
