### PR TITLE
fixed bug#1448: made VtmnSelect React component to show label only when labelText prop is passed to it

### DIFF
--- a/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
+++ b/packages/sources/react/src/components/forms/VtmnSelect/VtmnSelect.tsx
@@ -22,7 +22,7 @@ export const VtmnSelect = React.forwardRef<HTMLSelectElement, VtmnSelectProps>(
       error = false,
       errorText,
       id,
-      labelText,
+      labelText = '',
       labelClassName,
       labelProps,
       options = [],
@@ -40,9 +40,11 @@ export const VtmnSelect = React.forwardRef<HTMLSelectElement, VtmnSelectProps>(
           'vtmn-select--no-border': !border,
         })}
       >
-        <label className={labelClassName || ''} htmlFor={id} {...labelProps}>
-          {labelText}
-        </label>
+        {labelText && (
+          <label className={labelClassName || ''} htmlFor={id} {...labelProps}>
+            {labelText}
+          </label>
+        )}
         <select
           id={id}
           className={clsx(className, {


### PR DESCRIPTION


## Changes description
Made changes to  VtmnSelect React component to show label only when labelText prop is passed to it.

## Context
The issue mentioned in the below link says the VtmnSelect component shows label html tag when empty label is passed to the component. I have made fix for this in the  VtmnSelect React component only, as I am well versed with react. With this fix the component will not add empty label html tag if  labelText prop is not passed to it.
[#1448](https://github.com/Decathlon/vitamin-web/issues/1448)

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
- No

## Other information
This issue is only fixed for VtmnSelect React component
