### PR TITLE
chore: upgrade to actions/cache v4 (GitHub is closing down our existing actions/cache)

### DIFF
--- a/.github/workflows/build-canary.yml
+++ b/.github/workflows/build-canary.yml
@@ -27,7 +27,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore/create node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore/create node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -68,7 +68,7 @@ jobs:
           github-token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Restore/create node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

Following Decathlon + GitHub recommendations, I have to do this quick PR even if the project is no longer maintained.

TL;DR: GitHub actions/cache@v1-v2 is closing down. So we just need to move to actions/cache@v4:

![CleanShot 2024-12-11 at 11 56 18](https://github.com/user-attachments/assets/83ac1355-b016-4975-811a-f9103d18bd60)

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on related showcases.
- [x] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
