### PR TITLE
fix(`@vtmn/svelte`): `VtmnListItem` tabindex can be false

### DIFF
--- a/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/VtmnListItem.svelte
@@ -103,7 +103,7 @@
   {#if href}
     <a
       class="vtmn-list__link"
-      tabindex={disabled && -1}
+      tabindex={disabled ? -1 : 0}
       {href}
       {target}
       on:click|stopPropagation

--- a/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
+++ b/packages/sources/svelte/src/components/structure/VtmnListItem/test/VtmnListItem.spec.js
@@ -88,6 +88,7 @@ describe('VtmnListItem', () => {
     });
     expect(getByRole('link')).toHaveAttribute('href', 'https://decathlon.fr');
     expect(getByRole('link')).toHaveAttribute('aria-disabled', 'true');
+    expect(getByRole('link')).toHaveAttribute('tabindex', '-1');
   });
   test('Should have a link _blank with noopener noreferrer', () => {
     const { getByRole } = render(VtmnListItem, {
@@ -96,5 +97,6 @@ describe('VtmnListItem', () => {
     expect(getByRole('link')).toHaveAttribute('href', 'https://decathlon.fr');
     expect(getByRole('link')).toHaveAttribute('target', '_blank');
     expect(getByRole('link')).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(getByRole('link')).toHaveAttribute('tabindex', undefined);
   });
 });


### PR DESCRIPTION
## Changes description
A non disabled component apply a `tabindex="false"` on the link

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
https://github.com/Decathlon/vitamin-web/issues/1489

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
