### PR TITLE
fix(`@vtmn/svelte`): fix dispatch close for `VtmnAlertItem` / `VtmnSnackbarItem` / `VtmnToastItem`

### DIFF
--- a/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnAlert/VtmnAlertItem.svelte
@@ -55,6 +55,7 @@
   const _setTimeout = () =>
     (timeoutId =
       typeof timeout === 'number' &&
+      timeout > 0 &&
       setTimeout(
         closeHandler,
         (timeout < Infinity ? timeout : INFINITE_TIMEOUT_MS) +

--- a/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnSnackbar/VtmnSnackbarItem.svelte
@@ -40,6 +40,7 @@
   const _setTimeout = () =>
     (timeoutId =
       typeof timeout === 'number' &&
+      timeout > 0 &&
       setTimeout(
         closeHandler,
         (timeout < Infinity ? timeout : INFINITE_TIMEOUT_MS) +

--- a/packages/sources/svelte/src/components/overlays/VtmnToast/VtmnToastItem.svelte
+++ b/packages/sources/svelte/src/components/overlays/VtmnToast/VtmnToastItem.svelte
@@ -41,6 +41,7 @@
   const _setTimeout = () =>
     (timeoutId =
       typeof timeout === 'number' &&
+      timeout > 0 &&
       setTimeout(
         closeHandler,
         (timeout < Infinity ? timeout : INFINITE_TIMEOUT_MS) +


### PR DESCRIPTION
## Changes description
The close dispatch is send even if the user has set a timeout to 0.
This PR fix this behaviour.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
